### PR TITLE
fix: restore type checks after secret helper migration

### DIFF
--- a/src/config/types.secrets.ts
+++ b/src/config/types.secrets.ts
@@ -7,7 +7,6 @@ import {
   DEFAULT_SECRET_PROVIDER_ALIAS,
   ENV_SECRET_REF_ID_RE,
   isSecretRef,
-  isValidEnvSecretRefId,
   type SecretRef,
   type SecretRefSource,
 } from "../secrets/ref-contract.js";


### PR DESCRIPTION
## What Problem This Solves

Production and test type checks fail on main with TS6133 after #146660 removed the local consumer of `isValidEnvSecretRefId`.

## User Impact

Restores type-checking for subsequent pull requests. There is no runtime or public API change.

## Why This Change Was Made

Remove the unused local import while retaining the separate public re-export from the same module.

## Evidence

- The completed production and test jobs for #146682 and #146684 report this exact unused-import error against their newer main merge snapshots.
- Both existing secret coercion and resolution test files pass: 17 tests.
- Formatting and `git diff --check` pass. Both hosted production and test type checks pass in [CI run 34735533373](https://github.com/openclaw/openclaw/actions/runs/34735533373).
