### PR TITLE
fix(diagnostics): report stuck-session force-clears as force-clears

### DIFF
--- a/src/infra/diagnostic-events.ts
+++ b/src/infra/diagnostic-events.ts
@@ -345,6 +345,7 @@ export type DiagnosticSessionStuckEvent = DiagnosticSessionAttentionBaseEvent & 
 
 export type DiagnosticSessionRecoveryStatus =
   | "aborted"
+  | "force_cleared"
   | "released"
   | "skipped"
   | "noop"

--- a/src/logging/diagnostic-session-recovery-coordinator.ts
+++ b/src/logging/diagnostic-session-recovery-coordinator.ts
@@ -10,6 +10,7 @@ import {
 import { markDiagnosticActivity as markActivity } from "./diagnostic-runtime.js";
 import type { SessionAttentionClassification } from "./diagnostic-session-attention.js";
 import {
+  isRecoveryRunReclaimOutcome,
   recoveryOutcomeClearsQueuedSessionState,
   resolveStuckSessionRecoveryRef,
   type StuckSessionRecoveryOutcome,
@@ -90,7 +91,7 @@ function applyRecoveryOutcomeToDiagnosticState(params: {
   if (!params.outcome) {
     return;
   }
-  if (params.outcome.status !== "aborted" && params.outcome.status !== "released") {
+  if (!isRecoveryRunReclaimOutcome(params.outcome) && params.outcome.status !== "released") {
     emitSessionRecoveryCompleted({ request: params.request, outcome: params.outcome });
     return;
   }
@@ -101,7 +102,8 @@ function applyRecoveryOutcomeToDiagnosticState(params: {
   const stateIsCurrent =
     expectedState === "idle" &&
     params.request.stateGeneration !== undefined &&
-    params.outcome.action === "abort_embedded_run"
+    (params.outcome.action === "abort_embedded_run" ||
+      params.outcome.action === "force_clear_embedded_run")
       ? currentState?.state === "idle" &&
         (currentGeneration === requestGeneration || currentGeneration === requestGeneration + 1)
       : isDiagnosticSessionStateCurrent({

--- a/src/logging/diagnostic-session-recovery.ts
+++ b/src/logging/diagnostic-session-recovery.ts
@@ -55,15 +55,25 @@ type DiagnosticSessionRecoveryBaseOutcome = {
   activeWorkKind?: DiagnosticSessionActiveWorkKind;
 };
 
+type DiagnosticSessionRecoveryReclaimOutcome = DiagnosticSessionRecoveryBaseOutcome & {
+  aborted: boolean;
+  drained: boolean;
+  forceCleared: boolean;
+  released: number;
+  queuedCount?: number;
+};
+
 export type StuckSessionRecoveryOutcome =
-  | (DiagnosticSessionRecoveryBaseOutcome & {
+  | (DiagnosticSessionRecoveryReclaimOutcome & {
       status: "aborted";
       action: "abort_embedded_run";
-      aborted: boolean;
-      drained: boolean;
-      forceCleared: boolean;
-      released: number;
-      queuedCount?: number;
+    })
+  // A force-clear releases a lane whose owner never acknowledged an abort. It is
+  // a distinct outcome: reporting it as an abort makes a release that aborted
+  // nothing indistinguishable from a run the recovery actually stopped.
+  | (DiagnosticSessionRecoveryReclaimOutcome & {
+      status: "force_cleared";
+      action: "force_clear_embedded_run";
     })
   | (DiagnosticSessionRecoveryBaseOutcome & {
       status: "released";
@@ -92,11 +102,22 @@ export type StuckSessionRecoveryOutcome =
       error: string;
     });
 
+/**
+ * Both reclaim outcomes settle an embedded run and carry the same fields; they
+ * differ only in which mechanism released it.
+ */
+export function isRecoveryRunReclaimOutcome(
+  outcome: StuckSessionRecoveryOutcome,
+): outcome is Extract<StuckSessionRecoveryOutcome, { status: "aborted" | "force_cleared" }> {
+  return outcome.status === "aborted" || outcome.status === "force_cleared";
+}
+
 export function recoveryOutcomeClearsQueuedSessionState(
   outcome: StuckSessionRecoveryOutcome,
 ): boolean {
   return (
-    (outcome.status === "released" || (outcome.status === "aborted" && outcome.released > 0)) &&
+    (outcome.status === "released" ||
+      (isRecoveryRunReclaimOutcome(outcome) && outcome.released > 0)) &&
     (outcome.queuedCount ?? 0) === 0
   );
 }
@@ -131,7 +152,7 @@ export function formatRecoveryOutcome(outcome: StuckSessionRecoveryOutcome): str
     fields.push(`released=${outcome.released}`);
   }
   if (
-    (outcome.status === "aborted" || outcome.status === "released") &&
+    (isRecoveryRunReclaimOutcome(outcome) || outcome.status === "released") &&
     outcome.queuedCount !== undefined
   ) {
     fields.push(`queuedCount=${outcome.queuedCount}`);

--- a/src/logging/diagnostic-stuck-session-followup-recovery.integration.test.ts
+++ b/src/logging/diagnostic-stuck-session-followup-recovery.integration.test.ts
@@ -76,8 +76,8 @@ describe("stuck session follow-up recovery", () => {
         await vi.advanceTimersByTimeAsync(15_100);
 
         await expect(recovery).resolves.toMatchObject({
-          status: "aborted",
-          action: "abort_embedded_run",
+          status: "force_cleared",
+          action: "force_clear_embedded_run",
           forceCleared: true,
         });
         await vi.advanceTimersByTimeAsync(0);

--- a/src/logging/diagnostic-stuck-session-recovery.integration.test.ts
+++ b/src/logging/diagnostic-stuck-session-recovery.integration.test.ts
@@ -661,9 +661,11 @@ describe("stuck session recovery integration", () => {
       // The shared deadline can leave the owner-settlement clamp's final 100 ms.
       await vi.advanceTimersByTimeAsync(15_100);
 
+      // Nothing was aborted here: the owner never acknowledged the abort and the
+      // lane was released by the force-clear, so the outcome must say so.
       await expect(recovery).resolves.toMatchObject({
-        status: "aborted",
-        action: "abort_embedded_run",
+        status: "force_cleared",
+        action: "force_clear_embedded_run",
         aborted: false,
         drained: false,
         forceCleared: true,
@@ -675,6 +677,41 @@ describe("stuck session recovery integration", () => {
       await vi.runOnlyPendingTimersAsync();
       vi.useRealTimers();
     }
+  });
+
+  it("still reports an acknowledged abort as an abort", async () => {
+    // Companion to the force-clear case above: an owner that honours the abort
+    // and drains must keep reporting status=aborted, so the two stay tellable
+    // apart in the recovery log.
+    const sessionKey = "agent:main:acknowledged-abort";
+    const sessionId = "acknowledged-abort-session";
+    const lane = resolveEmbeddedSessionLane(sessionKey);
+    const operation = createReplyOperation({ sessionKey, sessionId, resetTriggered: false });
+    operation.attachBackend({
+      kind: "embedded",
+      cancel: () => queueMicrotask(() => operation.complete()),
+      isStreaming: () => false,
+    });
+    operation.setPhase("running");
+    void enqueueCommandInLane(lane, () => new Promise<never>(() => {}), {
+      warnAfterMs: Number.MAX_SAFE_INTEGER,
+    });
+
+    const outcome = await recoverStuckDiagnosticSession({
+      sessionId,
+      sessionKey,
+      ageMs: 720_000,
+      queueDepth: 1,
+      allowActiveAbort: true,
+    });
+
+    expect(outcome).toMatchObject({
+      status: "aborted",
+      action: "abort_embedded_run",
+      aborted: true,
+      drained: true,
+      forceCleared: false,
+    });
   });
 
   it("leaves committed reply finalization to its existing lease before releasing queued work", async () => {

--- a/src/logging/diagnostic-stuck-session-recovery.runtime.core.test-utils.ts
+++ b/src/logging/diagnostic-stuck-session-recovery.runtime.core.test-utils.ts
@@ -324,7 +324,7 @@ describe("stuck session recovery", () => {
     });
   });
 
-  it("reports queued lane work when aborting active work releases a lane", async () => {
+  it("reports a force-clear that releases a lane as a force-clear, not an abort", async () => {
     mocks.resolveActiveEmbeddedRunSessionId.mockReturnValue("queued-reply-session");
     mocks.resolveActiveEmbeddedRunHandleSessionId.mockReturnValue(undefined);
     mocks.isEmbeddedAgentRunActive.mockReturnValue(true);
@@ -351,13 +351,15 @@ describe("stuck session recovery", () => {
     });
 
     expect(outcome).toMatchObject({
-      status: "aborted",
-      action: "abort_embedded_run",
+      status: "force_cleared",
+      action: "force_clear_embedded_run",
+      aborted: false,
+      forceCleared: true,
       released: 1,
       queuedCount: 1,
     });
     expect(warnLogMessages()).toContain(
-      "stuck session recovery outcome: status=aborted action=abort_embedded_run sessionId=queued-reply-session sessionKey=agent:main:main activeSessionId=queued-reply-session activeWorkKind=embedded_run lane=session:agent:main:main aborted=false drained=false forceCleared=true released=1 queuedCount=1",
+      "stuck session recovery outcome: status=force_cleared action=force_clear_embedded_run sessionId=queued-reply-session sessionKey=agent:main:main activeSessionId=queued-reply-session activeWorkKind=embedded_run lane=session:agent:main:main aborted=false drained=false forceCleared=true released=1 queuedCount=1",
     );
   });
 

--- a/src/logging/diagnostic-stuck-session-recovery.runtime.ts
+++ b/src/logging/diagnostic-stuck-session-recovery.runtime.ts
@@ -443,7 +443,14 @@ export async function recoverStuckDiagnosticSession(
 
     if (aborted || forceCleared || released > 0 || clearStaleSession) {
       retireStaleFollowupDrain?.();
-      const action = aborted || forceCleared ? "abort_embedded_run" : "release_lane";
+      // A force-clear releases the lane without the owner ever acknowledging an
+      // abort, so it must not be reported as one: otherwise a release that
+      // stopped nothing reads exactly like a run recovery actually aborted.
+      const action = aborted
+        ? "abort_embedded_run"
+        : forceCleared
+          ? "force_clear_embedded_run"
+          : "release_lane";
       const stoppedFields = formatStoppedCronSessionDiagnosticFields(
         resolveCronSessionDiagnosticContext({ sessionKey: params.sessionKey, activeSessionId }),
       );
@@ -454,31 +461,32 @@ export async function recoverStuckDiagnosticSession(
           stoppedFields ? ` ${stoppedFields}` : ""
         }`,
       );
+      const reclaimFields = {
+        sessionId: params.sessionId,
+        sessionKey: params.sessionKey,
+        activeSessionId,
+        activeWorkKind: "embedded_run" as const,
+        aborted,
+        drained,
+        forceCleared,
+        released,
+        lane: sessionLane ?? undefined,
+        ...(queuedCount > 0 ? { queuedCount } : {}),
+      };
       return reportRecoveryOutcome(
-        aborted || forceCleared
-          ? {
-              status: "aborted",
-              action: "abort_embedded_run",
-              sessionId: params.sessionId,
-              sessionKey: params.sessionKey,
-              activeSessionId,
-              activeWorkKind: "embedded_run",
-              aborted,
-              drained,
-              forceCleared,
-              released,
-              lane: sessionLane ?? undefined,
-              ...(queuedCount > 0 ? { queuedCount } : {}),
-            }
-          : {
-              status: "released",
-              action: "release_lane",
-              sessionId: params.sessionId,
-              sessionKey: params.sessionKey,
-              released,
-              lane: sessionLane ?? undefined,
-              ...(clearStaleSession ? { reason: "no_active_work" as const } : {}),
-            },
+        aborted
+          ? { status: "aborted", action: "abort_embedded_run", ...reclaimFields }
+          : forceCleared
+            ? { status: "force_cleared", action: "force_clear_embedded_run", ...reclaimFields }
+            : {
+                status: "released",
+                action: "release_lane",
+                sessionId: params.sessionId,
+                sessionKey: params.sessionKey,
+                released,
+                lane: sessionLane ?? undefined,
+                ...(clearStaleSession ? { reason: "no_active_work" as const } : {}),
+              },
       );
     }
     // An active run that neither aborted nor released still owns its work. Reporting


### PR DESCRIPTION
## What Problem This Solves

`recoverStuckDiagnosticSession` collapses two different recovery outcomes into one. A force-clear, which releases a lane without stopping any run, is reported with `status: "aborted"` and `action: "abort_embedded_run"`:

```ts
const action = aborted || forceCleared ? "abort_embedded_run" : "release_lane";
```

Issue #145152 documents the consequence: on the reported incident the recovery path fired about 67 times in a day and every one of those lines reported a success it had not achieved. An operator reading the diagnostics cannot tell a real reclaim from a no-op, which is what kept that incident invisible for over an hour.

ClawSweeper's review of that issue names this specific defect as source-proven and points at the evidence: an existing integration case expects `status=aborted` while `aborted` is `false`.

### Scope

This change fixes **one** of the five defects listed in #145152: the misreported outcome. The other four (queue accounting, ownership validation, the generation fence across awaited cleanup, and releasing the lane by session id) are deliberately left in the issue. It does not overlap with #145444, which addresses reply-owner recovery in `runs.ts`; the only file both touch is the shared integration test.

### Change

- `force_cleared` becomes a distinct outcome status next to `aborted`, so a release that stopped nothing no longer reads as a run that was aborted.
- The action follows the outcome: an abort reports `abort_embedded_run`, a force-clear reports its own action.
- A shared type guard covers the places that legitimately treat both reclaim outcomes alike, so existing accounting keeps working.

## Evidence

The existing integration case that pinned the wrong behaviour is updated rather than removed. It asserted `status=aborted` for a run that was not aborted; it now asserts the force-clear outcome. That is the correction of a pinned misreport, not a relaxed assertion, and the opposite direction is covered by a new case:

```
it("still reports an acknowledged abort as an abort")
```

so a genuine abort is still reported as an abort.

Measured on the branch head:

- `vitest run src/logging/diagnostic-stuck-session-recovery.integration.test.ts src/logging/diagnostic-stuck-session-followup-recovery.integration.test.ts`: **2 files passed, 21 tests passed**
- `node scripts/run-tsgo.mjs -p tsconfig.core.json`: clean, exit 0

Refs #145152


## Runtime and telemetry proof (2026-09-14)

Plain Node/tsx before/after runs exercised the actual recovery owner, command
lanes, reply and embedded-run registries, recovery coordinator, diagnostic broker,
`diagnostics-otel` service and OTLP/protobuf exporter. The 15-second settlement
windows elapsed in wall-clock time. No Vitest, fake timers or mocked recovery,
registry, event or exporter functions were used.

Tested runtime: `3e06eab3abdd39c2c9f1ab1e51d8722b5e07e9f4`. Current head adds only
operator documentation. The before comparison uses the exact pre-PR recovery-owner
file from `ee6a7ef0cb5`, with remaining components held constant; it is not a boot
of the entire old release.

| Scenario | Actual flags: aborted / drained / forceCleared | Before status | After status |
| --- | --- | --- | --- |
| Reply owner never acknowledges cancellation | false / false / true | aborted | force_cleared |
| Owner acknowledges cancellation and drains | true / true / false | aborted | aborted |
| Registered handle accepts abort but never ends within 15 seconds | true / false / true | aborted | force_cleared |

The actual coordinator emitted `session.recovery.completed` with matching
status/action and no stale-result flag in all six cases. Queued work drained and
all lane queues became empty. The timeout case uses a real registered run handle,
not a mocked `abortAndDrainEmbeddedAgentRun` result.

Selected after-run terminal output (synthetic identities omitted):

```text
stuck recovery: reply owner settlement timed out ... settleMs=15000
stuck session recovery outcome: status=force_cleared action=force_clear_embedded_run ... aborted=false drained=false forceCleared=true released=1 queuedCount=1
stuck session recovery outcome: status=aborted action=abort_embedded_run ... aborted=true drained=true forceCleared=false released=1 queuedCount=1
wait timeout: ... timeoutMs=15000
stuck session recovery outcome: status=force_cleared action=force_clear_embedded_run ... aborted=true drained=false forceCleared=true released=1 queuedCount=1
PROOF_PASS before elapsedMs=30642
PROOF_PASS after elapsedMs=30713
```

### Actual event-to-exporter receipt

The task-owned loopback HTTP collector received `application/x-protobuf` from
the real plugin exporter. `protobufjs` decoded the received OTLP wire payload;
assertions checked the metric name, values and both label dimensions:

```text
metric: openclaw.session.recovery.completed
before: value=3 openclaw.status=aborted       openclaw.action=abort_embedded_run
after:  value=2 openclaw.status=force_cleared openclaw.action=force_clear_embedded_run
after:  value=1 openclaw.status=aborted       openclaw.action=abort_embedded_run
```

### Operator transition

`docs/logging.md` now documents the new event values and exported attributes.
Queries counting all run reclaims must include `force_cleared` alongside
`aborted`, or `force_clear_embedded_run` alongside `abort_embedded_run` for action
filters. Keep them separate when measuring acknowledged aborts. Queue accounting
is unchanged. The docs-only follow-up passed the repository formatter and
`git diff --check`.

### Exact limits

The backend work and loopback collector are synthetic. SDK specifiers resolve to
the real source facades. The eligibility request enters the actual coordinator
directly; this does not claim the full scheduled watchdog, an external provider,
or an installed Gateway run. No production Gateway/configuration/credentials or
channel was used. Force-clear proves release of recovery ownership, not that
remote work stopped. The standalone driver, raw logs, protobuf payloads and
decoded assertions are preserved together for reproduction.
