### PR TITLE
fix: restore typechecks after env reference cleanup

### DIFF
--- a/src/config/types.secrets.ts
+++ b/src/config/types.secrets.ts
@@ -7,7 +7,6 @@ import {
   DEFAULT_SECRET_PROVIDER_ALIAS,
   ENV_SECRET_REF_ID_RE,
   isSecretRef,
-  isValidEnvSecretRefId,
   type SecretRef,
   type SecretRefSource,
 } from "../secrets/ref-contract.js";


### PR DESCRIPTION
## What Problem This Solves

Fixes shared CI typecheck and lint failures after #146660 removed the last local use of `isValidEnvSecretRefId` from the config secret types module.

## User Impact

Restores checks for unrelated PRs, including #146678 and #146547. There is no runtime behavior change.

## Why This Change Was Made

Remove the unused local import while preserving the independent public re-export from the canonical SecretRef contract. All validation and coercion logic stays unchanged.

## Evidence

The existing failure is recorded in [the production typecheck job](https://github.com/openclaw/openclaw/actions/runs/34734796710/job/103664232130): `TS6133` for the unused import. Scoped typed lint reproduced the same defect before the change and passes afterward:

```sh
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/config/types.secrets.ts
```

Formatting and `git diff --check` pass. The diff deletes one imported binding and retains the public re-export. Fresh independent P2 review of the one-line diff is scoped-clean with no actionable findings. That review did not include the complete module; full local source inspection and the before/after typed lint establish remaining usage and re-export preservation. A bounded runtime import smoke confirms the config re-export is the identical canonical validator and seven synthetic valid/invalid ID cases agree. [Exact-head ready CI run34735450417](https://github.com/openclaw/openclaw/actions/runs/34735450417) is green for `bcae9681018b59a63291d764f97432e9e7e11474`, including required compiler and lint checks.
