### PR TITLE
refactor: reuse shared deferred promises in core and plugin tests

### DIFF
--- a/extensions/browser/chrome-extension/background.fetch-continuation.test.ts
+++ b/extensions/browser/chrome-extension/background.fetch-continuation.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ExtensionRelayBridge } from "../src/browser/extension-relay/relay-bridge.js";
 import { FakeSocket } from "../src/browser/extension-relay/relay-bridge.test-support.js";
@@ -52,10 +53,7 @@ const bodyReads: FetchOperation[] = [
 const releases = new Set<() => void>();
 const cleanups: Array<() => Promise<void>> = [];
 function deferred() {
-  let release = () => {};
-  const promise = new Promise<void>((resolve) => {
-    release = resolve;
-  });
+  const { promise, resolve: release } = createDeferred<void>();
   const finish = () => {
     releases.delete(finish);
     release();

--- a/extensions/browser/chrome-extension/background.initial-target.test.ts
+++ b/extensions/browser/chrome-extension/background.initial-target.test.ts
@@ -1,3 +1,4 @@
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ExtensionRelayBridge } from "../src/browser/extension-relay/relay-bridge.js";
 import {
@@ -11,11 +12,7 @@ import {
 
 const pendingReleases = new Set<() => void>();
 function deferred<T>(fallback: T) {
-  let resolve = (_value: T) => {};
-  const promise = new Promise<T>((done) => {
-    resolve = done;
-  });
-  const pending = { promise, resolve };
+  const pending = createDeferred<T>();
   const release = () => pending.resolve(fallback);
   pendingReleases.add(release);
   return {

--- a/extensions/browser/chrome-extension/background.navigation.test.ts
+++ b/extensions/browser/chrome-extension/background.navigation.test.ts
@@ -1,3 +1,4 @@
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   cleanupBackgroundHarnesses,
@@ -8,10 +9,7 @@ import {
 
 const releases = new Set<() => void>();
 function deferred<T>(value: T) {
-  let resolve = (_value: T) => {};
-  const promise = new Promise<T>((done) => {
-    resolve = done;
-  });
+  const { promise, resolve } = createDeferred<T>();
   const release = () => {
     releases.delete(release);
     resolve(value);

--- a/extensions/browser/chrome-extension/modules/tab-access-events.test.ts
+++ b/extensions/browser/chrome-extension/modules/tab-access-events.test.ts
@@ -1,14 +1,7 @@
+import { createDeferred as deferred } from "openclaw/plugin-sdk/extension-shared";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { registerTabAccessEvents } from "./tab-access-events.js";
 import type { BrowserTabSnapshot } from "./tab-eligibility.js";
-
-function deferred<T>() {
-  let resolve = (_value: T) => {};
-  const promise = new Promise<T>((next) => {
-    resolve = next;
-  });
-  return { promise, resolve };
-}
 
 function createHarness(
   mode: "all" | "selected" = "selected",

--- a/extensions/browser/src/browser/bridge-server.auth.test.ts
+++ b/extensions/browser/src/browser/bridge-server.auth.test.ts
@@ -1,5 +1,6 @@
 // Browser tests cover bridge server.auth plugin behavior.
 import { createServer } from "node:http";
+import { createDeferred as deferred } from "openclaw/plugin-sdk/extension-shared";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { getBridgeAuthForPort } from "./bridge-auth-registry.js";
 import { startBrowserBridgeServer, stopBrowserBridgeServer } from "./bridge-server.js";
@@ -9,14 +10,6 @@ import {
   DEFAULT_OPENCLAW_BROWSER_PROFILE_NAME,
 } from "./constants.js";
 import { isBrowserRuntimeRunning } from "./server-context.lifecycle.js";
-
-function deferred() {
-  let resolve!: () => void;
-  const promise = new Promise<void>((done) => {
-    resolve = done;
-  });
-  return { promise, resolve };
-}
 
 function buildResolvedConfig(): ResolvedBrowserConfig {
   return {
@@ -159,8 +152,8 @@ describe("startBrowserBridgeServer auth", () => {
   });
 
   it("invalidates an active request before waiting for HTTP close", async () => {
-    const attachStarted = deferred();
-    const releaseAttach = deferred();
+    const attachStarted = deferred<void>();
+    const releaseAttach = deferred<void>();
     const bridge = await startBrowserBridgeServer({
       resolved: buildResolvedConfig(),
       authToken: "secret-token",

--- a/extensions/browser/src/browser/chrome.internal.test.ts
+++ b/extensions/browser/src/browser/chrome.internal.test.ts
@@ -7,6 +7,7 @@ import { Agent, createServer } from "node:http";
 import type { AddressInfo } from "node:net";
 import os from "node:os";
 import path from "node:path";
+import { createDeferred as deferred } from "openclaw/plugin-sdk/extension-shared";
 import { createOpenClawTestState } from "openclaw/plugin-sdk/test-state";
 import { rawDataToString } from "openclaw/plugin-sdk/webhook-ingress";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -179,16 +180,6 @@ function mockExpiredLaunchPollingClock(): void {
     now += 1_000;
     return now;
   });
-}
-
-function deferred<T = void>() {
-  let resolve!: (value: T | PromiseLike<T>) => void;
-  let reject!: (reason?: unknown) => void;
-  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
-    resolve = resolvePromise;
-    reject = rejectPromise;
-  });
-  return { promise, reject, resolve };
 }
 
 async function startLinuxZombieProcess(): Promise<{ pid: number; reap: () => Promise<void> }> {
@@ -767,7 +758,7 @@ describe("chrome.ts internal", () => {
       stubBrowserExecutableAndPrefs("present");
       const proc = makeFakeProc({ pid: 51114 });
       spawnMock.mockReturnValue(proc);
-      const probeEntered = deferred();
+      const probeEntered = deferred<void>();
       vi.stubGlobal(
         "fetch",
         vi.fn(async () => {
@@ -792,7 +783,7 @@ describe("chrome.ts internal", () => {
     it("aborts bootstrap immediately and never reaches the runtime launch", async () => {
       stubBrowserExecutableAndPrefs("missing");
       const bootstrap = makeFakeProc({ pid: 51115 });
-      const spawned = deferred();
+      const spawned = deferred<void>();
       spawnMock.mockImplementation(() => {
         spawned.resolve();
         return bootstrap;
@@ -818,7 +809,7 @@ describe("chrome.ts internal", () => {
         kill: vi.fn(() => true),
       });
       spawnMock.mockReturnValue(proc);
-      const probeEntered = deferred();
+      const probeEntered = deferred<void>();
       vi.stubGlobal(
         "fetch",
         vi.fn(async () => {

--- a/extensions/browser/src/browser/extension-relay/relay-lifecycle.test.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-lifecycle.test.ts
@@ -1,3 +1,4 @@
+import { createDeferred as deferred } from "openclaw/plugin-sdk/extension-shared";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { relayTestKey } from "../../../chrome-extension/relay-key.test-support.js";
 import { resolveProfile, type ResolvedBrowserConfig } from "../config.js";
@@ -74,14 +75,6 @@ function createHandle(token: string, port = RELAY_PORT): ExtensionRelayHandle {
     bridge: {} as ExtensionRelayHandle["bridge"],
     close: vi.fn(async () => {}),
   };
-}
-
-function deferred() {
-  let resolve!: () => void;
-  const promise = new Promise<void>((done) => {
-    resolve = done;
-  });
-  return { promise, resolve };
 }
 
 describe("extension relay lifecycle", () => {
@@ -162,8 +155,8 @@ describe("extension relay lifecycle", () => {
   it("coalesces concurrent rebinds to one exact relay handle", async () => {
     const oldRelay = createHandle(OLD_TOKEN);
     const { profile, state } = createState(OLD_TOKEN, oldRelay);
-    const startEntered = deferred();
-    const releaseStart = deferred();
+    const startEntered = deferred<void>();
+    const releaseStart = deferred<void>();
     const replacement = createHandle(ROTATED_TOKEN);
     startExtensionRelayServerMock.mockImplementationOnce(async () => {
       startEntered.resolve();
@@ -186,8 +179,8 @@ describe("extension relay lifecycle", () => {
     const oldRelay = createHandle(OLD_TOKEN);
     const { profile, state } = createState(OLD_TOKEN, oldRelay);
     const runtime = getOrCreateProfileRuntime(state, profile);
-    const startEntered = deferred();
-    const releaseStart = deferred();
+    const startEntered = deferred<void>();
+    const releaseStart = deferred<void>();
     const replacement = createHandle(ROTATED_TOKEN);
     startExtensionRelayServerMock.mockImplementationOnce(async () => {
       startEntered.resolve();
@@ -232,8 +225,8 @@ describe("extension relay lifecycle", () => {
     const oldRelay = createHandle(OLD_TOKEN);
     const { profile, state } = createState(OLD_TOKEN, oldRelay);
     const runtime = getOrCreateProfileRuntime(state, profile);
-    const startEntered = deferred();
-    const releaseStart = deferred();
+    const startEntered = deferred<void>();
+    const releaseStart = deferred<void>();
     const replacement = createHandle(ROTATED_TOKEN);
     startExtensionRelayServerMock.mockImplementationOnce(async () => {
       startEntered.resolve();
@@ -281,8 +274,8 @@ describe("extension relay lifecycle", () => {
     const oldRelay = createHandle(OLD_TOKEN);
     const { profile, state } = createState(OLD_TOKEN, oldRelay);
     const runtime = getOrCreateProfileRuntime(state, profile);
-    const startEntered = deferred();
-    const releaseStart = deferred();
+    const startEntered = deferred<void>();
+    const releaseStart = deferred<void>();
     const replacement = createHandle(ROTATED_TOKEN);
     startExtensionRelayServerMock.mockImplementationOnce(async () => {
       startEntered.resolve();

--- a/extensions/browser/src/browser/profiles-service.test.ts
+++ b/extensions/browser/src/browser/profiles-service.test.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
+import { createDeferred as deferred } from "openclaw/plugin-sdk/extension-shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test-support.js";
 import { getRuntimeConfig } from "../config/config.js";
@@ -120,14 +121,6 @@ function createCtx(resolved: BrowserServerState["resolved"]) {
   } as unknown as BrowserRouteContext;
 
   return { state, ctx };
-}
-
-function deferred() {
-  let resolve!: () => void;
-  const promise = new Promise<void>((done) => {
-    resolve = done;
-  });
-  return { promise, resolve };
 }
 
 async function createWorkProfileWithConfig(params: {
@@ -616,8 +609,8 @@ describe("BrowserProfilesService", () => {
     const userDataDir = path.join(tempDir, "work", "user-data");
     fs.mkdirSync(userDataDir, { recursive: true });
     vi.mocked(resolveOpenClawUserDataDir).mockReturnValue(userDataDir);
-    const launch = deferred();
-    const entered = deferred();
+    const launch = deferred<void>();
+    const entered = deferred<void>();
     const running = {
       pid: 42,
       exe: { kind: "chromium", path: "/usr/bin/chromium" },
@@ -707,8 +700,8 @@ describe("BrowserProfilesService", () => {
       throw new Error("Expected work profile");
     }
     const runtime = getOrCreateProfileRuntime(state, profile);
-    const entered = deferred();
-    const release = deferred();
+    const entered = deferred<void>();
+    const release = deferred<void>();
     const starting = enqueueProfileStart({
       state,
       runtime,

--- a/extensions/browser/src/browser/runtime-lifecycle.shutdown-race.test.ts
+++ b/extensions/browser/src/browser/runtime-lifecycle.shutdown-race.test.ts
@@ -1,6 +1,7 @@
 // Browser tests cover runtime shutdown against deferred profile starts.
 import type { ChildProcessWithoutNullStreams } from "node:child_process";
 import { EventEmitter } from "node:events";
+import { createDeferred as deferred } from "openclaw/plugin-sdk/extension-shared";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { RunningChrome } from "./chrome.js";
 import { makeBrowserProfile } from "./server-context.test-harness.js";
@@ -33,14 +34,6 @@ const {
   getOrCreateProfileRuntime,
   registerProfileHandle,
 } = await import("./server-context.lifecycle.js");
-
-function deferred<T>() {
-  let resolve!: (value: T) => void;
-  const promise = new Promise<T>((resolvePromise) => {
-    resolve = resolvePromise;
-  });
-  return { promise, resolve };
-}
 
 function fakeRunning(pid: number): RunningChrome {
   return {

--- a/extensions/browser/src/browser/server-context.ensure-browser-available.waits-for-cdp-ready.test.ts
+++ b/extensions/browser/src/browser/server-context.ensure-browser-available.waits-for-cdp-ready.test.ts
@@ -1,6 +1,7 @@
 // Browser tests cover server context.ensure browser available.waits for cdp ready plugin behavior.
 import type { ChildProcessWithoutNullStreams } from "node:child_process";
 import { EventEmitter } from "node:events";
+import { createDeferred as deferred } from "openclaw/plugin-sdk/extension-shared";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import "./server-context.chrome-test-harness.js";
 import { PROFILE_ATTACH_RETRY_TIMEOUT_MS } from "./cdp-timeouts.js";
@@ -12,14 +13,6 @@ import { beginProfileTransition, getProfileLifecycle } from "./server-context.li
 import { makeBrowserServerState, mockLaunchedChrome } from "./server-context.test-harness.js";
 
 const PROFILE_HTTP_REACHABILITY_TIMEOUT_MS = 300;
-
-function deferred<T>() {
-  let resolve!: (value: T) => void;
-  const promise = new Promise<T>((done) => {
-    resolve = done;
-  });
-  return { promise, resolve };
-}
 
 function fakeRunning(pid: number): RunningChrome {
   return {

--- a/extensions/browser/src/browser/server-context.existing-session.test.ts
+++ b/extensions/browser/src/browser/server-context.existing-session.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
+import { createDeferred as deferred } from "openclaw/plugin-sdk/extension-shared";
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import "../test-support/browser-security.mock.js";
 import type { BrowserServerState } from "./server-context.js";
@@ -78,16 +79,6 @@ type ChromeLiveProfile = {
   userDataDir?: string;
   mcpArgs?: string[];
 };
-
-function deferred<T>() {
-  let resolve!: (value: T) => void;
-  let reject!: (reason?: unknown) => void;
-  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
-    resolve = resolvePromise;
-    reject = rejectPromise;
-  });
-  return { promise, resolve, reject };
-}
 
 function makeState(): BrowserServerState {
   return {

--- a/extensions/browser/src/browser/server-context.hot-reload-defaults.test.ts
+++ b/extensions/browser/src/browser/server-context.hot-reload-defaults.test.ts
@@ -1,3 +1,4 @@
+import { createDeferred as deferred } from "openclaw/plugin-sdk/extension-shared";
 import "./server-context.chrome-test-harness.js";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
@@ -16,14 +17,6 @@ vi.mock("./pw-ai-module.js", () => ({
   getLoadedPwAiModule: () => null,
   getPwAiModule: async () => null,
 }));
-
-function deferred() {
-  let resolve!: () => void;
-  const promise = new Promise<void>((done) => {
-    resolve = done;
-  });
-  return { promise, resolve };
-}
 
 describe("browser inherited launch settings reload", () => {
   beforeEach(() => {
@@ -143,8 +136,8 @@ describe("browser inherited launch settings reload", () => {
     vi.mocked(stopOpenClawChrome).mockImplementation(async () => {
       managedReachable = false;
     });
-    const started = deferred();
-    const release = deferred();
+    const started = deferred<void>();
+    const release = deferred<void>();
     const stale = mockLaunchedChrome(vi.mocked(launchOpenClawChrome), 201);
     const replacement = mockLaunchedChrome(vi.mocked(launchOpenClawChrome), 202);
     vi.mocked(launchOpenClawChrome)

--- a/extensions/browser/src/browser/server-context.hot-reload-profiles.test.ts
+++ b/extensions/browser/src/browser/server-context.hot-reload-profiles.test.ts
@@ -1,4 +1,5 @@
 // Browser tests cover server context.hot reload profiles plugin behavior.
+import { createDeferred as deferred } from "openclaw/plugin-sdk/extension-shared";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { RunningChrome } from "./chrome.js";
 import type { ResolvedBrowserProfile } from "./config.js";
@@ -110,14 +111,6 @@ function requireValue<T>(value: T | null | undefined, message: string): T {
     throw new Error(message);
   }
   return value;
-}
-
-function deferred() {
-  let resolve!: () => void;
-  const promise = new Promise<void>((resolvePromise) => {
-    resolve = resolvePromise;
-  });
-  return { promise, resolve };
 }
 
 function runtimeState(
@@ -396,8 +389,8 @@ describe("server-context hot-reload profiles", () => {
 
   it("never re-adopts a relay credential while an unexposed close is still pending", async () => {
     const { state, runtime, relay } = createExtensionRelayFixture();
-    const closeStarted = deferred();
-    const closeReleased = deferred();
+    const closeStarted = deferred<void>();
+    const closeReleased = deferred<void>();
     relay.close.mockImplementationOnce(async () => {
       closeStarted.resolve();
       await closeReleased.promise;
@@ -571,8 +564,8 @@ describe("server-context hot-reload profiles", () => {
       name: "work",
       config: { cdpPort: 18801, color: "#0066CC" },
     });
-    const launchA = deferred();
-    const launchAStarted = deferred();
+    const launchA = deferred<void>();
+    const launchAStarted = deferred<void>();
     const adopted: string[] = [];
     const revisionA = getProfileLifecycle(runtime).configRevision;
     const pendingA = enqueueCurrentProfileStart(state, runtime, async (signal, generation) => {
@@ -652,8 +645,8 @@ describe("server-context hot-reload profiles", () => {
     });
     expect(oldRuntime.running).toBeNull();
     const lateRunning = { pid: 321 } as RunningChrome;
-    const launch = deferred();
-    const launchStarted = deferred();
+    const launch = deferred<void>();
+    const launchStarted = deferred<void>();
     const pendingStart = enqueueCurrentProfileStart(state, oldRuntime, async () => {
       launchStarted.resolve();
       await launch.promise;

--- a/extensions/codex/src/app-server/desktop-generation.test.ts
+++ b/extensions/codex/src/app-server/desktop-generation.test.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { createDeferred as deferred } from "openclaw/plugin-sdk/extension-shared";
 import { withTempDir } from "openclaw/plugin-sdk/test-env";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
@@ -7,16 +8,6 @@ import {
   resolveMacOSDesktopGenerationWatchPaths,
 } from "./desktop-generation-fingerprint.js";
 import { createCodexDesktopGenerationOwner } from "./desktop-generation-owner.js";
-
-function deferred<T>() {
-  let resolve!: (value: T) => void;
-  let reject!: (error: unknown) => void;
-  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
-    resolve = resolvePromise;
-    reject = rejectPromise;
-  });
-  return { promise, resolve, reject };
-}
 
 describe("Codex desktop generation owner", () => {
   afterEach(() => vi.useRealTimers());

--- a/extensions/discord/src/monitor/message-avatar.test.ts
+++ b/extensions/discord/src/monitor/message-avatar.test.ts
@@ -1,3 +1,4 @@
+import { createDeferred as deferred } from "openclaw/plugin-sdk/extension-shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Client, User } from "../internal/discord.js";
 
@@ -15,16 +16,6 @@ vi.mock("openclaw/plugin-sdk/logging-core", () => ({
 }));
 
 const { createDiscordAvatarResolver } = await import("./message-avatar.js");
-
-function deferred<T>() {
-  let resolve!: (value: T) => void;
-  let reject!: (error: unknown) => void;
-  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
-    resolve = resolvePromise;
-    reject = rejectPromise;
-  });
-  return { promise, reject, resolve };
-}
 
 function discordUser(id: string, avatar: string | null): User {
   return { id, avatar } as User;

--- a/extensions/imessage/src/monitor/ingress.test.ts
+++ b/extensions/imessage/src/monitor/ingress.test.ts
@@ -6,6 +6,7 @@ import {
   closeOpenClawStateDatabaseForTest,
   createChannelIngressQueueForTests,
 } from "openclaw/plugin-sdk/channel-ingress-test-runtime";
+import { createDeferred as deferred } from "openclaw/plugin-sdk/extension-shared";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createIMessageDurableIngress } from "./ingress.js";
 
@@ -52,14 +53,6 @@ async function withQueue<T>(
 
 function runtime() {
   return { error: vi.fn(), log: vi.fn() };
-}
-
-function deferred() {
-  let resolve = () => {};
-  const promise = new Promise<void>((done) => {
-    resolve = done;
-  });
-  return { promise, resolve };
 }
 
 afterEach(() => {
@@ -123,8 +116,8 @@ describe("iMessage durable ingress", () => {
 
   it("serializes durable cursor advancement before admitting the next row", async () => {
     await withQueue(async (queue) => {
-      const cursorGate = deferred();
-      const cursorStarted = deferred();
+      const cursorGate = deferred<void>();
+      const cursorStarted = deferred<void>();
       let currentTime = 1_000;
       const onDurableEnqueue = vi.fn(async () => {
         cursorStarted.resolve();
@@ -165,9 +158,9 @@ describe("iMessage durable ingress", () => {
 
   it("lets an approval poll vote overtake the conversation turn awaiting it", async () => {
     await withQueue(async (queue) => {
-      const firstStarted = deferred();
-      const releaseFirst = deferred();
-      const voteStarted = deferred();
+      const firstStarted = deferred<void>();
+      const releaseFirst = deferred<void>();
+      const voteStarted = deferred<void>();
       const dispatch = vi.fn(async (message: { id?: number | null }) => {
         if (message.id === 101) {
           firstStarted.resolve();
@@ -218,9 +211,9 @@ describe("iMessage durable ingress", () => {
 
   it("keeps an unowned poll vote behind the earlier conversation turn", async () => {
     await withQueue(async (queue) => {
-      const firstStarted = deferred();
-      const releaseFirst = deferred();
-      const unrelatedChecked = deferred();
+      const firstStarted = deferred<void>();
+      const releaseFirst = deferred<void>();
+      const unrelatedChecked = deferred<void>();
       const dispatch = vi.fn(async (message: { id?: number | null }) => {
         if (message.id === 101) {
           firstStarted.resolve();

--- a/extensions/matrix/src/matrix/monitor/handler.active-turn-steering.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.active-turn-steering.test.ts
@@ -4,6 +4,7 @@ import {
   type ChannelInboundEventRunnerParams,
 } from "openclaw/plugin-sdk/channel-inbound";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import type { FinalizedMsgContext, GetReplyOptions } from "openclaw/plugin-sdk/reply-runtime";
 import { useAutoCleanupTempDirTracker } from "openclaw/plugin-sdk/test-env";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -20,14 +21,6 @@ type MatrixInboundRunParams = Parameters<MatrixInboundRun>[0];
 type TurnAdoptionLifecycle = NonNullable<GetReplyOptions["turnAdoptionLifecycle"]>;
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
-
-function createDeferred() {
-  let resolve!: () => void;
-  const promise = new Promise<void>((settle) => {
-    resolve = settle;
-  });
-  return { promise, resolve };
-}
 
 function createClaimSpies() {
   return {
@@ -81,9 +74,9 @@ describe("Matrix active-turn steering admission", () => {
       const storePath = path.join(tempDir, "sessions.json");
       const activeEventId = explicitSteer ? "$active-explicit-steer" : "$active-configured-steer";
       const followupEventId = explicitSteer ? "$explicit-steer" : "$configured-steer";
-      const activeResolverStarted = createDeferred();
-      const releaseActiveResolver = createDeferred();
-      const followupTurnResolved = createDeferred();
+      const activeResolverStarted = createDeferred<void>();
+      const releaseActiveResolver = createDeferred<void>();
+      const followupTurnResolved = createDeferred<void>();
       const claimsByEvent = new Map<string, ReturnType<typeof createClaimSpies>>();
       const inboundLifecycles = new Map<string, TurnAdoptionLifecycle | undefined>();
       let followupResolverLifecycle: TurnAdoptionLifecycle | undefined;

--- a/extensions/matrix/src/matrix/monitor/handler.group-history.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.group-history.test.ts
@@ -16,6 +16,7 @@
  *   user: @agent_a msg C     (triggers agent_a; agent_a sees [B] in history)
  */
 
+import { createDeferred as deferred } from "openclaw/plugin-sdk/extension-shared";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { installMatrixMonitorTestRuntime } from "../../test-runtime.js";
 import {
@@ -88,17 +89,6 @@ function makeDevRoute(agentId: string) {
 beforeEach(() => {
   installMatrixMonitorTestRuntime();
 });
-
-function deferred<T>() {
-  let resolve: ((value: T | PromiseLike<T>) => void) | undefined;
-  const promise = new Promise<T>((res) => {
-    resolve = res;
-  });
-  if (!resolve) {
-    throw new Error("Expected deferred resolver to be initialized");
-  }
-  return { promise, resolve };
-}
 
 type HistoryHarnessOptions = NonNullable<Parameters<typeof createMatrixHandlerTestHarness>[0]>;
 type FinalizeInboundContext = NonNullable<HistoryHarnessOptions["finalizeInboundContext"]>;

--- a/extensions/memory-core/src/standing-intents.async.test.ts
+++ b/extensions/memory-core/src/standing-intents.async.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { createDeferred as deferred } from "openclaw/plugin-sdk/extension-shared";
 import { getGlobalHookRunner } from "openclaw/plugin-sdk/plugin-runtime";
 import {
   createPluginRecord,
@@ -66,14 +67,6 @@ vi.mock("openclaw/plugin-sdk/sqlite-runtime", async (importOriginal) => {
   };
 });
 
-function deferred() {
-  let resolve!: () => void;
-  const promise = new Promise<void>((done) => {
-    resolve = done;
-  });
-  return { promise, resolve };
-}
-
 const pending: Promise<unknown>[] = [];
 const releases: Array<() => void> = [];
 const tempDirs = useAutoCleanupTempDirTracker((cleanup) =>
@@ -106,8 +99,8 @@ function keep<T>(work: Promise<T>): Promise<T> {
 }
 
 function holdAdmission(failure?: Error) {
-  const entered = deferred();
-  const finish = deferred();
+  const entered = deferred<void>();
+  const finish = deferred<void>();
   releases.push(finish.resolve);
   admission.pause = async () => {
     entered.resolve();
@@ -347,7 +340,7 @@ describe("standing-intent admitted operations", () => {
     const existing = await seed();
     const { runner } = registerHooks();
     closeOpenClawAgentDatabasesForTest();
-    const started = deferred();
+    const started = deferred<void>();
     admission.started = started.resolve;
     const held = holdAdmission();
     vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });

--- a/extensions/memory-wiki/index.test.ts
+++ b/extensions/memory-wiki/index.test.ts
@@ -1,6 +1,7 @@
 // Memory Wiki tests cover index plugin behavior.
 import fs from "node:fs/promises";
 import path from "node:path";
+import { createDeferred as deferred } from "openclaw/plugin-sdk/extension-shared";
 import { withEnv } from "openclaw/plugin-sdk/test-env";
 import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "./api.js";
@@ -13,7 +14,6 @@ import {
   type MemoryWikiCompiledCacheSnapshot,
 } from "./src/compiled-cache.js";
 import { resolveMemoryWikiConfig } from "./src/config.js";
-import { deferred } from "./src/deferred.test-helpers.js";
 import {
   appendMemoryWikiLog,
   loadMemoryWikiValidatedVaultIdentity,
@@ -261,8 +261,8 @@ describe("memory-wiki plugin", () => {
       throw new Error("Expected an active Memory Wiki vault generation");
     }
     const snapshot = emptyCompiledSnapshot();
-    const validationEntered = deferred();
-    const releaseValidation = deferred();
+    const validationEntered = deferred<void>();
+    const releaseValidation = deferred<void>();
     const commitPublication = vi.fn();
     const publicationId = createMemoryWikiCompiledCachePublicationId();
     const publication = writeMemoryWikiCompiledCache(
@@ -302,8 +302,8 @@ describe("memory-wiki plugin", () => {
       const service = registerService.mock.calls[0]?.[0];
       await service?.start?.();
 
-      const mutationEntered = deferred();
-      const releaseMutation = deferred();
+      const mutationEntered = deferred<void>();
+      const releaseMutation = deferred<void>();
       const mutation = withMemoryWikiVaultMutation(rootDir, async () => {
         mutationEntered.resolve();
         await releaseMutation.promise;

--- a/extensions/memory-wiki/src/chatgpt-import.test.ts
+++ b/extensions/memory-wiki/src/chatgpt-import.test.ts
@@ -3,6 +3,7 @@ import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { __setFsSafeTestHooksForTest } from "@openclaw/fs-safe/test-hooks";
+import { createDeferred as deferred } from "openclaw/plugin-sdk/extension-shared";
 import { KeyedAsyncQueue } from "openclaw/plugin-sdk/keyed-async-queue";
 import type { OpenKeyedStoreOptions } from "openclaw/plugin-sdk/plugin-state-runtime";
 import {
@@ -12,7 +13,6 @@ import {
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { rollbackChatGptImportRun } from "./chatgpt-import.js";
 import { configureMemoryWikiCompiledCacheStore } from "./compiled-cache.js";
-import { deferred } from "./deferred.test-helpers.js";
 import {
   configureMemoryWikiImportRunStateStore,
   createMemoryWikiImportRunStateStore,
@@ -349,15 +349,15 @@ describe("ChatGPT import rollback recovery", () => {
       contentHash: "not-the-edited-content",
     });
 
-    const lockEntered = deferred();
-    const releaseLock = deferred();
+    const lockEntered = deferred<void>();
+    const releaseLock = deferred<void>();
     const holder = withMemoryWikiVaultMutation(rootDir, async () => {
       lockEntered.resolve();
       await releaseLock.promise;
     });
     await lockEntered.promise;
 
-    const rollbackQueued = deferred();
+    const rollbackQueued = deferred<void>();
     const originalEnqueue = Object.getOwnPropertyDescriptor(KeyedAsyncQueue.prototype, "enqueue")
       ?.value as KeyedAsyncQueue["enqueue"];
     const enqueueSpy = vi

--- a/extensions/memory-wiki/src/deferred.test-helpers.ts
+++ b/extensions/memory-wiki/src/deferred.test-helpers.ts
@@ -1,7 +1,0 @@
-export function deferred<T = void>() {
-  let resolve!: (value: T) => void;
-  const promise = new Promise<T>((done) => {
-    resolve = done;
-  });
-  return { promise, resolve };
-}

--- a/extensions/memory-wiki/src/gateway.test.ts
+++ b/extensions/memory-wiki/src/gateway.test.ts
@@ -1,10 +1,10 @@
 // Memory Wiki tests cover gateway plugin behavior.
 import path from "node:path";
+import { createDeferred as deferred } from "openclaw/plugin-sdk/extension-shared";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { applyMemoryWikiMutation, normalizeMemoryWikiMutationInput } from "./apply.js";
 import { compileMemoryWikiVault } from "./compile.js";
 import { MemoryWikiDashboardUnavailableError } from "./compiled-cache.js";
-import { deferred } from "./deferred.test-helpers.js";
 import { registerMemoryWikiGatewayMethods } from "./gateway.js";
 import { listMemoryWikiImportInsights } from "./import-insights.js";
 import { listMemoryWikiImportRuns } from "./import-runs.js";

--- a/extensions/memory-wiki/src/ingest.test.ts
+++ b/extensions/memory-wiki/src/ingest.test.ts
@@ -1,9 +1,9 @@
 // Memory Wiki tests cover ingest plugin behavior.
 import fs from "node:fs/promises";
 import path from "node:path";
+import { createDeferred as deferred } from "openclaw/plugin-sdk/extension-shared";
 import { KeyedAsyncQueue } from "openclaw/plugin-sdk/keyed-async-queue";
 import { describe, expect, it, vi } from "vitest";
-import { deferred } from "./deferred.test-helpers.js";
 import { ingestMemoryWikiSource } from "./ingest.js";
 import { withMemoryWikiVaultMutation } from "./mutation-coordinator.js";
 import { createMemoryWikiTestHarness } from "./test-helpers.js";
@@ -77,15 +77,15 @@ hello from source
     });
     const pagePath = path.join(config.vault.path, "sources", "meeting-notes.md");
 
-    const lockEntered = deferred();
-    const releaseLock = deferred();
+    const lockEntered = deferred<void>();
+    const releaseLock = deferred<void>();
     const holder = withMemoryWikiVaultMutation(config.vault.path, async () => {
       lockEntered.resolve();
       await releaseLock.promise;
     });
     await lockEntered.promise;
 
-    const ingestQueued = deferred();
+    const ingestQueued = deferred<void>();
     const originalEnqueue = Object.getOwnPropertyDescriptor(KeyedAsyncQueue.prototype, "enqueue")
       ?.value as KeyedAsyncQueue["enqueue"];
     const enqueueSpy = vi

--- a/extensions/memory-wiki/src/mutation-coordinator.test.ts
+++ b/extensions/memory-wiki/src/mutation-coordinator.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { createDeferred as deferred } from "openclaw/plugin-sdk/extension-shared";
 import { describe, expect, it } from "vitest";
-import { deferred } from "./deferred.test-helpers.js";
 import { withMemoryWikiVaultMutation } from "./mutation-coordinator.js";
 import { createMemoryWikiTestHarness } from "./test-helpers.js";
 
@@ -9,8 +9,8 @@ const { createTempDir } = createMemoryWikiTestHarness();
 
 describe("withMemoryWikiVaultMutation", () => {
   it("serializes mutations for one vault and permits nested work", async () => {
-    const firstEntered = deferred();
-    const releaseFirst = deferred();
+    const firstEntered = deferred<void>();
+    const releaseFirst = deferred<void>();
     const order: string[] = [];
 
     const first = withMemoryWikiVaultMutation("/tmp/wiki-a", async () => {
@@ -37,9 +37,9 @@ describe("withMemoryWikiVaultMutation", () => {
   });
 
   it("allows distinct agent vaults to mutate in parallel", async () => {
-    const firstEntered = deferred();
-    const secondEntered = deferred();
-    const releaseFirst = deferred();
+    const firstEntered = deferred<void>();
+    const secondEntered = deferred<void>();
+    const releaseFirst = deferred<void>();
 
     const first = withMemoryWikiVaultMutation("/tmp/wiki/support", async () => {
       firstEntered.resolve();
@@ -61,8 +61,8 @@ describe("withMemoryWikiVaultMutation", () => {
     const aliasPath = path.join(root, "vault-alias");
     await fs.mkdir(vaultPath);
     await fs.symlink(vaultPath, aliasPath, process.platform === "win32" ? "junction" : "dir");
-    const firstEntered = deferred();
-    const releaseFirst = deferred();
+    const firstEntered = deferred<void>();
+    const releaseFirst = deferred<void>();
     let aliasEntered = false;
     let first: Promise<void> | undefined;
     let alias: Promise<void> | undefined;
@@ -90,9 +90,9 @@ describe("withMemoryWikiVaultMutation", () => {
   });
 
   it("queues detached work after its inherited transaction has ended", async () => {
-    const releaseDetached = deferred();
-    const holderEntered = deferred();
-    const releaseHolder = deferred();
+    const releaseDetached = deferred<void>();
+    const holderEntered = deferred<void>();
+    const releaseHolder = deferred<void>();
     let detachedEntered = false;
     let detached!: Promise<void>;
 

--- a/extensions/memory-wiki/src/source-sync.test.ts
+++ b/extensions/memory-wiki/src/source-sync.test.ts
@@ -1,10 +1,10 @@
 // Memory Wiki tests cover source sync plugin behavior.
 import os from "node:os";
 import path from "node:path";
+import { createDeferred as deferred } from "openclaw/plugin-sdk/extension-shared";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../api.js";
 import { resolveMemoryWikiConfig } from "./config.js";
-import { deferred } from "./deferred.test-helpers.js";
 import { withMemoryWikiVaultMutation } from "./mutation-coordinator.js";
 import { syncMemoryWikiImportedSources } from "./source-sync.js";
 
@@ -158,8 +158,8 @@ describe("syncMemoryWikiImportedSources", () => {
 
   it("waits for an existing vault mutation before starting source sync", async () => {
     const config = createConfig();
-    const blockerEntered = deferred();
-    const blockerGate = deferred();
+    const blockerEntered = deferred<void>();
+    const blockerGate = deferred<void>();
     const blocker = withMemoryWikiVaultMutation(config.vault.path, async () => {
       blockerEntered.resolve(undefined);
       await blockerGate.promise;

--- a/extensions/openai/realtime-quicksilver-delegation.test.ts
+++ b/extensions/openai/realtime-quicksilver-delegation.test.ts
@@ -1,4 +1,5 @@
 import { setImmediate as nextEventLoopTurn } from "node:timers/promises";
+import { createDeferred as deferred } from "openclaw/plugin-sdk/extension-shared";
 import type { RealtimeVoiceGatewayControl } from "openclaw/plugin-sdk/realtime-voice";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { OpenAIQuicksilverDelegationController } from "./realtime-quicksilver-delegation-controller.js";
@@ -13,14 +14,6 @@ import {
   createDelegationHarness,
   type ConsultRunner,
 } from "./realtime-quicksilver.test-helpers.js";
-
-function deferred<T>() {
-  let resolve!: (value: T) => void;
-  const promise = new Promise<T>((done) => {
-    resolve = done;
-  });
-  return { promise, resolve };
-}
 
 function delegate(
   controller: OpenAIQuicksilverDelegationController,

--- a/extensions/qa-lab/src/gateway-child-lifecycle.test.ts
+++ b/extensions/qa-lab/src/gateway-child-lifecycle.test.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { createDeferred as deferred } from "openclaw/plugin-sdk/extension-shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { resolveQaStagedBundledPluginsRoot } from "./bundled-plugin-staging.js";
 import { createQaGatewayChild } from "./gateway-child.js";
@@ -142,14 +143,6 @@ function own(params: Parameters<ReturnType<typeof createQaGatewayChild>["start"]
   const owner = createQaGatewayChild();
   owners.push(owner);
   return { start: () => owner.start(params), stop: owner.stop };
-}
-
-function deferred() {
-  let resolve!: () => void;
-  const promise = new Promise<void>((done) => {
-    resolve = done;
-  });
-  return { promise, resolve };
 }
 
 describe.skipIf(process.platform === "win32")("QA gateway lifetime ownership", () => {
@@ -455,8 +448,8 @@ describe.skipIf(process.platform === "win32")("QA gateway lifetime ownership", (
     const owner = own(params);
     const gateway = await owner.start();
     pids();
-    const entered = deferred();
-    const release = deferred();
+    const entered = deferred<void>();
+    const release = deferred<void>();
     const restarting = gateway.restartAfterStateMutation(async () => {
       entered.resolve();
       await release.promise;

--- a/extensions/qa-lab/src/suite-launch.runtime.test.ts
+++ b/extensions/qa-lab/src/suite-launch.runtime.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { QaSuiteInfraError } from "./errors.js";
 import type { QaLabServerHandle } from "./lab-server.types.js";
@@ -83,14 +84,6 @@ async function writeEvidence(pathLocal: string, writeFile = true) {
   return evidence;
 }
 
-function createDeferred() {
-  let resolve!: () => void;
-  const promise = new Promise<void>((done) => {
-    resolve = done;
-  });
-  return { promise, resolve };
-}
-
 function requireDefaultQaFlowSuiteImplementation() {
   const implementation = runQaFlowSuite.getMockImplementation();
   if (!implementation) {
@@ -109,8 +102,8 @@ function requireDefaultQaTestFileImplementation() {
 
 function blockNextQaFlowSuite() {
   const implementation = requireDefaultQaFlowSuiteImplementation();
-  const started = createDeferred();
-  const blocked = createDeferred();
+  const started = createDeferred<void>();
+  const blocked = createDeferred<void>();
   runQaFlowSuite.mockImplementationOnce(async (params) => {
     started.resolve();
     await blocked.promise;
@@ -121,8 +114,8 @@ function blockNextQaFlowSuite() {
 
 function blockNextQaTestFileRun() {
   const implementation = requireDefaultQaTestFileImplementation();
-  const started = createDeferred();
-  const blocked = createDeferred();
+  const started = createDeferred<void>();
+  const blocked = createDeferred<void>();
   runQaTestFileScenarios.mockImplementationOnce(async (params) => {
     started.resolve();
     await blocked.promise;
@@ -2122,10 +2115,10 @@ describe("qa suite runtime launcher", () => {
     const repoRoot = await makeTempRepo("qa-suite-parallel-scripts-");
     const defaultFlowImplementation = requireDefaultQaFlowSuiteImplementation();
     const defaultTestFileImplementation = requireDefaultQaTestFileImplementation();
-    const flow = createDeferred();
-    const native = createDeferred();
-    const serial = createDeferred();
-    const parallel = createDeferred();
+    const flow = createDeferred<void>();
+    const native = createDeferred<void>();
+    const serial = createDeferred<void>();
+    const parallel = createDeferred<void>();
     const started: string[] = [];
     const preparedEnv = Object.freeze({ OPENCLAW_CURRENT_PACKAGE_TGZ: "/tmp/candidate.tgz" });
     const scriptEnvs: unknown[] = [];
@@ -2285,7 +2278,7 @@ describe("qa suite runtime launcher", () => {
   it("keeps selected evidence order and successful siblings when a parallel script rejects", async () => {
     const repoRoot = await makeTempRepo("qa-suite-parallel-script-rejection-");
     const defaultTestFileImplementation = requireDefaultQaTestFileImplementation();
-    const first = createDeferred();
+    const first = createDeferred<void>();
     runQaTestFileScenarios.mockImplementation(async (params) => {
       const scenario = params.scenarios[0] as QaTestFileScenario | undefined;
       if (!scenario) {
@@ -2349,7 +2342,7 @@ describe("qa suite runtime launcher", () => {
   it("serializes every fail-fast script and stops before post-failure work", async () => {
     const repoRoot = await makeTempRepo("qa-suite-fail-fast-scripts-");
     const defaultTestFileImplementation = requireDefaultQaTestFileImplementation();
-    const first = createDeferred();
+    const first = createDeferred<void>();
     const preparedEnv = Object.freeze({ OPENCLAW_CURRENT_PACKAGE_TGZ: "/tmp/candidate.tgz" });
     const started: string[] = [];
     let active = 0;

--- a/extensions/reef/src/friends.test.ts
+++ b/extensions/reef/src/friends.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { createDeferred as deferred } from "openclaw/plugin-sdk/extension-shared";
 import type { OpenKeyedStoreOptions } from "openclaw/plugin-sdk/plugin-state-runtime";
 import {
   createPluginStateSyncKeyedStoreForTests,
@@ -17,16 +18,6 @@ import { openReefTrustStore } from "./trust-store.js";
 import type { RelayFriend } from "./types.js";
 
 let stateDir: string;
-
-function deferred<T>() {
-  let resolve!: (value: T) => void;
-  let reject!: (reason: unknown) => void;
-  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
-    resolve = resolvePromise;
-    reject = rejectPromise;
-  });
-  return { promise, resolve, reject };
-}
 
 function relayFriend(
   peer: string,

--- a/extensions/slack/src/monitor/context.test.ts
+++ b/extensions/slack/src/monitor/context.test.ts
@@ -1,6 +1,7 @@
 // Slack tests cover context plugin behavior.
 import type { App } from "@slack/bolt";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { createDeferred as deferred } from "openclaw/plugin-sdk/extension-shared";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { setSlackRuntime } from "../runtime.js";
@@ -18,14 +19,6 @@ vi.mock("./media.runtime.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("./media.runtime.js")>()),
   saveRemoteMedia: saveRemoteMediaMock,
 }));
-
-function deferred<T>() {
-  let resolve!: (value: T) => void;
-  const promise = new Promise<T>((resolvePromise) => {
-    resolve = resolvePromise;
-  });
-  return { promise, resolve };
-}
 
 function createTestContext(params?: {
   dmScope?: "main" | "per-peer" | "per-channel-peer" | "per-account-channel-peer";

--- a/extensions/slack/src/monitor/relay-source.test.ts
+++ b/extensions/slack/src/monitor/relay-source.test.ts
@@ -5,6 +5,7 @@ import net, { type AddressInfo } from "node:net";
 import path from "node:path";
 import type { Duplex } from "node:stream";
 import tls from "node:tls";
+import { createDeferred as deferred } from "openclaw/plugin-sdk/extension-shared";
 import { useAutoCleanupTempDirTracker } from "openclaw/plugin-sdk/test-env";
 import { rawDataToString } from "openclaw/plugin-sdk/webhook-ingress";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -18,16 +19,6 @@ import {
   SLACK_RELAY_MAX_PAYLOAD_BYTES,
   type SlackRelayIdentity,
 } from "./relay-source.js";
-
-function deferred<T>() {
-  let resolve!: (value: T) => void;
-  let reject!: (reason?: unknown) => void;
-  const promise = new Promise<T>((nextResolve, nextReject) => {
-    resolve = nextResolve;
-    reject = nextReject;
-  });
-  return { promise, reject, resolve };
-}
 
 function relayFrame(text: string): Buffer {
   return Buffer.from(text, "utf8");

--- a/extensions/telegram/src/account-throttler.test.ts
+++ b/extensions/telegram/src/account-throttler.test.ts
@@ -1,6 +1,7 @@
 // Telegram tests cover account throttler plugin behavior.
 import { createRequire } from "node:module";
 import { Api } from "grammy";
+import { createDeferred as deferred } from "openclaw/plugin-sdk/extension-shared";
 import { assert, beforeEach, describe, expect, it, vi } from "vitest";
 import { getOrCreateAccountThrottler } from "./account-throttler.js";
 import { asTelegramClientFetch } from "./client-fetch.js";
@@ -30,14 +31,6 @@ function callLooseSendMessage(
     signal: undefined,
   ) => ReturnType<TelegramTransform>;
   return loose(prev, "sendMessage", payload, undefined);
-}
-
-function deferred<T>() {
-  let resolve: (value: T) => void;
-  const promise = new Promise<T>((innerResolve) => {
-    resolve = innerResolve;
-  });
-  return { promise, resolve: resolve! };
 }
 
 describe("getOrCreateAccountThrottler", () => {

--- a/extensions/telegram/src/bot-native-command-menu-sync.test.ts
+++ b/extensions/telegram/src/bot-native-command-menu-sync.test.ts
@@ -1,4 +1,5 @@
 // Telegram tests cover native command menu remote synchronization.
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import type { PluginStateKeyedStore } from "openclaw/plugin-sdk/plugin-state-runtime";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { syncTelegramMenuCommands } from "./bot-native-command-menu.js";
@@ -14,14 +15,6 @@ function waitForTelegramMenuTurn() {
   return new Promise<void>((resolve) => {
     setTimeout(resolve, 0);
   });
-}
-
-function createDeferred() {
-  let resolve!: () => void;
-  const promise = new Promise<void>((done) => {
-    resolve = done;
-  });
-  return { promise, resolve };
 }
 
 const ledgerRows = new Map<string, unknown>();
@@ -736,7 +729,7 @@ describe("bot-native-command-menu sync lifecycle", () => {
   });
 
   it("queues a later generation until the current remote-owner lane completes", async () => {
-    const gate = createDeferred();
+    const gate = createDeferred<void>();
     const events: string[] = [];
     let active = 0;
     let maxActive = 0;

--- a/extensions/telegram/src/bot-update-tracker.test.ts
+++ b/extensions/telegram/src/bot-update-tracker.test.ts
@@ -1,4 +1,5 @@
 // Telegram tests cover bot update tracker plugin behavior.
+import { createDeferred as deferred } from "openclaw/plugin-sdk/extension-shared";
 import { describe, expect, it, vi } from "vitest";
 import { createTelegramUpdateTracker } from "./bot-update-tracker.js";
 import type { TelegramUpdateKeyContext } from "./bot-updates.js";
@@ -17,17 +18,6 @@ const updateCtx = (updateId: number): TelegramUpdateKeyContext => ({
 async function flushTrackerMicrotasks() {
   await Promise.resolve();
   await Promise.resolve();
-}
-
-function deferred() {
-  let resolve: (() => void) | undefined;
-  const promise = new Promise<void>((resolvePromise) => {
-    resolve = resolvePromise;
-  });
-  if (!resolve) {
-    throw new Error("Expected tracker deferred resolver to be initialized");
-  }
-  return { promise, resolve };
 }
 
 function expectTrackerState(
@@ -363,8 +353,8 @@ describe("createTelegramUpdateTracker", () => {
   });
 
   it("serializes and coalesces accepted offset persistence", async () => {
-    const firstWrite = deferred();
-    const secondWrite = deferred();
+    const firstWrite = deferred<void>();
+    const secondWrite = deferred<void>();
     const writes: number[] = [];
     const onAcceptedUpdateId = vi.fn((updateId: number) => {
       writes.push(updateId);

--- a/extensions/telegram/src/update-offset-persistence.test.ts
+++ b/extensions/telegram/src/update-offset-persistence.test.ts
@@ -1,16 +1,7 @@
 // Telegram tests cover monotonic update-offset persistence and retry.
+import { createDeferred as deferred } from "openclaw/plugin-sdk/extension-shared";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createTelegramUpdateOffsetPersistence } from "./update-offset-persistence.js";
-
-function deferred<T = void>() {
-  let resolve!: (value: T | PromiseLike<T>) => void;
-  let reject!: (error?: unknown) => void;
-  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
-    resolve = resolvePromise;
-    reject = rejectPromise;
-  });
-  return { promise, reject, resolve };
-}
 
 async function flushMicrotasks() {
   await Promise.resolve();
@@ -59,7 +50,7 @@ describe("createTelegramUpdateOffsetPersistence", () => {
   });
 
   it("never regresses when a lower update arrives during a higher write", async () => {
-    const write = deferred();
+    const write = deferred<void>();
     const writes: number[] = [];
     const persistence = createTelegramUpdateOffsetPersistence({
       initialUpdateId: 100,
@@ -83,7 +74,7 @@ describe("createTelegramUpdateOffsetPersistence", () => {
   });
 
   it("restarts the drain when a higher update arrives during teardown", async () => {
-    const firstWrite = deferred();
+    const firstWrite = deferred<void>();
     const writes: number[] = [];
     const persistence = createTelegramUpdateOffsetPersistence({
       initialUpdateId: 100,
@@ -109,7 +100,7 @@ describe("createTelegramUpdateOffsetPersistence", () => {
   });
 
   it("fences an in-flight write before stop resolves", async () => {
-    const write = deferred();
+    const write = deferred<void>();
     const persistence = createTelegramUpdateOffsetPersistence({
       initialUpdateId: 100,
       writeUpdateId: async () => await write.promise,

--- a/extensions/tlon/src/monitor/ingress.test.ts
+++ b/extensions/tlon/src/monitor/ingress.test.ts
@@ -6,6 +6,7 @@ import {
   closeOpenClawStateDatabaseForTest,
   createChannelIngressQueueForTests,
 } from "openclaw/plugin-sdk/channel-ingress-test-runtime";
+import { createDeferred as deferred } from "openclaw/plugin-sdk/extension-shared";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { UrbitHttpError } from "../urbit/errors.js";
 import { createTlonIngressMonitor } from "./ingress.js";
@@ -107,14 +108,6 @@ function startMonitor(queue: TlonIngressQueue, dispatch: TlonIngressDispatch) {
   });
   monitor.start();
   return monitor;
-}
-
-function deferred() {
-  let resolve = () => {};
-  const promise = new Promise<void>((done) => {
-    resolve = done;
-  });
-  return { promise, resolve };
 }
 
 afterEach(() => {
@@ -331,8 +324,8 @@ describe("Tlon durable ingress", () => {
 
   it("waits for admitted work and leaves it pending on repeated stop", async () => {
     await withQueue(async (queue) => {
-      const stored = deferred();
-      const release = deferred();
+      const stored = deferred<void>();
+      const release = deferred<void>();
       const enqueue = queue.enqueue.bind(queue);
       queue.enqueue = async (...args) => {
         const result = await enqueue(...args);

--- a/extensions/workboard/src/lifecycle-sync.restart.test.ts
+++ b/extensions/workboard/src/lifecycle-sync.restart.test.ts
@@ -1,18 +1,9 @@
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { describe, expect, it, vi } from "vitest";
 import { dispatchAndStartWorkboardCards } from "./dispatcher.js";
 import { createWorkboardLifecycleService, syncWorkboardSubagentEnded } from "./lifecycle-sync.js";
 import { WorkboardStore } from "./store.js";
 import { createWorkboardSqliteTestHarness, sqliteTestAuxStores } from "./test/sqlite-store.js";
-
-function createDeferred<T>() {
-  let resolve!: (value: T) => void;
-  let reject!: (reason?: unknown) => void;
-  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
-    resolve = resolvePromise;
-    reject = rejectPromise;
-  });
-  return { promise, resolve, reject };
-}
 
 async function beginPreparedDispatch() {
   const { store: dispatchStore, stores } = createWorkboardSqliteTestHarness();

--- a/src/agents/agent-tools.runtime.test.ts
+++ b/src/agents/agent-tools.runtime.test.ts
@@ -1,6 +1,7 @@
 // Coverage for agent tool runtime execution and scoped authority.
 import { expectDefined } from "@openclaw/normalization-core";
 import { describe, expect, it, vi } from "vitest";
+import { createDeferred as deferred } from "../../test/helpers/promise.js";
 import "./test-helpers/fast-coding-tools.js";
 import "./test-helpers/fast-openclaw-tools.js";
 import { wrapToolWithAbortSignal } from "./agent-tools.abort.js";
@@ -513,22 +514,6 @@ function ringZeroTool(name: string) {
   };
 }
 
-function deferred() {
-  let resolve!: () => void;
-  const promise = new Promise<void>((resolvePromise) => {
-    resolve = resolvePromise;
-  });
-  return { promise, resolve };
-}
-
-function deferredValue<T>() {
-  let resolve!: (value: T) => void;
-  const promise = new Promise<T>((resolvePromise) => {
-    resolve = resolvePromise;
-  });
-  return { promise, resolve };
-}
-
 describe("agent ring-zero tool context", () => {
   it("isolates concurrent async runs and clears the scope after settlement", async () => {
     const firstTool = ringZeroTool("first-ring-zero");
@@ -577,7 +562,7 @@ describe("agent ring-zero tool context", () => {
 
   it("revokes authority from detached callbacks after the run settles", async () => {
     const tool = ringZeroTool("ring-zero");
-    const detachedResult = deferredValue<readonly { name: string }[]>();
+    const detachedResult = deferred<readonly { name: string }[]>();
 
     await runWithAgentRingZeroTools([tool], async () => {
       expect(getActiveAgentRingZeroTools().map((activeTool) => activeTool.name)).toEqual([

--- a/src/agents/embedded-agent-runner.guard.test.ts
+++ b/src/agents/embedded-agent-runner.guard.test.ts
@@ -11,6 +11,7 @@ import {
 } from "openclaw/plugin-sdk/hook-runtime";
 import { createMockPluginRegistry } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferred as deferred } from "../../test/helpers/promise.js";
 import { createFileBackedSessionManagerForTest } from "../../test/helpers/session-manager-file-fixture.js";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { makeUserMessage } from "../../test/helpers/user-message.js";
@@ -577,26 +578,13 @@ function toolResult(id: string, text: string): AgentMessage {
   } as AgentMessage;
 }
 
-function deferred<T>() {
-  // Tests control when waitForIdle resolves so real tool results can race the
-  // synthetic flush path deterministically.
-  let resolve: ((value: T | PromiseLike<T>) => void) | undefined;
-  const promise = new Promise<T>((r) => {
-    resolve = r;
-  });
-  if (!resolve) {
-    throw new Error("Expected wait-for-idle deferred resolver to be initialized");
-  }
-  return { promise, resolve };
-}
-
 describe("flushPendingToolResultsAfterIdle", () => {
   it("waits for idle so real tool results can land before flush", async () => {
     // Waiting gives the tool runner a chance to persist its real output before
     // the guard synthesizes a missing result.
     const sm = guardSessionManager(SessionManager.inMemory());
     const appendMessage = sm.appendMessage.bind(sm) as unknown as (message: AgentMessage) => void;
-    const idle = deferred<void>();
+    const idle = deferred();
     const agent = { waitForIdle: () => idle.promise };
 
     appendMessage(idleToolCall("call_retry_1"));
@@ -688,7 +676,7 @@ describe("flushPendingToolResultsAfterIdle", () => {
   it("clamps oversized idle wait timeouts before scheduling", async () => {
     // JavaScript timers overflow above the platform max; clamp to keep huge
     // configs from firing immediately.
-    const idle = deferred<void>();
+    const idle = deferred();
     const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
     try {
       const flushPromise = flushPendingToolResultsAfterIdle({
@@ -709,7 +697,7 @@ describe("flushPendingToolResultsAfterIdle", () => {
     // Non-positive timeouts are an explicit "do not wait" policy.
     const sm = guardSessionManager(SessionManager.inMemory());
     const appendMessage = sm.appendMessage.bind(sm) as unknown as (message: AgentMessage) => void;
-    const idle = deferred<void>();
+    const idle = deferred();
     const waitForIdleSpy = vi.fn(() => idle.promise);
     const agent = { waitForIdle: waitForIdleSpy };
 

--- a/src/agents/embedded-agent-runner/run/attempt-session-settle.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-session-settle.test.ts
@@ -1,15 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
+import { createDeferred as deferred } from "../../../../test/helpers/promise.js";
 import { createAgentCleanupScope } from "../../run-cleanup-timeout.js";
 import type { AgentSession } from "../../sessions/index.js";
 import { createEmbeddedAttemptSessionSettleTracker } from "./attempt-session-settle.js";
-
-function deferred(): { promise: Promise<void>; resolve: () => void } {
-  let resolve!: () => void;
-  const promise = new Promise<void>((done) => {
-    resolve = done;
-  });
-  return { promise, resolve };
-}
 
 describe("createEmbeddedAttemptSessionSettleTracker", () => {
   it("preserves a teardown failure raised outside the caller async context", async () => {

--- a/src/cli/plugins-cli.registry.test.ts
+++ b/src/cli/plugins-cli.registry.test.ts
@@ -1,17 +1,10 @@
 import { beforeEach, describe, expect, it } from "vitest";
+import { createDeferred as deferred } from "../../test/helpers/promise.js";
 import {
   refreshPluginRegistryMock,
   resetPluginsCliTestState,
   runPluginsCommand,
 } from "./plugins-cli-test-helpers.js";
-
-function deferred(): { promise: Promise<void>; resolve: () => void } {
-  let resolve!: () => void;
-  const promise = new Promise<void>((resolvePromise) => {
-    resolve = resolvePromise;
-  });
-  return { promise, resolve };
-}
 
 describe("plugins registry refresh", () => {
   beforeEach(() => {

--- a/src/config/io.write-lock.test.ts
+++ b/src/config/io.write-lock.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 import { afterEach, describe, expect, it } from "vitest";
+import { createDeferred as deferred } from "../../test/helpers/promise.js";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import {
   releaseUpdateCommandPreflightForHandoff,
@@ -30,14 +31,6 @@ const tempDirs = useAutoCleanupTempDirTracker((cleanup) => {
     cleanup();
   });
 });
-
-function deferred() {
-  let resolve!: () => void;
-  const promise = new Promise<void>((done) => {
-    resolve = done;
-  });
-  return { promise, resolve };
-}
 
 async function withConfigExecutor(
   home: string,

--- a/src/gateway/github-oauth-lifecycle.test.ts
+++ b/src/gateway/github-oauth-lifecycle.test.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import { isDeepStrictEqual } from "node:util";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ToolsGitHubStatusResult } from "../../packages/gateway-protocol/src/index.js";
+import { createDeferred as deferred } from "../../test/helpers/promise.js";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import {
   inspectGitHubOAuthRecord,
@@ -115,16 +116,6 @@ let stateDir: string;
 let installedTokens: string[];
 let refreshedTokens: string[];
 let lifecycleInstances: GitHubOAuthLifecycle[];
-
-function deferred<T>() {
-  let resolve!: (value: T) => void;
-  let reject!: (error: unknown) => void;
-  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
-    resolve = resolvePromise;
-    reject = rejectPromise;
-  });
-  return { promise, resolve, reject };
-}
 
 function identity(profileId: string, options: { oauth?: boolean; author?: boolean } = {}) {
   return {
@@ -535,8 +526,8 @@ describe("GitHub OAuth authorization lifecycle", () => {
     async (race) => {
       const lifecycle = createLifecycle();
       const started = await startAuthorization(lifecycle, "system");
-      const installStarted = deferred<void>();
-      const continueInstall = deferred<void>();
+      const installStarted = deferred();
+      const continueInstall = deferred();
       mocks.pollDeviceToken.mockResolvedValue({ status: "authorized", tokens: TOKENS });
       mocks.installProfile.mockImplementationOnce(async ({ token, commitConfig }) => {
         installedTokens.push(token);
@@ -566,8 +557,8 @@ describe("GitHub OAuth authorization lifecycle", () => {
   it("reports cancellation as too late once the config commit starts", async () => {
     const lifecycle = createLifecycle();
     const started = await startAuthorization(lifecycle, "system");
-    const commitStarted = deferred<void>();
-    const continueCommit = deferred<void>();
+    const commitStarted = deferred();
+    const continueCommit = deferred();
     mocks.pollDeviceToken.mockResolvedValue({ status: "authorized", tokens: TOKENS });
     mocks.updateConfig.mockImplementationOnce(async (params) => {
       commitStarted.resolve();

--- a/src/gateway/server-http.mcp-app-admission.test.ts
+++ b/src/gateway/server-http.mcp-app-admission.test.ts
@@ -1,6 +1,7 @@
 // Proves standalone MCP App HTTP work participates in Gateway suspension admission.
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred as deferred } from "../../test/helpers/promise.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   getActiveGatewayRootWorkCount,
@@ -26,14 +27,6 @@ import {
 } from "./server-http.test-harness.js";
 
 const MCP_APP_PATH = "/__openclaw__/mcp-app";
-
-function deferred() {
-  let resolve = () => {};
-  const promise = new Promise<void>((done) => {
-    resolve = done;
-  });
-  return { promise, resolve };
-}
 
 function mcpAppsConfig(): OpenClawConfig {
   return {

--- a/src/gateway/server-methods.suspension-admission.test.ts
+++ b/src/gateway/server-methods.suspension-admission.test.ts
@@ -1,5 +1,6 @@
 // Proves dispatcher root-work accounting and fail-closed suspension behavior.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred as deferred } from "../../test/helpers/promise.js";
 import { createGatewayHostLifecycle } from "../cli/gateway-cli/host-lifecycle.js";
 import {
   consumeGatewaySuspendHandoff,
@@ -22,14 +23,6 @@ import { suspendHandlers } from "./server-methods/suspend.js";
 import type { GatewayRequestHandler } from "./server-methods/types.js";
 import { TerminalSessionManager } from "./terminal/session-manager.js";
 import { baseOpenRequest, makeFakePty } from "./terminal/session-manager.test-helpers.js";
-
-function deferred() {
-  let resolve = () => {};
-  const promise = new Promise<void>((done) => {
-    resolve = done;
-  });
-  return { promise, resolve };
-}
 
 function dispatch(params: {
   method: string;

--- a/src/gateway/server-methods.suspension-continuations.test.ts
+++ b/src/gateway/server-methods.suspension-continuations.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { GATEWAY_CLIENT_IDS } from "../../packages/gateway-protocol/src/client-info.js";
+import { createDeferred as deferred } from "../../test/helpers/promise.js";
 import { NODE_WORKER_ENVIRONMENT_STOP_COMMAND } from "../infra/node-commands.js";
 import { NODE_WORKER_SUPERVISOR_PROTOCOL_FEATURE } from "../infra/node-runner-inventory.js";
 import {
@@ -49,14 +50,6 @@ function closeAdmission(mode: (typeof completionDrainModes)[number] | "direct cl
   const suspension = tryBeginGatewaySuspendAdmission(() => {});
   expect(suspension?.drain()).toBe(true);
   return suspension;
-}
-
-function deferred<T = void>() {
-  let resolve!: (value: T) => void;
-  const promise = new Promise<T>((done) => {
-    resolve = done;
-  });
-  return { promise, resolve };
 }
 
 function createClient(role: "operator" | "node", connId = "conn-live"): GatewayWsClient {

--- a/src/gateway/server-methods/session-catalog-list-admission.test.ts
+++ b/src/gateway/server-methods/session-catalog-list-admission.test.ts
@@ -1,15 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
+import { createDeferred as deferred } from "../../../test/helpers/promise.js";
 import { SessionCatalogListAdmission } from "./session-catalog-list-admission.js";
-
-function deferred<T>() {
-  let resolve!: (value: T) => void;
-  let reject!: (reason: unknown) => void;
-  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
-    resolve = resolvePromise;
-    reject = rejectPromise;
-  });
-  return { promise, reject, resolve };
-}
 
 describe("SessionCatalogListAdmission", () => {
   it("starts at most the configured number of provider lists", async () => {
@@ -31,7 +22,7 @@ describe("SessionCatalogListAdmission", () => {
 
   it("releases a slot after rejection and preserves FIFO order", async () => {
     const admission = new SessionCatalogListAdmission(1, 2);
-    const active = deferred<void>();
+    const active = deferred();
     const order: string[] = [];
     const first = admission.run(() => active.promise);
     const second = admission.run(async () => {
@@ -51,7 +42,7 @@ describe("SessionCatalogListAdmission", () => {
 
   it("rejects overflow without starting the provider", async () => {
     const admission = new SessionCatalogListAdmission(1, 1);
-    const active = deferred<void>();
+    const active = deferred();
     const first = admission.run(() => active.promise);
     const queued = admission.run(async () => undefined);
     const overflowTask = vi.fn(async () => undefined);

--- a/src/gateway/server/hooks.terminal-target.test.ts
+++ b/src/gateway/server/hooks.terminal-target.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { resolveSystemEventOwnerAgentId } from "../../infra/system-event-ownership.js";
 import { resetGatewayWorkAdmission } from "../../process/gateway-work-admission.js";
@@ -71,14 +72,6 @@ function globalConfig(defaultAgentId: "main" | "work", includeMain = true): Open
     },
     session: { scope: "global" },
   };
-}
-
-function createDeferred() {
-  let resolve!: () => void;
-  const promise = new Promise<void>((innerResolve) => {
-    resolve = innerResolve;
-  });
-  return { promise, resolve };
 }
 
 function dispatch(value: HookPayload): Promise<unknown> {

--- a/src/gateway/server/plugins-http.suspension-admission.test.ts
+++ b/src/gateway/server/plugins-http.suspension-admission.test.ts
@@ -2,6 +2,7 @@
 import type { IncomingMessage } from "node:http";
 import type { Duplex } from "node:stream";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred as deferred } from "../../../test/helpers/promise.js";
 import type { GatewayActiveWorkInspectors } from "../../infra/gateway-active-work.js";
 import {
   prepareGatewaySuspend,
@@ -25,14 +26,6 @@ import {
 
 const ROUTE_PATH = "/plugin/suspension-proof";
 let rateLimitEpochMs = Date.now();
-
-function deferred() {
-  let resolve = () => {};
-  const promise = new Promise<void>((done) => {
-    resolve = done;
-  });
-  return { promise, resolve };
-}
 
 function createRoute(
   params: Partial<PluginHttpRouteRegistration> & Pick<PluginHttpRouteRegistration, "handler">,

--- a/src/gateway/session-companion.test.ts
+++ b/src/gateway/session-companion.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferred as deferred } from "../../test/helpers/promise.js";
 import {
   createAgentToAgentPolicy,
   resolveSessionToolAccess,
@@ -15,14 +16,6 @@ import { trimSessionCompanionExchanges } from "./session-companion-state.js";
 import { createSessionCompanion } from "./session-companion.js";
 import type { SessionObserverCompanionSnapshot } from "./session-observer-contract.js";
 import { notifyGatewaySessionReset } from "./session-reset-notifications.js";
-
-function deferred<T>() {
-  let resolve!: (value: T) => void;
-  const promise = new Promise<T>((res) => {
-    resolve = res;
-  });
-  return { promise, resolve };
-}
 
 function createHarness(overrides?: {
   now?: () => number;

--- a/src/gateway/talk-client-gateway-control.agent-consult.test.ts
+++ b/src/gateway/talk-client-gateway-control.agent-consult.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred as deferred } from "../../test/helpers/promise.js";
 import type { OperationalRunInstanceRef } from "../agents/admitted-run-context.js";
 import {
   clearActiveEmbeddedRun,
@@ -24,14 +25,6 @@ import {
 type ConsultParams = Parameters<
   typeof import("../talk/agent-consult-runtime.js").consultRealtimeVoiceAgent
 >[0];
-
-function deferred<T>() {
-  let resolve!: (value: T) => void;
-  const promise = new Promise<T>((done) => {
-    resolve = done;
-  });
-  return { promise, resolve };
-}
 
 const mocks = vi.hoisted(() => ({
   close: vi.fn(),
@@ -221,7 +214,7 @@ describe("Talk client agent consult admission", () => {
   it.each(["runOwnedArgs", "runPrompt"] as const)(
     "steers and claims only the exact registered consult owner through %s",
     async (entrypoint) => {
-      const core = deferred<void>();
+      const core = deferred();
       const chatAbortControllers = new Map();
       const isRunCurrent = vi.fn(() => true);
       const operationalRunInstance = {
@@ -302,9 +295,9 @@ describe("Talk client agent consult admission", () => {
   );
 
   it("waits for backend publication and projects its registered caller authority", async () => {
-    const announced = deferred<void>();
-    const publish = deferred<void>();
-    const finish = deferred<void>();
+    const announced = deferred();
+    const publish = deferred();
+    const finish = deferred();
     const chatAbortControllers = new Map();
     const client = sharingPolicyClient({
       deviceId: "caller-device",
@@ -391,8 +384,8 @@ describe("Talk client agent consult admission", () => {
   });
 
   it("refreshes steering authority when the admitted run publishes a new attempt", async () => {
-    const secondPublished = deferred<void>();
-    const finish = deferred<void>();
+    const secondPublished = deferred();
+    const finish = deferred();
     const chatAbortControllers = new Map();
     const firstHandle = createEmbeddedRunHandle({ runId: "run-talk" });
     const secondHandle = createEmbeddedRunHandle({ runId: "run-talk" });
@@ -496,8 +489,8 @@ describe("Talk client agent consult admission", () => {
   });
 
   it("rejects steering when a replacement reuses the run id from another admission", async () => {
-    const secondPublished = deferred<void>();
-    const finish = deferred<void>();
+    const secondPublished = deferred();
+    const finish = deferred();
     const outbound = vi.fn();
     const admittedRun = { instanceId: "instance:owner", runId: "run-talk" };
     const replacementRun = { instanceId: "instance:replacement", runId: "run-talk" };
@@ -575,10 +568,10 @@ describe("Talk client agent consult admission", () => {
   });
 
   it("does not let a stale runtime bind a replacement owner before admission", async () => {
-    const firstAnnounced = deferred<void>();
-    const secondAnnounced = deferred<void>();
-    const releaseFirst = deferred<void>();
-    const releaseSecond = deferred<void>();
+    const firstAnnounced = deferred();
+    const secondAnnounced = deferred();
+    const releaseFirst = deferred();
+    const releaseSecond = deferred();
     const staleRun = { instanceId: "instance:stale", runId: "run-talk" };
     const currentRun = { instanceId: "instance:current", runId: "run-talk" };
     let invocation = 0;
@@ -639,10 +632,10 @@ describe("Talk client agent consult admission", () => {
   });
 
   it("rejects a stale owner before it can announce over its replacement", async () => {
-    const firstWaiting = deferred<void>();
-    const releaseFirst = deferred<void>();
-    const secondPublished = deferred<void>();
-    const finishSecond = deferred<void>();
+    const firstWaiting = deferred();
+    const releaseFirst = deferred();
+    const secondPublished = deferred();
+    const finishSecond = deferred();
     const chatAbortControllers = new Map();
     const registerRun = vi.fn();
     const currentRun = { instanceId: "instance:current-owner", runId: "run-talk" };
@@ -737,10 +730,10 @@ describe("Talk client agent consult admission", () => {
   });
 
   it("does not let a stale runner revoke a replacement completion claim", async () => {
-    const staleWaiting = deferred<void>();
-    const releaseStale = deferred<void>();
-    const currentStarted = deferred<void>();
-    const finishCurrent = deferred<void>();
+    const staleWaiting = deferred();
+    const releaseStale = deferred();
+    const currentStarted = deferred();
+    const finishCurrent = deferred();
     let invocation = 0;
     mocks.consultRealtimeVoiceAgent.mockImplementation(async (params: ConsultParams) => {
       const currentInvocation = (invocation += 1);
@@ -802,8 +795,8 @@ describe("Talk client agent consult admission", () => {
   });
 
   it("installs steering ownership before readiness and delays backend admission", async () => {
-    const ready = deferred<void>();
-    const finish = deferred<void>();
+    const ready = deferred();
+    const finish = deferred();
     const chatAbortControllers = new Map();
     const handle = createEmbeddedRunHandle({ runId: "run-talk" });
     const operationalRunInstance = {

--- a/src/gateway/talk-realtime-relay-voice.test.ts
+++ b/src/gateway/talk-realtime-relay-voice.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred as deferred } from "../../test/helpers/promise.js";
 import { createClientVoiceConfirmationReadiness } from "../talk/client-voice-confirmation-readiness.js";
 import { VOICE_TRANSCRIPT_QUEUE_POLICY } from "../talk/voice-transcript.js";
 import type { RelaySession } from "./talk-realtime-relay-state.js";
@@ -14,14 +15,6 @@ const voiceSessionMocks = vi.hoisted(() => ({
 }));
 
 vi.mock("../talk/client-voice-session.js", () => voiceSessionMocks);
-
-function deferred(): { promise: Promise<void>; resolve: () => void } {
-  let resolve!: () => void;
-  const promise = new Promise<void>((accept) => {
-    resolve = accept;
-  });
-  return { promise, resolve };
-}
 
 function createRelaySession(): {
   session: RelaySession;

--- a/src/gateway/test/talk-client-agent-consult.requester-final.test.ts
+++ b/src/gateway/test/talk-client-agent-consult.requester-final.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred as deferred } from "../../../test/helpers/promise.js";
 import type { OperationalRunInstanceRef } from "../../agents/admitted-run-context.js";
 import {
   clearActiveEmbeddedRun,
@@ -19,14 +20,6 @@ import type { PluginRuntime } from "../../plugins/runtime/types.js";
 type ConsultParams = Parameters<
   typeof import("../../talk/agent-consult-runtime.js").consultRealtimeVoiceAgent
 >[0];
-
-function deferred<T>() {
-  let resolve!: (value: T) => void;
-  const promise = new Promise<T>((done) => {
-    resolve = done;
-  });
-  return { promise, resolve };
-}
 
 const mocks = vi.hoisted(() => ({
   close: vi.fn(),

--- a/src/gateway/worker-environments/desktop-tunnel.test.ts
+++ b/src/gateway/worker-environments/desktop-tunnel.test.ts
@@ -2,6 +2,7 @@ import { access, mkdir, mkdtemp, rm, stat } from "node:fs/promises";
 import path from "node:path";
 import { setImmediate } from "node:timers/promises";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
 import type { WorkerDesktopEndpoint, WorkerSshEndpoint } from "../../plugins/types.js";
 import type { CommandOptions, SpawnResult } from "../../process/exec.js";
 import { createWorkerDesktopTunnels } from "./desktop-tunnel.js";
@@ -22,12 +23,7 @@ const DESKTOP: WorkerDesktopEndpoint = {
 const resolveIdentity = async () => ({ kind: "path", path: "/keys/worker" }) as const;
 
 function deferred<T>() {
-  let resolve!: (value: T) => void;
-  let reject!: (error: Error) => void;
-  const promise = new Promise<T>((promiseResolve, promiseReject) => {
-    resolve = promiseResolve;
-    reject = promiseReject;
-  });
+  const { promise, resolve, reject } = createDeferred<T>();
   void promise.catch(() => undefined);
   return { promise, resolve, reject };
 }

--- a/src/gateway/worker-environments/node-desktop-carrier.test.ts
+++ b/src/gateway/worker-environments/node-desktop-carrier.test.ts
@@ -1,6 +1,7 @@
 import { PassThrough } from "node:stream";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { GATEWAY_CLIENT_IDS } from "../../../packages/gateway-protocol/src/client-info.js";
+import { createDeferred } from "../../../test/helpers/promise.js";
 import { NODE_WORKER_SUPERVISOR_PROTOCOL_FEATURE } from "../../infra/node-runner-inventory.js";
 import type { NodeDesktopStreamBroker } from "../desktop/node-stream-broker.js";
 import * as observeBridge from "../desktop/observe-bridge.js";
@@ -14,12 +15,7 @@ import * as support from "./service.test-support.js";
 import type { WorkerEnvironmentRecord } from "./store.js";
 
 function deferred<T>() {
-  let resolve!: (value: T) => void;
-  let reject!: (error: Error) => void;
-  const promise = new Promise<T>((promiseResolve, promiseReject) => {
-    resolve = promiseResolve;
-    reject = promiseReject;
-  });
+  const { promise, resolve, reject } = createDeferred<T>();
   void promise.catch(() => undefined);
   return { promise, reject, resolve };
 }

--- a/src/gateway/worker-environments/tunnel.test-support.ts
+++ b/src/gateway/worker-environments/tunnel.test-support.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { expect, vi } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
 import type { WorkerSshEndpoint } from "../../plugins/types.js";
 import {
   runCommandWithTimeout,
@@ -165,12 +166,7 @@ export function workspaceSetup(
 }
 
 export function deferred<T>() {
-  let resolve!: (value: T) => void;
-  let reject!: (error: Error) => void;
-  const promise = new Promise<T>((promiseResolve, promiseReject) => {
-    resolve = promiseResolve;
-    reject = promiseReject;
-  });
+  const { promise, resolve, reject } = createDeferred<T>();
   void promise.catch(() => undefined);
   return { promise, resolve, reject };
 }

--- a/src/link-understanding/runner.transport.test.ts
+++ b/src/link-understanding/runner.transport.test.ts
@@ -2,6 +2,7 @@ import { createServer, type RequestListener } from "node:http";
 import type { AddressInfo, Socket } from "node:net";
 import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred as deferred } from "../../test/helpers/promise.js";
 import type { MsgContext } from "../auto-reply/templating.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { isPidAlive } from "../shared/pid-alive.js";
@@ -56,14 +57,6 @@ vi.mock("../process/exec.js", async () => {
     ),
   };
 });
-
-function deferred() {
-  let resolve!: () => void;
-  const promise = new Promise<void>((done) => {
-    resolve = done;
-  });
-  return { promise, resolve };
-}
 
 async function within<T>(promise: Promise<T>, timeoutMs: number, message: string): Promise<T> {
   let timer: ReturnType<typeof setTimeout> | undefined;

--- a/src/skills/lifecycle/upload-store.test.ts
+++ b/src/skills/lifecycle/upload-store.test.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import { toErrorObject as toLintErrorObject } from "@openclaw/normalization-core/error-coercion";
 import { MAX_DATE_TIMESTAMP_MS } from "@openclaw/normalization-core/number-coercion";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { createDeferred as deferred } from "../../../test/helpers/promise.js";
 import { createTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import {
   closeOpenClawStateDatabaseForTest,
@@ -104,14 +105,6 @@ function installLeaseCount(databasePath: string, uploadId: string): number {
 
 function sha256(bytes: Buffer): string {
   return createHash("sha256").update(bytes).digest("hex");
-}
-
-function deferred() {
-  let resolve!: () => void;
-  const promise = new Promise<void>((innerResolve) => {
-    resolve = innerResolve;
-  });
-  return { promise, resolve };
 }
 
 async function expectUploadError(

--- a/src/talk/client-voice-mutation-digest-owner.test.ts
+++ b/src/talk/client-voice-mutation-digest-owner.test.ts
@@ -1,19 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
+import { createDeferred as deferred } from "../../test/helpers/promise.js";
 import { ClientVoiceMutationDigestOwner } from "./client-voice-mutation-digest-owner.js";
-
-function deferred<T>(): {
-  promise: Promise<T>;
-  resolve: (value: T) => void;
-  reject: (error: Error) => void;
-} {
-  let resolve!: (value: T) => void;
-  let reject!: (error: Error) => void;
-  const promise = new Promise<T>((accept, fail) => {
-    resolve = accept;
-    reject = fail;
-  });
-  return { promise, resolve, reject };
-}
 
 async function flushMicrotasks(): Promise<void> {
   await Promise.resolve();

--- a/src/tui/embedded-backend.test.ts
+++ b/src/tui/embedded-backend.test.ts
@@ -1,6 +1,7 @@
 // Covers embedded backend behavior used by the TUI runtime.
 import fs from "node:fs/promises";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred as deferred } from "../../test/helpers/promise.js";
 import { QuestionAnswerUnconfirmedError } from "../agents/harness/gateway-question-dispatch.js";
 import {
   INTERNAL_RUNTIME_CONTEXT_BEGIN,
@@ -358,19 +359,6 @@ vi.mock("../gateway/server-methods/agent-timestamp.js", () => ({
   injectTimestamp: (message: string) => message,
   timestampOptsFromConfig: () => ({}),
 }));
-
-function deferred<T>() {
-  let resolve: ((value: T) => void) | undefined;
-  let reject: ((error?: unknown) => void) | undefined;
-  const promise = new Promise<T>((res, rej) => {
-    resolve = res;
-    reject = rej;
-  });
-  if (!resolve || !reject) {
-    throw new Error("Expected deferred callbacks to be initialized");
-  }
-  return { promise, resolve, reject };
-}
 
 async function flushMicrotasks() {
   await Promise.resolve();
@@ -1128,7 +1116,7 @@ describe("EmbeddedTuiBackend", () => {
   it("publishes the configured runtime before admitting the first local turn", async () => {
     const initialConfig = { agents: { list: [{ id: "main" }] } };
     getRuntimeConfigMock.mockReturnValue(initialConfig);
-    const publication = deferred<void>();
+    const publication = deferred();
     refreshPreparedModelRuntimeSnapshotsMock.mockReturnValueOnce(publication.promise);
 
     const backend = new EmbeddedTuiBackend();
@@ -1159,7 +1147,7 @@ describe("EmbeddedTuiBackend", () => {
     backend.start();
     await vi.waitFor(() => expect(refreshPreparedModelRuntimeSnapshotsMock).toHaveBeenCalledOnce());
 
-    const replacement = deferred<void>();
+    const replacement = deferred();
     refreshPreparedModelRuntimeSnapshotsMock.mockReturnValueOnce(replacement.promise);
     configWriteListener?.({ runtimeConfig: nextConfig });
 
@@ -1186,9 +1174,9 @@ describe("EmbeddedTuiBackend", () => {
     const middleConfig = { agents: { defaults: { model: "openai/middle" } } };
     const latestConfig = { agents: { defaults: { model: "openai/latest" } } };
     getRuntimeConfigMock.mockReturnValue(initialConfig);
-    const initial = deferred<void>();
-    const middle = deferred<void>();
-    const latest = deferred<void>();
+    const initial = deferred();
+    const middle = deferred();
+    const latest = deferred();
     refreshPreparedModelRuntimeSnapshotsMock
       .mockReturnValueOnce(initial.promise)
       .mockReturnValueOnce(middle.promise)
@@ -1240,7 +1228,7 @@ describe("EmbeddedTuiBackend", () => {
       runId: "runtime-refresh-second",
     });
 
-    const replacement = deferred<void>();
+    const replacement = deferred();
     refreshPreparedModelRuntimeSnapshotsMock.mockReturnValueOnce(replacement.promise);
     configWriteListener?.({
       runtimeConfig: { agents: { defaults: { model: "openai/next" } } },
@@ -1607,8 +1595,8 @@ describe("EmbeddedTuiBackend", () => {
   });
 
   it("waits for the newest publication before returning model choices", async () => {
-    const initial = deferred<void>();
-    const replacement = deferred<void>();
+    const initial = deferred();
+    const replacement = deferred();
     refreshPreparedModelRuntimeSnapshotsMock
       .mockReturnValueOnce(initial.promise)
       .mockReturnValueOnce(replacement.promise);
@@ -1632,7 +1620,7 @@ describe("EmbeddedTuiBackend", () => {
   });
 
   it("reports publication failure instead of returning stale model choices", async () => {
-    const publication = deferred<void>();
+    const publication = deferred();
     refreshPreparedModelRuntimeSnapshotsMock.mockReturnValueOnce(publication.promise);
     const backend = new EmbeddedTuiBackend();
     backend.start();

--- a/src/tui/tui-plugin-approvals.test.ts
+++ b/src/tui/tui-plugin-approvals.test.ts
@@ -2,6 +2,7 @@ import type { Component, OverlayHandle, SelectItem } from "@earendil-works/pi-tu
 import { expectDefined } from "@openclaw/normalization-core";
 import { describe, expect, it, vi } from "vitest";
 import { stripAnsi } from "../../packages/terminal-core/src/ansi.js";
+import { createDeferred as deferred } from "../../test/helpers/promise.js";
 import { createTuiPluginApprovalController } from "./tui-plugin-approvals.js";
 
 type TestSelector = Component & {
@@ -29,14 +30,6 @@ function approvalPayload(overrides: Record<string, unknown> = {}) {
     expiresAtMs: 6_000,
     ...overrides,
   };
-}
-
-function deferred<T>() {
-  let resolve!: (value: T) => void;
-  const promise = new Promise<T>((resolvePromise) => {
-    resolve = resolvePromise;
-  });
-  return { promise, resolve };
 }
 
 function createHarness() {

--- a/src/tui/tui-questions.test.ts
+++ b/src/tui/tui-questions.test.ts
@@ -9,6 +9,7 @@ import type {
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { GatewayClientRequestError } from "../../packages/gateway-client/src/request-error.js";
 import { stripAnsi } from "../../packages/terminal-core/src/ansi.js";
+import { createDeferred as deferred } from "../../test/helpers/promise.js";
 import { createTuiQuestionController } from "./tui-questions.js";
 
 const UP = "\x1b[A";
@@ -39,16 +40,6 @@ function questionRecord(overrides: Partial<QuestionRecord> = {}): QuestionRecord
     ],
     ...overrides,
   };
-}
-
-function deferred<T>() {
-  let resolve!: (value: T) => void;
-  let reject!: (reason: unknown) => void;
-  const promise = new Promise<T>((done, fail) => {
-    resolve = done;
-    reject = fail;
-  });
-  return { promise, resolve, reject };
 }
 
 const controllers: Array<ReturnType<typeof createTuiQuestionController>> = [];


### PR DESCRIPTION
## What Problem This Solves

Core and plugin tests repeatedly implement Promise resolver capture, including wrappers that own separate cleanup policy.

## User Impact

No production behavior changes. Resolution, rejection, cancellation, admission, and cleanup expectations remain intact.

## Why This Change Was Made

Reuse the existing core test and public plugin SDK deferred helpers. Remove 52 duplicate constructors and migrate all six callers of the retired memory-wiki helper. Six policy wrappers retain their rejection handlers, fallback values, cleanup sets, and returned keys. Removes 375 net maintained test/support code lines.

## Evidence

All 78 suites pass again on refreshed main: 1,492 tests and the same existing skip, with identical inventories. Full changed checks and 57 quota-owner tests pass. The exact patch and all 63 touched paths are unchanged; prior independent P2 review, 3,831-expectation parity, 355 generic payload types, and wrapper-policy proof remain applicable.

The branch includes the existing main repairs for the unrelated MCP cache and quota-availability CI failures. Exact-head hosted CI, including those real-Gateway flows, is checked separately before landing. No test cases, assertions, or timeouts are removed.
