### PR TITLE
fix(ask-user): report an incomplete multi-question answer instead of dropping it

### DIFF
--- a/src/agents/harness/gateway-question.ts
+++ b/src/agents/harness/gateway-question.ts
@@ -40,6 +40,8 @@ const TERMINAL_QUESTION_ERROR_REASONS = new Set([
   "QUESTION_NOT_FOUND",
 ]);
 
+const QUESTION_INVALID_ANSWER_REASON = "QUESTION_INVALID_ANSWER";
+
 type PendingAgentGatewayQuestion = {
   kind: "gateway";
   questionId: string;
@@ -105,6 +107,27 @@ function readQuestionRejection(error: unknown): { code: unknown; reason?: string
 function isTerminalAgentQuestionError(error: unknown): boolean {
   const reason = readQuestionRejection(error)?.reason;
   return reason !== undefined && TERMINAL_QUESTION_ERROR_REASONS.has(reason);
+}
+
+/**
+ * Answer validation runs before `question.resolve` commits, so a rejected answer
+ * leaves the question pending and the sender can still correct it. Callers that
+ * own a user-visible surface read this to explain the rejection instead of
+ * failing their own dispatch with an unhandled gateway error, which the ingress
+ * would retry into the same rejection without ever reaching the sender.
+ */
+export function readQuestionAnswerRejection(error: unknown): { detail?: string } | undefined {
+  const rejection = readQuestionRejection(error);
+  if (
+    rejection?.code !== "INVALID_REQUEST" ||
+    rejection.reason !== QUESTION_INVALID_ANSWER_REASON
+  ) {
+    return undefined;
+  }
+  // The manager names the offending question in the message; the structured
+  // reason only carries the code.
+  const detail = error instanceof Error ? error.message.trim() : "";
+  return detail ? { detail } : {};
 }
 
 type QuestionInputAuthority = { kind: "run" | "source-bound"; assertCurrent: () => void };

--- a/src/auto-reply/reply/agent-runner-question-input.ts
+++ b/src/auto-reply/reply/agent-runner-question-input.ts
@@ -2,7 +2,10 @@ import {
   QuestionAnswerUnconfirmedError,
   QuestionDispatchRefusedError,
 } from "../../agents/harness/gateway-question-dispatch.js";
-import { claimPendingAgentQuestionAnswerFromCaller } from "../../agents/harness/gateway-question.js";
+import {
+  claimPendingAgentQuestionAnswerFromCaller,
+  readQuestionAnswerRejection,
+} from "../../agents/harness/gateway-question.js";
 import { logVerbose } from "../../globals.js";
 import { markReplyPayloadForSourceSuppressionDelivery } from "../reply-payload.js";
 import type { ReplyPayload } from "../types.js";
@@ -93,6 +96,28 @@ export async function runReplyQuestionInput(
         handled: true,
         payload: markReplyPayloadForSourceSuppressionDelivery({
           text: `The answer was not sent: ${error.message}. Use the question controls in the Control UI, or check the active run and your permissions before retrying.`,
+          isError: true,
+        }),
+      };
+    }
+    // A rejected answer never reached commitment, so the question is still
+    // pending for a corrected reply. Report it on the same channel: rethrowing
+    // here fails the whole dispatch, and the ingress then retries the identical
+    // answer into the identical rejection until the question times out, without
+    // the sender ever learning that anything was wrong.
+    const rejection = readQuestionAnswerRejection(error);
+    if (rejection) {
+      if (state) {
+        state.admission = { status: "skipped", reason: "question-response-rejected" };
+      }
+      return {
+        handled: true,
+        payload: markReplyPayloadForSourceSuppressionDelivery({
+          text: `${
+            rejection.detail
+              ? `The answer was not accepted: ${rejection.detail}.`
+              : "The answer was not accepted because a question is still unanswered."
+          } The question is still open, so reply again and answer every question by number or question id.`,
           isError: true,
         }),
       };

--- a/src/auto-reply/reply/dispatch-from-config.finalize.ts
+++ b/src/auto-reply/reply/dispatch-from-config.finalize.ts
@@ -494,7 +494,8 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
   const questionFailure =
     replyAdmission?.status === "skipped" &&
     (replyAdmission.reason === "question-response-indeterminate" ||
-      replyAdmission.reason === "question-response-refused")
+      replyAdmission.reason === "question-response-refused" ||
+      replyAdmission.reason === "question-response-rejected")
       ? replyAdmission.reason
       : undefined;
   const preRunRejection =

--- a/src/auto-reply/reply/dispatch-from-config.question-custody.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.question-custody.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { registerPendingAgentQuestion } from "../../agents/harness/gateway-question.js";
+import {
+  createAgentQuestionAnswerAuthority,
+  withAgentQuestionAnswerAuthority,
+} from "../../agents/harness/host-private-capabilities.js";
 import { clearAgentHarnesses } from "../../agents/harness/registry.js";
 import type { MsgContext } from "../templating.js";
 import type { GetReplyOptions } from "../types.js";
@@ -214,35 +218,50 @@ describe("dispatch input custody after a question response", () => {
     const fixture = createQuestionDispatch("incomplete-answer");
     const dispatcher = createDispatcher();
     const resolves: unknown[] = [];
-    const gatewayCall = vi.fn(async (method: string, _headers: unknown, params: unknown) => {
-      if (method !== "question.resolve") {
+    // Mirrors QuestionManager.validateAnswers: an unanswered question is
+    // rejected with QUESTION_INVALID_ANSWER before the resolve commits.
+    const gatewayCall = {
+      version: 2 as const,
+      call: async (request: { method: string; params?: unknown }) => {
+        if (request.method !== "question.resolve") {
+          return {};
+        }
+        resolves.push(request.params);
+        const answers = (request.params as { answers: { answers: Record<string, string[]> } })
+          .answers.answers;
+        const unanswered = Object.keys(answers).find((id) => answers[id]?.length === 0);
+        if (unanswered) {
+          const rejection = new Error(`question '${unanswered}' requires an answer`);
+          rejection.name = "GatewayClientRequestError";
+          throw Object.assign(rejection, {
+            gatewayCode: "INVALID_REQUEST",
+            details: { reason: "QUESTION_INVALID_ANSWER" },
+            retryable: false,
+          });
+        }
         return {};
-      }
-      resolves.push(params);
-      const answers = (params as { answers: { answers: Record<string, string[]> } }).answers
-        .answers;
-      const unanswered = Object.keys(answers).find((id) => answers[id]?.length === 0);
-      if (unanswered) {
-        const rejection = new Error(`question '${unanswered}' requires an answer`);
-        rejection.name = "GatewayClientRequestError";
-        throw Object.assign(rejection, {
-          gatewayCode: "INVALID_REQUEST",
-          details: { reason: "QUESTION_INVALID_ANSWER" },
-          retryable: false,
-        });
-      }
-      return {};
-    });
-    const question = registerPendingAgentQuestion({
+      },
+    };
+    // The creator authority the source-bound claim path requires; this fixture
+    // accepts any caller so the test exercises answer validation, not policy.
+    const authority = createAgentQuestionAnswerAuthority({
       sessionKey: fixture.operation.key,
-      questionId: "ask_incomplete_answer",
-      questions: [
-        { id: "destination", header: "Where", question: "Where to?" },
-        { id: "budget", header: "Budget", question: "How much?" },
-      ],
-      gatewayCall,
-      answer: Promise.resolve({ status: "pending" }),
+      fingerprint: "question-custody-fixture",
+      project: () => "question-custody-fixture",
+      assertActive: () => {},
     });
+    const question = withAgentQuestionAnswerAuthority(authority, () =>
+      registerPendingAgentQuestion({
+        sessionKey: fixture.operation.key,
+        questionId: "ask_incomplete_answer",
+        questions: [
+          { id: "destination", header: "Where", question: "Where to?" },
+          { id: "budget", header: "Budget", question: "How much?" },
+        ],
+        gatewayCall,
+        answer: Promise.resolve({ status: "pending" }),
+      }),
+    );
     question.attachRegistration(Promise.resolve());
     try {
       // One unkeyed line for two questions: the second question stays empty and

--- a/src/auto-reply/reply/dispatch-from-config.question-custody.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.question-custody.test.ts
@@ -210,6 +210,93 @@ describe("dispatch input custody after a question response", () => {
     }
   });
 
+  it("reports an incomplete multi-question answer and keeps the question open", async () => {
+    const fixture = createQuestionDispatch("incomplete-answer");
+    const dispatcher = createDispatcher();
+    const resolves: unknown[] = [];
+    const gatewayCall = vi.fn(async (method: string, _headers: unknown, params: unknown) => {
+      if (method !== "question.resolve") {
+        return {};
+      }
+      resolves.push(params);
+      const answers = (params as { answers: { answers: Record<string, string[]> } }).answers
+        .answers;
+      const unanswered = Object.keys(answers).find((id) => answers[id]?.length === 0);
+      if (unanswered) {
+        const rejection = new Error(`question '${unanswered}' requires an answer`);
+        rejection.name = "GatewayClientRequestError";
+        throw Object.assign(rejection, {
+          gatewayCode: "INVALID_REQUEST",
+          details: { reason: "QUESTION_INVALID_ANSWER" },
+          retryable: false,
+        });
+      }
+      return {};
+    });
+    const question = registerPendingAgentQuestion({
+      sessionKey: fixture.operation.key,
+      questionId: "ask_incomplete_answer",
+      questions: [
+        { id: "destination", header: "Where", question: "Where to?" },
+        { id: "budget", header: "Budget", question: "How much?" },
+      ],
+      gatewayCall,
+      answer: Promise.resolve({ status: "pending" }),
+    });
+    question.attachRegistration(Promise.resolve());
+    try {
+      // One unkeyed line for two questions: the second question stays empty and
+      // the gateway rejects the whole answer before it is committed.
+      await dispatchReplyFromConfig({
+        ctx: fixture.ctx,
+        cfg: { ...automaticDirectReplyConfig, diagnostics: { enabled: true } },
+        dispatcher,
+        replyOptions: { turnAdoptionLifecycle: { onAdopted: async () => {} } },
+        replyResolver: async (ctx, opts) => {
+          const result = await runReplyQuestionInput({
+            commandBody: "Lisbon",
+            followupRun: createQueueTestRun({ prompt: "Lisbon" }),
+            sessionKey: fixture.operation.key,
+            sessionCtx: ctx,
+            opts,
+          });
+          expect(result.handled).toBe(true);
+          return result.handled ? result.payload : undefined;
+        },
+      });
+      expect(dispatcher.sendFinalReply).toHaveBeenCalledWith(
+        expect.objectContaining({
+          text: expect.stringContaining("The answer was not accepted: question 'budget'"),
+          isError: true,
+        }),
+      );
+      expect(dispatcher.sendFinalReply).toHaveBeenCalledWith(
+        expect.objectContaining({ text: expect.stringContaining("still open") }),
+      );
+      expect(diagnosticMocks.logMessageProcessed).toHaveBeenCalledWith(
+        expect.objectContaining({ outcome: "error", reason: "question-response-rejected" }),
+      );
+      expect(question.isResolving()).toBe(false);
+      expect(fixture.cancel).not.toHaveBeenCalled();
+
+      // The question survived the rejection, so a complete answer still lands.
+      const retry = await runReplyQuestionInput({
+        commandBody: "Lisbon\n2000",
+        followupRun: createQueueTestRun({ prompt: "Lisbon\n2000" }),
+        sessionKey: fixture.operation.key,
+        sessionCtx: fixture.ctx,
+      });
+      expect(retry).toEqual({ handled: true, payload: undefined });
+      expect(resolves).toHaveLength(2);
+      expect(resolves[1]).toMatchObject({
+        answers: { answers: { destination: ["Lisbon"], budget: ["2000"] } },
+      });
+    } finally {
+      question.dispose();
+      fixture.operation.complete();
+    }
+  });
+
   it("still permits retry when the source failed before any input custody transfer", async () => {
     const fixture = createQuestionDispatch("before-custody");
     const error = new Error("failure before input dispatch");

--- a/src/auto-reply/reply/reply-operation-run-state.ts
+++ b/src/auto-reply/reply/reply-operation-run-state.ts
@@ -17,7 +17,8 @@ type ReplyOperationAdmissionSnapshot =
         | "lifecycle-invalidated"
         | "queue-cap"
         | "question-response-indeterminate"
-        | "question-response-refused";
+        | "question-response-refused"
+        | "question-response-rejected";
     };
 
 // Rejection diagnostics carry owner-selected codes, never user-facing error text.


### PR DESCRIPTION
Closes #145126. Builds on #149498 and #149617.

## What Problem This Solves

A partial reply to a multi-part `ask_user` question fails silently. The user gets no correction and cannot tell that the question is still open.

## Why This Change Was Made

The reply boundary alone translates the manager's invalid-answer rejection. The question manager still validates and commits answers. The harness still releases or retains answer reservations. Finalization records the reply outcome.

Production grows by 22 lines: reply translation +20, final diagnostic +1, and private outcome type +1. No new module remains.

Growth accepted under the owner's standing acceptance (2026-09-15).

## User Impact

One correction names the unanswered question. A complete reply resumes the waiting task once.

## Evidence

The baseline `6c28739b` received no correction after a partial reply. On `2d8eac46`, a real Telegram Test Server conversation produced this sequence:

1. `Lisbon` received one correction: “The answer was not accepted: question 'budget' requires an answer.”
2. The same question remained pending, with no answer event.
3. A single complete numbered reply with Lisbon and 2000 stored one successful result for the original waiting tool, emitted one answer event, and resumed the task once.

The Gateway, storage, and channel delivery were real. Provider responses were scripted. The flow includes the merged fixes from #149498 and #149617.

All 171 owner and sibling tests passed on merge `2d8eac46`, with candidate parent `7d59c815` and main parent `46c107b9`. Both changed test files are selected once by hosted commands. The focused dispatch regression runs with:

```sh
node scripts/run-vitest.mjs run src/auto-reply/reply/dispatch-from-config.question-custody.test.ts
```

The four rejection controls now invoke `dispatchReplyFromConfig` through the existing `auto-reply-reply` test project. All 13 cases in that file pass with unchanged production.

## Compatibility

No schema, configuration, protocol or public API change. Forbidden, terminal, uncertain-delivery, cancellation and repeated-input behavior remains covered.

## Consumers

Channel paths through the reply boundary receive the correction; finalization records its diagnostic outcome.

## Invalidation

The existing question manager and harness retain validation, reservation release and terminal custody.

## Tests

Both changed tests are selected once by hosted commands. Test-root budgets and local type-aware checks pass.
