### PR TITLE
test(ui): match versioned MCP sandbox cache policy

### DIFF
--- a/ui/src/e2e/mcp-app-conformance.e2e.test.ts
+++ b/ui/src/e2e/mcp-app-conformance.e2e.test.ts
@@ -846,7 +846,7 @@ suite.define(() => {
             ).toHaveLength(initializations);
 
             // Playwright does not support BFCache restoration; use its supported history flow.
-            // Production no-store headers stay unchanged, and ordinary history is not BFCache proof.
+            // Ticketed responses stay uncached; the versioned public sandbox shell may be cached.
             const historyContext = await newProofContext();
             const historyPage = await historyContext.newPage();
             const historyStates: Array<Record<string, unknown>> = [];
@@ -917,15 +917,13 @@ suite.define(() => {
               expect(
                 historyEvents.filter((event) => event.event === "response-written"),
               ).toMatchObject([{ id: historyCallId, isError: false }]);
-              for (const pathname of [
-                "/__openclaw__/mcp-app",
-                "/__openclaw__/mcp-app/view",
-                "/mcp-app-sandbox",
+              for (const [pathname, cacheControl] of [
+                ["/__openclaw__/mcp-app", "no-store"],
+                ["/__openclaw__/mcp-app/view", "no-store"],
+                ["/mcp-app-sandbox", "public, max-age=31536000, immutable"],
               ]) {
                 expect(responses.filter((response) => response.pathname === pathname)).toEqual(
-                  expect.arrayContaining([
-                    expect.objectContaining({ status: 200, cacheControl: "no-store" }),
-                  ]),
+                  expect.arrayContaining([expect.objectContaining({ status: 200, cacheControl })]),
                 );
               }
               historyObservations.phase = "complete";


### PR DESCRIPTION
## What Problem This Solves

The MCP app browser conformance test expects no-store for the versioned public sandbox shell, although #146602 intentionally made that shell immutable.

## User Impact

No runtime behavior changes. CI verifies the intended public-shell caching while retaining no-store checks for both ticketed MCP app routes.

## Why This Change Was Made

Use the existing route table to express each cache policy. Existing operation, history, cancellation, and authority assertions remain intact.

## Evidence

- Current failing flow: [55/56 real-Gateway tests pass](https://github.com/openclaw/openclaw/actions/runs/34737205539/job/103671185832); the only failure is the stale sandbox cache assertion, and both quota-recovery cases pass.
- The original repaired revision passes both MCP conformance cases in [hosted CI](https://github.com/openclaw/openclaw/actions/runs/34735436770/job/103666012543). That older run failed only the separate quota-recovery case.
- Rebased onto main 26b9c98df80b03cbfeea4c3709cc37e05d5350cd. The one-file patch is identical by range-diff, the complete test file is byte-identical to the original repaired revision, and diff whitespace checking passes.
- The original author reported twelve passing sibling HTTP tests and full changed checks. Those local captures were not independently inspected during this refresh. The unchanged HTTP tests cover matching, stale, unversioned, and policy-mismatched sandbox URLs.
- Fresh independent P2 review passed with no findings (confidence 0.98); exact-head CI is pending for d60ef8f4d19469d2d5977cf63e236b6f69dcd8ea. Local changed-check planning could not run without dependencies in the isolated refresh checkout; no local test pass is claimed for this rebase.
