### PR TITLE
improve: reduce repeated reads during startup integrity checks

### DIFF
--- a/docs/reference/database-schemas/integrity-and-recovery.md
+++ b/docs/reference/database-schemas/integrity-and-recovery.md
@@ -61,6 +61,11 @@ Agent database maintenance fences other writers with a 60-second lease in the sh
 
 Asynchronous agent-database admission runs the first full-file integrity check in a read-only child process when that check is outside a write transaction. Later ordinary opens reuse remembered verification. Maintenance retains its independent full check. The connection and owning scope remain held until the child closes, including on cancellation or timeout. Schema changes, index repairs, and compaction retain their synchronous phases.
 
+The integrity child allows SQLite to cache up to about 64 MiB of database pages
+while checking indexes and foreign keys. SQLite allocates those pages as needed,
+and the cache ends with the child; retained Gateway connections keep their
+existing cache settings. Full integrity and foreign-key checks still run.
+
 Explicit session-maintenance finalization uses this asynchronous admission if its writable handle was evicted during archive or deletion preparation. It keeps its place in the session writer queue and rechecks maintenance and deletion authority before committing. Automatic maintenance retires when its original handle closes instead of reopening it.
 
 The integrity child and both asynchronous and synchronous read-only snapshot workers share a lifetime budget: 30 seconds for startup and shutdown plus one second per 32 MiB of source database file size, rounded up, capped at 30 minutes. A full copy or full scan reads the whole file at least once; the budget allows for a conservative cold-cache read rate of 32 MiB/s. A 9.4 GiB database gets 331 seconds. Budgets above 30 seconds are logged once per call at debug level with the operation, path, size, and applied budget, keeping ordinary CLI output quiet. If the snapshot worker cannot stat the source, it uses the 30-second base budget and lets the child report the underlying error.

--- a/src/infra/sqlite-integrity.worker.ts
+++ b/src/infra/sqlite-integrity.worker.ts
@@ -47,7 +47,7 @@ try {
   setSqliteBusyTimeout(database, input.busyTimeoutMs);
   // Full index checks revisit pages. Keep their cache in this disposable child,
   // without raising the memory budget of the Gateway's retained connections.
-  database.exec("PRAGMA cache_size = -65536;");
+  database.exec("PRAGMA cache_size = -65536;"); // sqlite-allow-raw -- Connection-local page-cache policy for this disposable integrity child.
   readSqliteIntegrityFileIdentity(input.pathname, input.identity);
   await sendPhase("checking");
   assertSqliteIntegrity(database, input.pathname);

--- a/src/infra/sqlite-integrity.worker.ts
+++ b/src/infra/sqlite-integrity.worker.ts
@@ -45,6 +45,9 @@ try {
   readSqliteIntegrityFileIdentity(input.pathname, input.identity);
   database = openNodeSqliteDatabase(input.pathname, { readOnly: true });
   setSqliteBusyTimeout(database, input.busyTimeoutMs);
+  // Full index checks revisit pages. Keep their cache in this disposable child,
+  // without raising the memory budget of the Gateway's retained connections.
+  database.exec("PRAGMA cache_size = -65536;");
   readSqliteIntegrityFileIdentity(input.pathname, input.identity);
   await sendPhase("checking");
   assertSqliteIntegrity(database, input.pathname);


### PR DESCRIPTION
## Summary
### High Level TLDR
Large agent databases cause slow Gateway startup checks. Give the disposable integrity worker a 64 MiB SQLite page-cache allowance so full index and foreign-key checks reread fewer pages.

## What Problem This Solves
The first writable agent-database admission can spend minutes validating a large indexed database with SQLite's default page cache.

## User Impact
Reduces repeated reads during the existing full checks. An offline 21.37 GiB database showed 35% fewer logical bytes read; a synthetic indexed fixture exercised through the actual worker showed about 5% lower median warm check time. This does not establish an end-to-end startup percentage.

The tradeoff is roughly 64 MiB additional peak resident memory per active integrity child in the synthetic benchmark. SQLite allocates cache pages as needed; the allowance is not a total-process memory cap. The connection closes with the child, and retained Gateway connections are unchanged.

## Why This Change Was Made
### Root Cause
The integrity child opens a read-only SQLite connection and runs full integrity and foreign-key checks without adjusting its page cache. Full index checking revisits database pages. On the same offline database, baseline checks consistently issued about 97.16 GB of logical reads versus 63.17 GB with the candidate allowance.

Only the disposable child's connection receives `PRAGMA cache_size = -65536`. No mmap, persistent validation marker, schema, dependency, config option, or integrity-check bypass is added. Identity checks, errors, cancellation, owner lifetime, and full verification on a fresh process remain unchanged. Existing installed update drivers require no new marker or option; this is candidate-side connection tuning.

## Verification
### Real behavior proof
- 46 tests passed across `src/infra/sqlite-integrity.test.ts`, `src/state/openclaw-agent-db.integrity-cache.test.ts`, and `src/state/openclaw-agent-db-open-authority.test.ts`, including actual child success, foreign-key failure, native close, timeout, cancellation, and current authority.
- Independent autoreview: scoped-clean at P0–P2, no actionable findings. Fresh review after the CI correction is also scoped-clean.
- CI correction at `6614ca2cf56ea26fee35d03fdc2857f96f6e0ba6`: documented the connection-local pragma using the existing `sqlite-allow-raw` convention. The Kysely architecture guard now passes locally. Only a comment changed; executable code and benchmark inputs are unchanged.
- Repository changed-file checks passed: formatting, core/core-test typechecks, lint, dead exports, import cycles, and selected storage/runtime guards.
- Actual parent/child benchmark: 1,000,000 related rows with a dispersed index and 768-byte payloads, Linux and Node 24.19.0. Warm baseline check times 1493.7/1508.5 ms; candidate 1373.8/1430.1/1500.3 ms. Logical reads 6.609 GB versus 2.500 GB; every warm sample had zero physical reads. All checks passed.
- Read-only offline 21.37 GiB operator-state backup: full `integrity_check` returned `ok` and `foreign_key_check` returned no violations in both variants. Logical reads fell consistently by 35%. Elapsed times were confounded by varying filesystem-cache conditions and are not presented as a speedup.

### Review scope and risk mitigation
This PR claims reduced reads in the disposable integrity child, not a particular end-to-end startup improvement or a cross-platform performance guarantee. The mitigation is implemented in the patch: the larger cache is confined to one short-lived read-only connection, all full checks remain, and the measured per-child memory cost is explicit above. Unmeasured cold-cache and other-platform performance remain limitations rather than claimed results.

### What was not tested
No live Gateway restart, complete updater replay, published-driver integration run, cold-cache speed guarantee, or macOS/Windows performance measurement. Existing integrity guarantees are preserved; this PR does not implement cross-process reuse of Doctor validation.

<details>
<summary>Portable synthetic benchmark</summary>

### Portable Linux reproduction

Use Node 24.19.0 with dependencies installed in baseline and candidate worktrees. The baseline is the PR base SHA; the candidate is the exact PR head. Save the following as `.artifacts/integrity-benchmark.mts` in the candidate and run:

```sh
node --import tsx .artifacts/integrity-benchmark.mts /absolute/baseline /absolute/candidate
```

The first result is warmup; compare subsequent alternating samples and include physical reads. This calls the real admission parent and real child entries. The wrapper observes IPC phase timings and I/O only. It does not change checks or connection settings.

```ts
import fs from 'node:fs';
import os from 'node:os';
import path from 'node:path';
import { pathToFileURL } from 'node:url';
import { DatabaseSync } from 'node:sqlite';
const [base, candidate] = process.argv.slice(2);
const root = fs.mkdtempSync(path.join(os.tmpdir(), 'integrity-benchmark-'));
const fixture = path.join(root, 'indexed.sqlite');
const db = new DatabaseSync(fixture);
db.exec(`PRAGMA journal_mode=OFF;
 CREATE TABLE parent(id INTEGER PRIMARY KEY, value TEXT);
 CREATE TABLE child(id INTEGER PRIMARY KEY, parent_id INTEGER REFERENCES parent(id), lookup TEXT, payload BLOB);
 CREATE INDEX child_lookup ON child(lookup); BEGIN;`);
const parent = db.prepare('INSERT INTO parent VALUES (?,?)');
const child = db.prepare('INSERT INTO child VALUES (?,?,?,?)');
for (let i=0; i<1000000; i++) {
 parent.run(i, 'p'+i);
 child.run(i, i, String((i*999983)%1000000).padStart(10,'0'), Buffer.alloc(768));
}
db.exec(`COMMIT; DROP INDEX child_lookup;
 UPDATE child SET lookup=printf('%010d', (id*618033)%1000000);
 CREATE INDEX child_lookup ON child(lookup);`);
db.close();
const { assertSqliteIntegrityInWorker } = await import(pathToFileURL(path.join(candidate,'src/infra/sqlite-integrity-worker.ts')).href);
const { registerSealedRuntimeProcessEntrypoint } = await import(pathToFileURL(path.join(candidate,'src/infra/runtime-process-url.ts')).href);
try {
 for (const variant of ['baseline','candidate','candidate','baseline','baseline','candidate']) {
  const checkout = variant==='baseline' ? base : candidate;
  const entry = pathToFileURL(path.join(checkout,'src/infra/sqlite-integrity.worker.ts')).href;
  const metrics = path.join(root,'metrics.json');
  const wrapper = path.join(root,'measured.worker.mts');
  fs.writeFileSync(wrapper, `import fs from 'node:fs';
   const io=()=>Object.fromEntries(fs.readFileSync('/proc/self/io','utf8').trim().split('\\n').map(l=>l.split(': ').map((v,i)=>i?Number(v):v)));
   const send=process.send.bind(process); let started; let before;
   process.send=(message,...args)=>{
    if(message.type==='phase'&&message.phase==='checking'){started=performance.now();before=io();}
    if('ok' in message){const after=io();fs.writeFileSync(${JSON.stringify(metrics)},JSON.stringify({checkMs:performance.now()-started,logicalReadBytes:after.rchar-before.rchar,readBytes:after.read_bytes-before.read_bytes,rssKiB:Number(fs.readFileSync('/proc/self/status','utf8').match(/VmHWM:\\s+(\\d+)/)[1])}));}
    return send(message,...args);
   };
   await import(${JSON.stringify(entry)});`);
  registerSealedRuntimeProcessEntrypoint('sqliteIntegrity',pathToFileURL(wrapper));
  const started = performance.now();
  await assertSqliteIntegrityInWorker(fixture,5000,new AbortController().signal);
  console.log(JSON.stringify({variant,totalMs:performance.now()-started,...JSON.parse(fs.readFileSync(metrics,'utf8'))}));
 }
} finally { fs.rmSync(root,{recursive:true,force:true}); }
```

Observed warm results from this fixture and equivalent instrumentation:

| Arm | Check elapsed samples(ms) | Logical bytes read per scan | Child VmHWM |
|---|---|---|---|
| Baseline |1493.7,1508.5|6,609,428,611|111456–137952KiB|
| Candidate |1373.8,1430.1,1500.3|2,500,071,555|174908–199124KiB|

The first baseline had 857 MB physical reads and a 15.8s check time; it is excluded. All reported warm samples had zero physical reads. Median check time improved about 5%; logical reads decreased 62%. This benchmark does not establish an end-to-end Gateway startup percentage.

</details>

