### PR TITLE
test: reuse WhatsApp setup runtime fixtures

### DIFF
--- a/extensions/whatsapp/src/channel.setup.test.ts
+++ b/extensions/whatsapp/src/channel.setup.test.ts
@@ -1,9 +1,9 @@
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-// Whatsapp tests cover channel.setup plugin behavior.
 import { createQueuedWizardPrompter } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/routing";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createRuntimeSpies } from "../../test-support/runtime-spies.js";
 import { WHATSAPP_AUTH_UNSTABLE_CODE } from "./auth-store.js";
 import { whatsappSetupPlugin } from "./channel.setup.js";
 import { checkWhatsAppHeartbeatReady } from "./heartbeat.js";
@@ -107,12 +107,6 @@ vi.mock("./auth-store.js", async () => {
   };
 });
 
-function createRuntime(): RuntimeEnv {
-  return {
-    error: vi.fn(),
-  } as unknown as RuntimeEnv;
-}
-
 describe("WhatsApp setup promotion contract", () => {
   it("exposes authDir on the setup-only plugin surface", () => {
     expect(whatsappSetupPlugin.setupContract?.singleAccountKeysToMove).toEqual(["authDir"]);
@@ -130,7 +124,7 @@ async function runConfigureWithHarness(params: {
     accountId: DEFAULT_ACCOUNT_ID,
     forceAllowFrom: params.forceAllowFrom ?? false,
     prompter: params.harness.prompter,
-    runtime: params.runtime ?? createRuntime(),
+    runtime: params.runtime ?? createRuntimeSpies(),
   });
   return {
     accountId: DEFAULT_ACCOUNT_ID,
@@ -204,7 +198,7 @@ describe("whatsapp setup wizard", () => {
       accountId: DEFAULT_ACCOUNT_ID,
       forceAllowFrom: false,
       prompter: harness.prompter,
-      runtime: createRuntime(),
+      runtime: createRuntimeSpies(),
       options: { deferDeviceLinkToClient: true },
     });
 
@@ -389,7 +383,7 @@ describe("whatsapp setup wizard", () => {
   it("runs WhatsApp login when not linked and user confirms linking", async () => {
     hoisted.hasWebCredsSync.mockReturnValue(false);
     const harness = createWhatsAppLinkingHarness(createQueuedWizardPrompter);
-    const runtime = createRuntime();
+    const runtime = createRuntimeSpies();
 
     await runConfigureWithHarness({
       harness,

--- a/extensions/whatsapp/src/logout.test.ts
+++ b/extensions/whatsapp/src/logout.test.ts
@@ -66,7 +66,7 @@ describe("web logout", () => {
     { timeout: WEB_LOGOUT_TEST_TIMEOUT_MS },
     async () => {
       const authDir = await createAuthCase({ "creds.json": "{}" });
-      const result = await logoutWeb({ authDir, runtime: runtime as never });
+      const result = await logoutWeb({ authDir, runtime });
       expect(result).toBe(true);
       expect(fs.existsSync(authDir)).toBe(false);
     },
@@ -78,14 +78,14 @@ describe("web logout", () => {
       "oauth.json": '{"token":true}',
       "session-abc.json": "{}",
     });
-    const result = await logoutWeb({ authDir, runtime: runtime as never });
+    const result = await logoutWeb({ authDir, runtime });
     expect(result).toBe(true);
     expect(fs.existsSync(authDir)).toBe(false);
   });
 
   it("no-ops when nothing to delete", { timeout: WEB_LOGOUT_TEST_TIMEOUT_MS }, async () => {
     const authDir = await makeCaseDir();
-    const result = await logoutWeb({ authDir, runtime: runtime as never });
+    const result = await logoutWeb({ authDir, runtime });
     expect(result).toBe(false);
     expect(runtime.log).toHaveBeenCalled();
   });
@@ -100,7 +100,7 @@ describe("web logout", () => {
     const result = await logoutWeb({
       authDir: credsDir,
       isLegacyAuthDir: true,
-      runtime: runtime as never,
+      runtime,
     });
     expect(result).toBe(true);
     expect(fs.existsSync(path.join(credsDir, "oauth.json"))).toBe(true);
@@ -116,7 +116,7 @@ describe("web logout", () => {
     await fsPromises.writeFile(path.join(authDir, "notes.txt"), "keep", "utf-8");
     await fsPromises.writeFile(path.join(authDir, "nested", "session-abc.json"), "keep", "utf-8");
 
-    const result = await logoutWeb({ authDir, runtime: runtime as never });
+    const result = await logoutWeb({ authDir, runtime });
     expect(result).toBe(false);
     expect(fs.existsSync(authDir)).toBe(true);
     expect(fs.existsSync(path.join(authDir, "creds.json"))).toBe(true);
@@ -133,7 +133,7 @@ describe("web logout", () => {
     await fsPromises.writeFile(path.join(externalDir, "notes.txt"), "keep", "utf-8");
     await fsPromises.symlink(externalDir, authDir, "dir");
 
-    const result = await logoutWeb({ authDir, runtime: runtime as never });
+    const result = await logoutWeb({ authDir, runtime });
     expect(result).toBe(false);
     expect(fs.existsSync(authDir)).toBe(true);
     expect(fs.existsSync(path.join(externalDir, "creds.json"))).toBe(true);
@@ -151,7 +151,7 @@ describe("web logout", () => {
     await fsPromises.writeFile(path.join(externalAuthDir, "notes.txt"), "keep", "utf-8");
     await fsPromises.symlink(externalRoot, linkedParent, "dir");
 
-    const result = await logoutWeb({ authDir, runtime: runtime as never });
+    const result = await logoutWeb({ authDir, runtime });
     expect(result).toBe(false);
     expect(fs.existsSync(authDir)).toBe(true);
     expect(fs.existsSync(path.join(externalAuthDir, "creds.json"))).toBe(true);

--- a/extensions/whatsapp/src/setup-surface.test.ts
+++ b/extensions/whatsapp/src/setup-surface.test.ts
@@ -1,4 +1,3 @@
-// Whatsapp tests cover setup surface plugin behavior.
 import {
   createPluginSetupWizardStatus,
   createQueuedWizardPrompter,
@@ -7,6 +6,7 @@ import {
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { DEFAULT_ACCOUNT_ID, type OpenClawConfig } from "openclaw/plugin-sdk/setup";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createRuntimeSpies } from "../../test-support/runtime-spies.js";
 import { whatsappSetupWizard } from "./setup-surface.js";
 import {
   createWhatsAppLinkingHarness,
@@ -86,11 +86,6 @@ vi.mock("./auth-store.js", async () => {
   });
 });
 
-const createRuntime = (): RuntimeEnv =>
-  ({
-    error: vi.fn(),
-  }) as unknown as RuntimeEnv;
-
 const whatsappGetStatus = createPluginSetupWizardStatus({
   id: "whatsapp",
   meta: {
@@ -111,7 +106,7 @@ async function runFinalizeWithHarness(params: {
     finalize: whatsappSetupWizard.finalize,
     cfg: params.cfg ?? {},
     accountId: params.accountId ?? DEFAULT_ACCOUNT_ID,
-    runtime: params.runtime ?? createRuntime(),
+    runtime: params.runtime ?? createRuntimeSpies(),
     prompter: params.harness.prompter,
     options: params.options,
     forceAllowFrom: params.forceAllowFrom ?? false,
@@ -317,7 +312,7 @@ describe("whatsapp setup wizard", () => {
   it("runs WhatsApp login when not linked and user confirms linking", async () => {
     hoisted.pathExists.mockResolvedValue(false);
     const harness = createWhatsAppLinkingHarness(createQueuedWizardPrompter);
-    const runtime = createRuntime();
+    const runtime = createRuntimeSpies();
     expect(hoisted.loginModuleState.loaded).toBe(false);
     const beforePersistentEffect = vi.fn(async () => {
       expect(hoisted.loginModuleState.loaded).toBe(true);
@@ -338,7 +333,7 @@ describe("whatsapp setup wizard", () => {
   it("propagates the persistent-effect guard before WhatsApp login persists state", async () => {
     hoisted.pathExists.mockResolvedValue(false);
     const harness = createWhatsAppLinkingHarness(createQueuedWizardPrompter);
-    const runtime = createRuntime();
+    const runtime = createRuntimeSpies();
     const guardError = new Error("verified inference changed");
     const beforePersistentEffect = vi.fn(async () => {
       throw guardError;
@@ -360,7 +355,7 @@ describe("whatsapp setup wizard", () => {
   it("rejects delayed credential persistence when the inference route changes during login", async () => {
     hoisted.pathExists.mockResolvedValue(false);
     const harness = createWhatsAppLinkingHarness(createQueuedWizardPrompter);
-    const runtime = createRuntime();
+    const runtime = createRuntimeSpies();
     const guardError = new Error("verified inference route changed");
     let routeOwner = "original";
     const beforePersistentEffect = vi.fn(async () => {


### PR DESCRIPTION
Replace duplicate runtime factories in the WhatsApp setup tests with the existing narrow runtime-spies helper, and remove seven unnecessary runtime casts in the logout suite. All cases, assertions, mock ordering and filesystem cleanup checks remain. Production code is unchanged; test code is +16/-27.

Validation: all 42 cases across the three changed suites and the setup-entry sibling passed before and after on macOS with Node 26.5. Formatting, type-aware lint and the normal 19-check changed gate passed. The gate completed via its automatic local fallback after remote checks succeeded but provider cleanup failed; canonical cleanup reconciliation subsequently succeeded. No live WhatsApp claim.

The earlier declaration-preparation failure was resolved by integrating the already-landed TLS sidecar fix into the base. That upstream fix is outside this test-only diff. The cleanup-failure classification issue is retained as a separate follow-up.
