### PR TITLE
fix(discord): deliver ACP thread replies with explicit ownership

### DIFF
--- a/extensions/discord/src/monitor/message-handler.context.ts
+++ b/extensions/discord/src/monitor/message-handler.context.ts
@@ -42,7 +42,7 @@ import { formatDiscordMediaText, resolveReferencedReplyMediaList } from "./messa
 import type { DiscordMediaInfo } from "./message-media.js";
 import { resolveDiscordMessageText } from "./message-text.js";
 import { buildDirectLabel, buildGuildLabel, resolveReplyContext } from "./reply-context.js";
-import { buildDiscordRoutePeer } from "./route-resolution.js";
+import { buildDiscordRoutePeer, isDiscordRuntimeAcpThreadBinding } from "./route-resolution.js";
 import { resolveDiscordAutoThreadReplyPlan, resolveDiscordThreadStarter } from "./threading.js";
 import {
   DISCORD_ATTACHMENT_IDLE_TIMEOUT_MS,
@@ -99,6 +99,7 @@ export async function buildDiscordMessageProcessContext(params: {
     channelConfig,
     baseSessionKey,
     boundSessionKey,
+    threadBinding,
     route,
     commandAuthorized,
     hasControlCommand,
@@ -364,7 +365,11 @@ export async function buildDiscordMessageProcessContext(params: {
     : undefined;
   const originatingTo = autoThreadContext?.OriginatingTo ?? dmConversationTarget ?? replyTarget;
   const effectiveSessionKey =
-    boundSessionKey ?? autoThreadContext?.SessionKey ?? threadKeys.sessionKey;
+    boundSessionKey &&
+    route.sessionKey !== boundSessionKey &&
+    isDiscordRuntimeAcpThreadBinding(threadBinding)
+      ? route.sessionKey
+      : (boundSessionKey ?? autoThreadContext?.SessionKey ?? threadKeys.sessionKey);
   const effectivePreviousTimestamp =
     effectiveSessionKey === route.sessionKey
       ? previousTimestamp

--- a/extensions/discord/src/monitor/message-handler.preflight.test.ts
+++ b/extensions/discord/src/monitor/message-handler.preflight.test.ts
@@ -967,6 +967,48 @@ describe("preflightDiscordMessage", () => {
     expect(expectPreflightResult(result).boundSessionKey).toBe(threadBinding.targetSessionKey);
   });
 
+  it("keeps the Discord source route when a runtime ACP binding targets another owner", async () => {
+    const threadId = "thread-runtime-acp-owner";
+    const parentId = "channel-runtime-acp-owner";
+    const targetSessionKey = "agent:claude:acp:runtime:discord-thread";
+    const threadBinding = createThreadBinding({
+      targetKind: "session",
+      targetSessionKey,
+      conversation: {
+        channel: "discord",
+        accountId: "default",
+        conversationId: threadId,
+        parentConversationId: parentId,
+      },
+      metadata: {
+        agentId: "worker",
+        boundBy: "user-1",
+      },
+    });
+
+    const result = await runThreadBoundPreflight({
+      threadId,
+      parentId,
+      message: createDiscordMessage({
+        id: "m-runtime-acp-owner",
+        channelId: threadId,
+        content: "continue in ACP",
+        author: { id: "user-1", bot: false, username: "alice" },
+      }),
+      threadBinding,
+      discordConfig: {} as DiscordConfig,
+      registerBindingAdapter: true,
+    });
+
+    const preflight = expectPreflightResult(result);
+    expect(preflight.boundSessionKey).toBe(targetSessionKey);
+    expect(preflight.boundAgentId).toBe("claude");
+    expect(preflight.route).toMatchObject({
+      agentId: "main",
+      sessionKey: `agent:main:discord:channel:${threadId}`,
+    });
+  });
+
   it("looks up thread bindings once for an accepted ordinary guild message", async () => {
     const channelId = "channel-binding-lookup-once";
     const manager = createThreadBindingManager({

--- a/extensions/discord/src/monitor/message-handler.process.session-routing.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.session-routing.test.ts
@@ -6,6 +6,7 @@ import {
   createDirectMessageContextOverrides,
   createDiscordDraftStream,
   createNoQueuedDispatchResult,
+  deliverDiscordReply,
   dispatchInboundMessageForTest as dispatchInboundMessage,
   getLastDispatchCtx,
   getLastDispatchReplyOptions,
@@ -416,12 +417,17 @@ describe("processDiscordMessage session routing", () => {
 
   it("dispatches runtime ACP thread messages with the Discord source owner and session", async () => {
     const sourceSessionKey = "agent:worker:discord:channel:thread-1";
+    const targetSessionKey = "agent:claude:acp:runtime:discord-thread";
+    dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
+      await params?.dispatcher.sendFinalReply({ text: "ACP reply" });
+      return { queuedFinal: true, counts: { final: 1, tool: 0, block: 0 } };
+    });
     const ctx = await createBaseContext({
       baseSessionKey: sourceSessionKey,
-      boundSessionKey: "agent:claude:acp:runtime:discord-thread",
+      boundSessionKey: targetSessionKey,
       threadBinding: {
         bindingId: "runtime-acp-thread",
-        targetSessionKey: "agent:claude:acp:runtime:discord-thread",
+        targetSessionKey,
         targetKind: "session",
         conversation: {
           channel: "discord",
@@ -447,6 +453,12 @@ describe("processDiscordMessage session routing", () => {
       AgentId: "worker",
       SessionKey: sourceSessionKey,
     });
+    expect(deliverDiscordReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionKey: targetSessionKey,
+        target: "channel:c1",
+      }),
+    );
   });
 
   it("marks explicit message-tool guild replies as message-tool-only and disables source streaming", async () => {

--- a/extensions/discord/src/monitor/message-handler.process.session-routing.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.session-routing.test.ts
@@ -414,6 +414,41 @@ describe("processDiscordMessage session routing", () => {
     });
   });
 
+  it("dispatches runtime ACP thread messages with the Discord source owner and session", async () => {
+    const sourceSessionKey = "agent:worker:discord:channel:thread-1";
+    const ctx = await createBaseContext({
+      baseSessionKey: sourceSessionKey,
+      boundSessionKey: "agent:claude:acp:runtime:discord-thread",
+      threadBinding: {
+        bindingId: "runtime-acp-thread",
+        targetSessionKey: "agent:claude:acp:runtime:discord-thread",
+        targetKind: "session",
+        conversation: {
+          channel: "discord",
+          accountId: "default",
+          conversationId: "thread-1",
+          parentConversationId: "channel-1",
+        },
+        status: "active",
+        boundAt: 1,
+      },
+      route: {
+        agentId: "worker",
+        channel: "discord",
+        accountId: "default",
+        sessionKey: sourceSessionKey,
+        mainSessionKey: "agent:worker:main",
+      },
+    });
+
+    await runProcessDiscordMessage(ctx);
+
+    expectRecordFields(requireRecord(getLastDispatchCtx(), "dispatch context"), {
+      AgentId: "worker",
+      SessionKey: sourceSessionKey,
+    });
+  });
+
   it("marks explicit message-tool guild replies as message-tool-only and disables source streaming", async () => {
     const ctx = await createBaseContext({
       shouldRequireMention: false,

--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -157,6 +157,9 @@ export async function processDiscordMessage(
     replyTarget,
     replyReference: sourceReplyReference,
   } = processContext;
+  // Admission stays owned by the Discord source session, while bound-thread
+  // delivery still needs the ACP target to recover its label, avatar, and thread address.
+  const replyDeliverySessionKey = ctx.boundSessionKey ?? ctxPayload.SessionKey;
   let deliverTarget = initialDeliverTarget;
   const activeThreadRoute = createDiscordMessageActiveThreadRoute({
     sessionKey: ctxPayload.SessionKey,
@@ -297,7 +300,7 @@ export async function processDiscordMessage(
       maxLinesPerMessage,
       tableMode,
       chunkMode,
-      sessionKey: deliverySession?.sessionKey ?? ctxPayload.SessionKey,
+      sessionKey: deliverySession?.sessionKey ?? replyDeliverySessionKey,
       threadBindings,
       mediaLocalRoots: deliverySession
         ? getAgentScopedMediaLocalRoots(cfg, deliverySession.agentId)

--- a/extensions/discord/src/monitor/message-handler.routing-preflight.ts
+++ b/extensions/discord/src/monitor/message-handler.routing-preflight.ts
@@ -6,6 +6,7 @@ import { resolveDiscordConversationBindingRoute } from "./conversation-binding-r
 import type { DiscordMessagePreflightParams } from "./message-handler.preflight.types.js";
 import {
   buildDiscordRoutePeer,
+  isDiscordRuntimeAcpThreadBinding,
   resolveDiscordConversationRoute,
   resolveDiscordEffectiveRoute,
 } from "./route-resolution.js";
@@ -59,8 +60,11 @@ export async function resolveDiscordPreflightRoute(params: {
   const boundSessionKey = conversationRuntime.isPluginOwnedSessionBindingRecord(threadBinding)
     ? ""
     : (runtimeRoute.boundSessionKey ?? threadBinding?.targetSessionKey?.trim());
+  const isRuntimeAcpBinding = isDiscordRuntimeAcpThreadBinding(runtimeRoute.bindingRecord);
   const effectiveRoute = runtimeRoute.boundSessionKey
-    ? runtimeRoute.route
+    ? isRuntimeAcpBinding
+      ? route
+      : runtimeRoute.route
     : resolveDiscordEffectiveRoute({
         route,
         boundSessionKey,
@@ -74,7 +78,9 @@ export async function resolveDiscordPreflightRoute(params: {
     configuredBinding,
     boundSessionKey,
     effectiveRoute,
-    boundAgentId: boundSessionKey ? effectiveRoute.agentId : undefined,
+    boundAgentId: boundSessionKey
+      ? (runtimeRoute.boundAgentId ?? effectiveRoute.agentId)
+      : undefined,
     baseSessionKey: effectiveRoute.sessionKey,
   };
 }

--- a/extensions/discord/src/monitor/route-resolution.ts
+++ b/extensions/discord/src/monitor/route-resolution.ts
@@ -123,6 +123,19 @@ export function resolveDiscordEffectiveRoute(params: {
   };
 }
 
+export function isDiscordRuntimeAcpThreadBinding(record?: SessionBindingRecord | null): boolean {
+  const targetSessionKey = record?.targetSessionKey?.trim();
+  const conversationId = record?.conversation.conversationId?.trim();
+  const parentConversationId = record?.conversation.parentConversationId?.trim();
+  return Boolean(
+    targetSessionKey &&
+    isAcpSessionKey(targetSessionKey) &&
+    conversationId &&
+    parentConversationId &&
+    conversationId !== parentConversationId,
+  );
+}
+
 function hasExplicitRuntimeBindingIntent(record: SessionBindingRecord): boolean {
   if (record.targetKind === "subagent") {
     return true;


### PR DESCRIPTION
Refs #146365

## What Problem This Solves

Fixes: Discord ACP child threads drop follow-up replies when `agents.ownership` is `explicit` and the ACP harness identity differs from the source OpenClaw agent.

## User Impact

User impact: users can continue conversations in Discord threads created by `/acp spawn --thread auto` without dispatch failures or dead-lettered replies.

## Why This Change Was Made

Discord now retains the source route and source session for reply-dispatch admission while keeping the ACP session as the separate bound target. The exception is limited to runtime-created ACP child threads; current-conversation `/acp spawn --bind here` and configured ACP bindings keep their existing routing behavior.

This PR covers text follow-ups in runtime-created ACP threads. The issue's native slash-command path is separate and remains tracked by #146365.

## Evidence

- A pre-fix proof on `b1b314e4bc67` reproduced the ownership overwrite: the source owner expected as `worker` resolved as the ACP harness owner instead. The same proof passes on `14501e89e44`, preserving `worker` and its Discord session while retaining the separate ACP target session.
- Six focused Discord test suites pass: 210 tests covering routing preflight, process-to-delivery session separation, bound-thread persona delivery, configured ACP bindings, and outbound webhook persona routing.
- `node scripts/check-changed.mjs --base upstream/main -- <changed files>` passes all selected formatting, typecheck, lint, boundary, dead-export, and import-cycle gates.
- `pnpm build` passes.
- Live Discord proof passed against an isolated Gateway with `agents.ownership: "explicit"`: `/acp spawn codex --mode persistent --thread auto` created the child thread, a follow-up entered with the source owner `worker`, ACP dispatch completed, and the bot replied exactly `OC146365_DISCORD_OK`.
- Repository autoreview is scoped-clean for P0–P2 findings.
