### PR TITLE
fix: refresh model availability after quota recovery

### DIFF
--- a/docs/auth-credential-semantics.md
+++ b/docs/auth-credential-semantics.md
@@ -141,6 +141,10 @@ catalog discovery. Configured subscription modes remain attached to direct
 credentials, and successful OAuth preparation supplies the resolved current token
 to its catalog consumer rather than the captured store's older token.
 
+For stored profiles, cached discovery does not freeze quota and cooldown status.
+Gateway model availability reflects health updates for the same credential without
+rescanning model inventory or interrupting an in-progress turn.
+
 Environment-backed profiles keep usable values from the discovery environment,
 including cold command and worker paths. When that material is missing, only the
 selected profile's activated snapshot may supply it; otherwise discovery reports

--- a/src/agents/auth-profiles/usage-observer.test.ts
+++ b/src/agents/auth-profiles/usage-observer.test.ts
@@ -1,0 +1,244 @@
+import path from "node:path";
+import { expectDefined } from "@openclaw/normalization-core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import * as machineState from "../../state/config-machine-state.js";
+import { resolveOpenClawStateSqlitePath } from "../../state/openclaw-state-db.paths.js";
+import {
+  clearRuntimeAuthProfileStoreSnapshotAtDatabasePath,
+  clearRuntimeAuthProfileStoreSnapshots,
+  getRuntimeAuthProfileStoreSnapshotAtDatabasePath,
+  setRuntimeAuthProfileStoreSnapshotAtDatabasePath,
+} from "./runtime-snapshots.js";
+import { resolveAuthProfileDatabasePath, type AuthProfileStoreOwner } from "./sqlite.js";
+import type { AuthProfileStore, OAuthCredential, ProfileUsageStats } from "./types.js";
+import {
+  bindRuntimeAuthProfileUsageObserver,
+  captureRuntimeAuthProfileUsageObserver,
+  copyRuntimeAuthProfileUsageObserver,
+  prepareRuntimeAuthProfileUsageObserver,
+} from "./usage-observer.js";
+
+const profileId = "openai:quota";
+const env = {
+  OPENCLAW_STATE_DIR: "/fixture/usage-observer/state",
+  OPENCLAW_AGENT_DIR: "/fixture/usage-observer/shared",
+};
+const agentDir = "/fixture/usage-observer/agent";
+const inheritedAuthDir = "/fixture/usage-observer/inherited";
+const requestedPath = resolveAuthProfileDatabasePath(agentDir);
+const inheritedPath = resolveAuthProfileDatabasePath(inheritedAuthDir);
+const sharedPath = resolveOpenClawStateSqlitePath(env);
+const legacyPath = resolveAuthProfileDatabasePath(env.OPENCLAW_AGENT_DIR);
+const blocked = { blockedUntil: 50_000, blockedReason: "subscription_limit" } as const;
+
+function credential(overrides: Partial<OAuthCredential> = {}): OAuthCredential {
+  return {
+    type: "oauth",
+    provider: "openai",
+    access: "synthetic-access",
+    refresh: "synthetic-refresh",
+    expires: 100_000,
+    accountId: "synthetic-account",
+    ...overrides,
+  };
+}
+
+function store(usage?: ProfileUsageStats, auth = credential()): AuthProfileStore {
+  return {
+    version: 1,
+    profiles: { [profileId]: auth },
+    order: { openai: [profileId] },
+    ...(usage ? { usageStats: { [profileId]: usage } } : {}),
+  };
+}
+
+function publish(
+  databasePath: string,
+  value: AuthProfileStore,
+  sharedDatabasePath = sharedPath,
+  location: AuthProfileStoreOwner["location"] = "state-db",
+) {
+  setRuntimeAuthProfileStoreSnapshotAtDatabasePath(
+    value,
+    databasePath,
+    path.dirname(databasePath),
+    {
+      databasePath,
+      sharedDatabasePath,
+      location,
+    },
+  );
+}
+
+afterEach(() => {
+  clearRuntimeAuthProfileStoreSnapshots();
+  vi.restoreAllMocks();
+});
+
+describe("prepared auth usage observation", () => {
+  it.each(["state-db", "legacy-main"] as const)(
+    "adopts a later %s publication without discovering storage and carries copied bindings",
+    (location) => {
+      vi.spyOn(machineState, "readConfigMachineState").mockImplementation(() => {
+        throw new Error("Usage observation attempted persistent ownership discovery");
+      });
+      const captured = store(blocked);
+      const observer = captureRuntimeAuthProfileUsageObserver({ agentDir, env });
+      bindRuntimeAuthProfileUsageObserver(captured, observer);
+      const copied = structuredClone(captured);
+      copyRuntimeAuthProfileUsageObserver(captured, copied);
+      const initial = prepareRuntimeAuthProfileUsageObserver(copied);
+      expect(initial.authStore.usageStats?.[profileId]).toEqual(blocked);
+      expect(initial.isCurrent()).toBe(true);
+
+      const databasePath = location === "state-db" ? sharedPath : legacyPath;
+      publish(databasePath, store({ lastUsed: 7 }), databasePath, location);
+      expect(initial.isCurrent()).toBe(false);
+      const recovered = prepareRuntimeAuthProfileUsageObserver(copied);
+      expect(recovered.authStore).toEqual({
+        ...captured,
+        usageStats: { [profileId]: { lastUsed: 7 } },
+      });
+      expect(recovered.isCurrent()).toBe(true);
+
+      publish(databasePath, store({ ...blocked, blockedUntil: 80_000 }), databasePath, location);
+      expect(recovered.isCurrent()).toBe(false);
+      expect(
+        prepareRuntimeAuthProfileUsageObserver(recovered.authStore).authStore.usageStats?.[
+          profileId
+        ]?.blockedUntil,
+      ).toBe(80_000);
+      expect(machineState.readConfigMachineState).not.toHaveBeenCalled();
+    },
+  );
+
+  it("does not choose between conflicting default shared owners", () => {
+    publish(sharedPath, store(), sharedPath);
+    publish(legacyPath, store(), legacyPath, "legacy-main");
+    publish(requestedPath, store(), "/fixture/other-owner/state/openclaw.sqlite");
+    const captured = store(blocked);
+    const observe = captureRuntimeAuthProfileUsageObserver({ agentDir, env });
+    const ambiguous = observe(captured);
+    expect(ambiguous.authStore.usageStats?.[profileId]).toEqual(blocked);
+    clearRuntimeAuthProfileStoreSnapshotAtDatabasePath(legacyPath);
+    expect(ambiguous.isCurrent()).toBe(false);
+    expect(observe(captured).authStore.usageStats?.[profileId]).toBeUndefined();
+  });
+
+  it.each([
+    { name: "inherited only", local: undefined, inherited: {}, expected: {} },
+    { name: "requested block", local: blocked, inherited: {}, expected: blocked },
+    { name: "requested clear", local: {}, inherited: blocked, expected: {} },
+  ])("honors requested/inherited precedence: $name", ({ local, inherited, expected }) => {
+    publish(inheritedPath, store(inherited));
+    if (local) {
+      publish(requestedPath, store(local));
+    }
+    const observed = captureRuntimeAuthProfileUsageObserver({ agentDir, inheritedAuthDir, env })(
+      store(blocked),
+    );
+    expect(observed.authStore.usageStats?.[profileId]).toEqual(expected);
+  });
+
+  it("uses an existing explicit owner when the default shared publication is absent", () => {
+    const sharedDatabasePath = "/fixture/other-owner/state/openclaw.sqlite";
+    publish(requestedPath, store(), sharedDatabasePath);
+    const observe = captureRuntimeAuthProfileUsageObserver({ agentDir, env });
+    const captured = store(blocked);
+    const prepared = observe(captured);
+    expect(prepared.authStore.usageStats?.[profileId]).toBeUndefined();
+    expect(prepared.isCurrent()).toBe(true);
+    publish(requestedPath, store(blocked), sharedDatabasePath);
+    expect(prepared.isCurrent()).toBe(false);
+    expect(observe(captured).authStore.usageStats?.[profileId]).toEqual(blocked);
+  });
+
+  it("rejects a foreign first publication instead of falling through to inherited health", () => {
+    publish(inheritedPath, store());
+    const observe = captureRuntimeAuthProfileUsageObserver({ agentDir, inheritedAuthDir, env });
+    const captured = store(blocked);
+    const prepared = observe(captured);
+    publish(requestedPath, store(), "/fixture/other-owner/state/openclaw.sqlite");
+    expect(prepared.isCurrent()).toBe(false);
+    expect(() => observe(captured)).toThrow(/another owner/);
+  });
+
+  it.each([
+    { name: "rotated token", auth: credential({ access: "rotated-access" }) },
+    { name: "different account", auth: credential({ accountId: "other-account" }) },
+    { name: "missing profile", auth: undefined },
+  ])("retains captured health for a $name", ({ auth }) => {
+    publish(inheritedPath, store());
+    publish(requestedPath, auth ? store({}, auth) : { version: 1, profiles: {} });
+    const observe = captureRuntimeAuthProfileUsageObserver({ agentDir, inheritedAuthDir, env });
+    // A missing local row permits inheritance; use a published empty parent for that control.
+    if (!auth) {
+      publish(inheritedPath, { version: 1, profiles: {} });
+    }
+    expect(observe(store(blocked)).authStore.usageStats?.[profileId]).toEqual(blocked);
+  });
+
+  it.each(["removed", "rebound"] as const)(
+    "retires a %s publication without creating a perpetually stale replacement",
+    (change) => {
+      publish(requestedPath, store());
+      const observe = captureRuntimeAuthProfileUsageObserver({ agentDir, env });
+      const captured = store(blocked);
+      const prepared = observe(captured);
+      expect(prepared.authStore.usageStats?.[profileId]).toBeUndefined();
+      if (change === "removed") {
+        clearRuntimeAuthProfileStoreSnapshotAtDatabasePath(requestedPath);
+      } else {
+        publish(requestedPath, store(), "/fixture/other-owner/state/openclaw.sqlite");
+      }
+      expect(prepared.isCurrent()).toBe(false);
+      expect(() => observe(captured)).toThrow(/reacquire the model catalog/);
+    },
+  );
+
+  it("ignores bookkeeping changes and isolates nested mutable usage rows", () => {
+    const usage = { ...blocked, failureCounts: { rate_limit: 2 } };
+    publish(requestedPath, store(usage));
+    const captured = store(blocked);
+    const observe = captureRuntimeAuthProfileUsageObserver({ agentDir, env });
+    const prepared = observe(captured);
+    const stats = expectDefined(prepared.authStore.usageStats?.[profileId], "observed usage");
+    expectDefined(stats.failureCounts, "observed failure counts").rate_limit = 99;
+    expect(
+      getRuntimeAuthProfileStoreSnapshotAtDatabasePath(requestedPath)?.usageStats?.[profileId]
+        ?.failureCounts?.rate_limit,
+    ).toBe(2);
+    expect(observe(captured).authStore.usageStats?.[profileId]?.failureCounts?.rate_limit).toBe(2);
+    publish(requestedPath, store({ ...usage, lastUsed: 9, lastProbeAt: 10, errorCount: 3 }));
+    expect(prepared.isCurrent()).toBe(true);
+    publish(requestedPath, store({ ...usage, blockedModel: "other", blockedScope: "model" }));
+    expect(prepared.isCurrent()).toBe(false);
+  });
+
+  it("keeps unsupported identity rows and unbound stores captured-only", () => {
+    const personal =
+      "personal:00000000-0000-0000-0000-000000000001:00000000-0000-0000-0000-000000000002";
+    const captured: AuthProfileStore = {
+      ...store(blocked),
+      profiles: { [profileId]: credential(), external: credential(), [personal]: credential() },
+      runtimeExternalProfileIds: ["external"],
+      usageStats: Object.fromEntries(
+        [profileId, "external", personal, "inline-api-key:openai", "synthetic"].map((id) => [
+          id,
+          { ...blocked },
+        ]),
+      ),
+    };
+    publish(requestedPath, { ...captured, usageStats: {} });
+    const unbound = prepareRuntimeAuthProfileUsageObserver(captured);
+    expect(unbound.authStore).toBe(captured);
+    expect(unbound.authStore.usageStats).toEqual(captured.usageStats);
+    expect(unbound.isCurrent()).toBe(true);
+    const observed = captureRuntimeAuthProfileUsageObserver({ agentDir, env })(captured);
+    expect(observed.authStore.usageStats).toEqual(
+      Object.fromEntries(
+        ["external", personal, "inline-api-key:openai", "synthetic"].map((id) => [id, blocked]),
+      ),
+    );
+  });
+});

--- a/src/agents/auth-profiles/usage-observer.ts
+++ b/src/agents/auth-profiles/usage-observer.ts
@@ -1,0 +1,243 @@
+import { isDeepStrictEqual } from "node:util";
+import { resolveOpenClawStateSqlitePath } from "../../state/openclaw-state-db.paths.js";
+import { isUserModelAuthProfileId } from "../../state/user-model-account-id.js";
+import { resolveUserPath } from "../../utils.js";
+import { cloneAuthProfileStore } from "./clone.js";
+import { captureAuthProfileOwnerScope } from "./path-resolve.js";
+import { mergeAuthProfileStores } from "./persisted.js";
+import {
+  runtimeAuthProfileSnapshotSharesOwner,
+  runtimeAuthSharedOwnerRebound,
+  type OwnedRuntimeAuthProfileStoreSnapshotEntry,
+  type RuntimeAuthSharedOwner,
+} from "./runtime-snapshot-owner.js";
+import {
+  getOwnedRuntimeAuthProfileStoreSnapshotAtDatabasePath,
+  getRuntimeAuthProfileStoreSnapshotRevisionAtDatabasePath,
+} from "./runtime-snapshots.js";
+import { resolveAuthProfileDatabasePath } from "./sqlite.js";
+import type { AuthProfileStore } from "./types.js";
+import { fingerprintAuthProfileAvailabilityState } from "./usage-state.js";
+
+type UsageObservation = { authStore: AuthProfileStore; isCurrent: () => boolean };
+type UsageObserver = (store: AuthProfileStore) => UsageObservation;
+type Snapshot = OwnedRuntimeAuthProfileStoreSnapshotEntry;
+type SnapshotSlot = {
+  databasePath: string;
+  owner?: RuntimeAuthSharedOwner;
+  published: boolean;
+};
+
+const observers = new WeakMap<AuthProfileStore, UsageObserver>();
+
+/** Capture addressing before discovery yields; observer reads never resolve storage ownership. */
+export function captureRuntimeAuthProfileUsageObserver(params: {
+  agentDir: string;
+  inheritedAuthDir?: string;
+  env?: NodeJS.ProcessEnv;
+}): UsageObserver {
+  const env = params.env ?? process.env;
+  const coldOwner = { kind: "unresolved", scope: captureAuthProfileOwnerScope(env) } as const;
+  const filename = (directory: string) => {
+    if (!directory.trim()) {
+      throw new Error("An agent directory is required to observe auth usage.");
+    }
+    return resolveAuthProfileDatabasePath(resolveUserPath(directory, env));
+  };
+  const sharedCandidates = [
+    resolveOpenClawStateSqlitePath({ OPENCLAW_STATE_DIR: coldOwner.scope.stateDir }),
+    resolveAuthProfileDatabasePath(coldOwner.scope.sharedMainDir),
+  ];
+  const snapshots = new Map<string, { revision: number; snapshot: Snapshot | undefined }>();
+  const readSnapshot = (databasePath: string): Snapshot | undefined => {
+    const revision = getRuntimeAuthProfileStoreSnapshotRevisionAtDatabasePath(databasePath);
+    const previous = snapshots.get(databasePath);
+    if (previous?.revision === revision) {
+      return previous.snapshot;
+    }
+    const snapshot = getOwnedRuntimeAuthProfileStoreSnapshotAtDatabasePath(databasePath);
+    snapshots.set(databasePath, { revision, snapshot });
+    return snapshot;
+  };
+  const captureSlot = (databasePath: string): SnapshotSlot => {
+    const snapshot = readSnapshot(databasePath);
+    return { databasePath, owner: snapshot?.owner, published: snapshot !== undefined };
+  };
+  const requested = captureSlot(filename(params.agentDir));
+  let inherited = params.inheritedAuthDir
+    ? captureSlot(filename(params.inheritedAuthDir))
+    : undefined;
+  let retired: Error | undefined;
+  const readSlot = (slot: SnapshotSlot): { snapshot?: Snapshot; error?: Error } => {
+    const snapshot = readSnapshot(slot.databasePath);
+    if (!snapshot) {
+      return slot.published
+        ? {
+            error: new Error(
+              "Prepared auth usage snapshot disappeared; reacquire the model catalog.",
+            ),
+          }
+        : {};
+    }
+    if (!slot.owner) {
+      const matches =
+        snapshot.owner.kind === "resolved"
+          ? runtimeAuthProfileSnapshotSharesOwner(coldOwner, snapshot.owner)
+          : isDeepStrictEqual(coldOwner, snapshot.owner);
+      if (!matches) {
+        return {
+          error: new Error(
+            "Prepared auth usage publication has another owner; reacquire the model catalog.",
+          ),
+        };
+      }
+    } else if (
+      runtimeAuthSharedOwnerRebound(slot.owner, snapshot.owner) ||
+      (slot.owner.kind === "resolved" &&
+        snapshot.owner.kind === "resolved" &&
+        slot.owner.location !== snapshot.owner.location)
+    ) {
+      retired ??= new Error("Prepared auth usage owner changed; reacquire the model catalog.");
+      return { error: retired };
+    }
+    slot.owner = snapshot.owner;
+    slot.published = true;
+    return { snapshot };
+  };
+  const resolveInherited = (): "ambiguous" | undefined => {
+    if (inherited) {
+      return undefined;
+    }
+    const owners = new Map<string, Extract<RuntimeAuthSharedOwner, { kind: "resolved" }>>();
+    for (const databasePath of [requested.databasePath, ...sharedCandidates]) {
+      const owner = readSnapshot(databasePath)?.owner;
+      if (owner?.kind === "resolved" && runtimeAuthProfileSnapshotSharesOwner(coldOwner, owner)) {
+        owners.set(JSON.stringify([owner.sharedDatabasePath, owner.location]), owner);
+      }
+    }
+    // Cold scopes can name both storage layouts. Only a unique producer selects the default.
+    if (owners.size === 1) {
+      const owner = owners.values().next().value;
+      if (owner) {
+        inherited = { ...captureSlot(owner.sharedDatabasePath), owner };
+      }
+    }
+    return owners.size > 1 ? "ambiguous" : undefined;
+  };
+  let previousRequested: Snapshot | undefined;
+  let previousInherited: Snapshot | undefined;
+  let effective: AuthProfileStore | undefined;
+  const read = (): { store?: AuthProfileStore; error?: Error } => {
+    if (retired) {
+      return { error: retired };
+    }
+    const inheritance = resolveInherited();
+    const local = readSlot(requested);
+    const parent: ReturnType<typeof readSlot> = inherited ? readSlot(inherited) : {};
+    const error = local.error ?? parent.error;
+    if (error) {
+      return { error };
+    }
+    if (inheritance === "ambiguous") {
+      return {};
+    }
+    if (local.snapshot !== previousRequested || parent.snapshot !== previousInherited) {
+      previousRequested = local.snapshot;
+      previousInherited = parent.snapshot;
+      effective =
+        inherited &&
+        local.snapshot &&
+        parent.snapshot &&
+        requested.databasePath !== inherited.databasePath
+          ? mergeAuthProfileStores(parent.snapshot.store, local.snapshot.store, {
+              preserveBaseRuntimeExternalProfiles: true,
+            })
+          : (local.snapshot ?? parent.snapshot)?.store;
+    }
+    return { store: effective };
+  };
+  // Pin any already-published ownership before the caller starts asynchronous preparation.
+  read();
+  const observer: UsageObserver = (capturedStore) => {
+    const captured = cloneAuthProfileStore(capturedStore);
+    const profileIds = Object.keys(captured.profiles).filter(
+      (id) => !isUserModelAuthProfileId(id) && !captured.runtimeExternalProfileIds?.includes(id),
+    );
+    const usageFrom = (store: AuthProfileStore | undefined) => {
+      const usage = { ...captured.usageStats };
+      for (const id of profileIds) {
+        if (
+          !store?.profiles[id] ||
+          store.runtimeExternalProfileIds?.includes(id) ||
+          !isDeepStrictEqual(captured.profiles[id], store.profiles[id])
+        ) {
+          continue;
+        }
+        const stats = store.usageStats?.[id];
+        if (stats) {
+          usage[id] = stats;
+        } else {
+          delete usage[id];
+        }
+      }
+      return usage;
+    };
+    const fingerprint = (usage: AuthProfileStore["usageStats"]) =>
+      JSON.stringify(profileIds.map((id) => fingerprintAuthProfileAvailabilityState(usage?.[id])));
+    const initial = read();
+    if (initial.error) {
+      throw initial.error;
+    }
+    const usage = usageFrom(initial.store);
+    const expected = fingerprint(usage);
+    let lastStore = initial.store;
+    let lastFingerprint = expected;
+    let current = true;
+    const authStore = { ...capturedStore, usageStats: structuredClone(usage) };
+    bindRuntimeAuthProfileUsageObserver(authStore, observer);
+    return {
+      authStore,
+      isCurrent: () => {
+        if (!current) {
+          return false;
+        }
+        const next = read();
+        if (next.error) {
+          current = false;
+          return false;
+        }
+        if (next.store !== lastStore) {
+          lastStore = next.store;
+          lastFingerprint = fingerprint(usageFrom(next.store));
+        }
+        current = lastFingerprint === expected;
+        return current;
+      },
+    };
+  };
+  return observer;
+}
+
+export function bindRuntimeAuthProfileUsageObserver(
+  store: AuthProfileStore,
+  observer: UsageObserver,
+): void {
+  observers.set(store, observer);
+}
+
+export function copyRuntimeAuthProfileUsageObserver(
+  source: AuthProfileStore | undefined,
+  target: AuthProfileStore,
+): void {
+  const observer = source && observers.get(source);
+  if (observer) {
+    observers.set(target, observer);
+  } else {
+    observers.delete(target);
+  }
+}
+
+export function prepareRuntimeAuthProfileUsageObserver(store: AuthProfileStore): UsageObservation {
+  const observer = observers.get(store);
+  return observer ? observer(store) : { authStore: store, isCurrent: () => true };
+}

--- a/src/agents/auth-profiles/usage-state.ts
+++ b/src/agents/auth-profiles/usage-state.ts
@@ -7,6 +7,25 @@ import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { asDateTimestampMs } from "@openclaw/normalization-core/number-coercion";
 import type { AuthProfileFailureReason, AuthProfileStore, ProfileUsageStats } from "./types.js";
 
+/** Availability observers ignore usage counters and successful-request bookkeeping. */
+export function fingerprintAuthProfileAvailabilityState(
+  stats: ProfileUsageStats | undefined,
+): string {
+  return JSON.stringify([
+    stats?.blockedUntil,
+    stats?.blockedReason,
+    stats?.blockedSource,
+    stats?.blockedModel,
+    stats?.blockedScope,
+    stats?.cooldownUntil,
+    stats?.cooldownReason,
+    stats?.cooldownClassification,
+    stats?.cooldownModel,
+    stats?.disabledUntil,
+    stats?.disabledReason,
+  ]);
+}
+
 /** Clears failure windows while preserving unrelated usage history. */
 export function resetAuthProfileFailureState(
   existing: ProfileUsageStats,

--- a/src/agents/model-catalog-decisions.ts
+++ b/src/agents/model-catalog-decisions.ts
@@ -15,6 +15,7 @@ import { resolveExternalCliAuthScopeFromConfig } from "./auth-profiles/external-
 import { materializePersonalAuthProfile } from "./auth-profiles/personal-profiles.js";
 import type { RuntimeAuthMaterialization } from "./auth-profiles/runtime-materializations.js";
 import type { AuthProfileStore } from "./auth-profiles/types.js";
+import { prepareRuntimeAuthProfileUsageObserver } from "./auth-profiles/usage-observer.js";
 import { listCliRuntimeModelBackendBindings } from "./cli-backends.js";
 import { resolveAgentHarnessAvailabilityDecision } from "./harness/availability.js";
 import { resolveAgentHarnessPolicy } from "./harness/policy.js";
@@ -194,7 +195,8 @@ export function createModelCatalogDecisions(params: ModelCatalogDecisionParams) 
     params.workspaceDir ??
     resolveAgentWorkspaceDir(params.cfg, params.agentId) ??
     resolveDefaultAgentWorkspaceDir();
-  let authStore = params.preparedAuthStore;
+  const authObserver = prepareRuntimeAuthProfileUsageObserver(params.preparedAuthStore);
+  let authStore = authObserver.authStore;
   const preferredProfilesByProvider = new Map<string, string>();
   const personalProviders = new Set<string>();
   // A persisted session pin wins over the current viewer's links. Only these
@@ -332,7 +334,9 @@ export function createModelCatalogDecisions(params: ModelCatalogDecisionParams) 
             }
     : evaluateStoredEntry;
   const isCurrent = () =>
-    Date.now() < authValidUntil && (params.isCurrent?.() ?? params.observationConfig === undefined);
+    Date.now() < authValidUntil &&
+    (params.isCurrent?.() ?? params.observationConfig === undefined) &&
+    authObserver.isCurrent();
   return {
     evaluateEntry,
     evaluateNative,

--- a/src/agents/prepared-model-catalog-worker.ts
+++ b/src/agents/prepared-model-catalog-worker.ts
@@ -21,6 +21,7 @@ import { listManifestSyntheticAuthProviderRefs } from "../plugins/synthetic-auth
 import type { PreparedAgentCredentialModes } from "./agent-auth-credential-modes.js";
 import { cloneAuthProfileStore } from "./auth-profiles/clone.js";
 import type { AuthProfileStore } from "./auth-profiles/types.js";
+import { copyRuntimeAuthProfileUsageObserver } from "./auth-profiles/usage-observer.js";
 import type { ModelCatalogAuthLabels } from "./model-catalog-auth-labels.js";
 import type { ModelCatalogSnapshot } from "./model-catalog.types.js";
 import {
@@ -399,6 +400,7 @@ export function createPreparedModelCatalogWorker(
       // validateResult fences this reply before the pool can resolve it.
       throw mismatch(message);
     }
+    copyRuntimeAuthProfileUsageObserver(params.agentFacts.authStore, message.authStore);
     return message;
   };
 

--- a/src/agents/prepared-model-runtime.facts.ts
+++ b/src/agents/prepared-model-runtime.facts.ts
@@ -32,6 +32,10 @@ import {
 } from "./agent-model-discovery.js";
 import { withAgentRosterFactsBatch } from "./agent-scope-config.js";
 import { getPreparedRuntimeAuthProfileStoreSnapshotCore } from "./auth-profiles/runtime-snapshots.js";
+import {
+  bindRuntimeAuthProfileUsageObserver,
+  captureRuntimeAuthProfileUsageObserver,
+} from "./auth-profiles/usage-observer.js";
 import { buildInlineProviderModels } from "./embedded-agent-runner/model.inline-provider.js";
 import {
   createBundledStaticCatalogModelResolver,
@@ -96,6 +100,7 @@ function prepareAgentFacts(
   input: PreparedModelRuntimeInput,
   catalogMode: PreparedModelRuntimeCatalogMode,
   ambientCredentials: Readonly<AgentCredentialMap>,
+  usageObserver: ReturnType<typeof captureRuntimeAuthProfileUsageObserver>,
   additionalProviderIds: readonly string[] = [],
   includeCredentialProviders = catalogMode === "live",
 ): PreparedModelRuntimeAgentBaseFacts {
@@ -113,6 +118,7 @@ function prepareAgentFacts(
     ...(input.workspaceDir ? { workspaceDir: input.workspaceDir } : {}),
     ...(input.env ? { env } : {}),
   });
+  bindRuntimeAuthProfileUsageObserver(authFacts.store, usageObserver);
   const credentials = authFacts.credentials;
   const templateAuthStorage = authFacts.authStorage;
   const rawConfiguredModelRefs = collectPreparedModelRuntimeConfiguredRefs(
@@ -185,6 +191,10 @@ export async function prepareWorkspaceBuildGroup(
     throw new Error("prepared model runtime workspace group is empty");
   }
   const env = input.env ?? process.env;
+  const authInputs = inputs.map((candidate) => ({
+    candidate,
+    usageObserver: captureRuntimeAuthProfileUsageObserver(candidate),
+  }));
   const reportStage = (stage: string) =>
     options.onStage?.(`${stage}; agent ${input.agentId ?? "standalone"}`);
   reportStage("workspace plugins");
@@ -378,12 +388,13 @@ export async function prepareWorkspaceBuildGroup(
     const ambientCredentialsMs = performance.now() - ambientCredentialsStartedAt;
     const agentFactsStartedAt = performance.now();
     reportStage("agent facts");
-    const agentBaseFacts = inputs.map((candidate) =>
+    const agentBaseFacts = authInputs.map(({ candidate, usageObserver }) =>
       withAgentRosterFactsBatch(candidate.config, () =>
         prepareAgentFacts(
           candidate,
           catalogMode,
           ambientCredentials,
+          usageObserver,
           options.providerDiscoveryProviderIds,
           options.includeCredentialProviders,
         ),

--- a/src/agents/prepared-model-runtime.startup-static.test.ts
+++ b/src/agents/prepared-model-runtime.startup-static.test.ts
@@ -200,7 +200,8 @@ vi.mock("./agent-scope-config.js", async (importOriginal) => ({
   resolveAgentWorkspaceDir: () => "/tmp/prepared-static-workspace",
 }));
 
-vi.mock("./auth-profiles/runtime-snapshots.js", () => ({
+vi.mock("./auth-profiles/runtime-snapshots.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./auth-profiles/runtime-snapshots.js")>()),
   getPreparedRuntimeAuthProfileStoreSnapshotCore: () => undefined,
   getRuntimeAuthProfileStoreCredentialsRevision: () => 0,
   registerRuntimeAuthProfileStoreMutationListener: (

--- a/src/gateway/server-methods/chat-metadata-runtime.ts
+++ b/src/gateway/server-methods/chat-metadata-runtime.ts
@@ -21,7 +21,7 @@ import { formatErrorMessage } from "../../infra/errors.js";
 import { pruneMapToMaxSize } from "../../infra/map-size.js";
 import { getActivePluginRegistryVersion } from "../../plugins/runtime.js";
 import { normalizeAgentId } from "../../routing/session-key.js";
-import { createDeferredCore } from "../../shared/deferred.js";
+import { createDeferredCore, type Deferred } from "../../shared/deferred.js";
 import { getSkillsSnapshotVersion } from "../../skills/runtime/refresh-state.js";
 import {
   assertAgentDatabaseAdmitted,
@@ -81,12 +81,6 @@ type PreparedMetadataGeneration = {
   sessionProjectionByKey: Map<string, AgentProjectionEntry>;
 };
 
-type MetadataReplacement = {
-  promise: Promise<void>;
-  reject: (error: Error) => void;
-  resolve: () => void;
-};
-
 type ChatMetadataRuntimeDeps = {
   getConfig: () => OpenClawConfig;
   getContext: () => GatewayRequestContext;
@@ -109,7 +103,7 @@ type ChatMetadataRuntimeDeps = {
 
 const CHAT_METADATA_CACHE_MAX_ENTRIES = 64;
 
-function createMetadataReplacement(): MetadataReplacement {
+function createMetadataReplacement(): Deferred {
   const replacement = createDeferredCore();
   // Reads and lifecycle refreshes observe the original promise. This handler only prevents an
   // unobserved rejection when shutdown or reload failure occurs without a concurrent reader.
@@ -243,7 +237,7 @@ export function createGatewayChatMetadataRuntime(params: {
   };
   let current: PreparedMetadataGeneration | undefined;
   let lastError: Error | undefined;
-  let replacement: MetadataReplacement | undefined;
+  let replacement: Deferred | undefined;
   let invalidationEpoch = 0;
   let refreshVersion = 0;
   let lastSettlement: PreparedMetadataGeneration | number | undefined;

--- a/src/gateway/server-methods/chat-metadata-runtime.ts
+++ b/src/gateway/server-methods/chat-metadata-runtime.ts
@@ -4,11 +4,15 @@ import {
   getRuntimeAuthProfileStoreSnapshotRevision,
   type AuthProfileStore,
 } from "../../agents/auth-profiles.js";
+import { copyRuntimeAuthProfileUsageObserver } from "../../agents/auth-profiles/usage-observer.js";
 import {
   getPublishedPreparedModelCatalogOwnerSnapshot,
   type GetPublishedPreparedModelCatalogOwnerParams,
 } from "../../agents/prepared-model-catalog.js";
-import { getPreparedModelFullCatalogAuth } from "../../agents/prepared-model-runtime-auth.js";
+import {
+  getPreparedModelFullCatalogAuth,
+  getPreparedModelRuntimeAuthStore,
+} from "../../agents/prepared-model-runtime-auth.js";
 import type { PreparedModelRuntimeSnapshot } from "../../agents/prepared-model-runtime.js";
 import { resolveSwarmConfig } from "../../agents/subagents/swarm/swarm-config.js";
 import { resolveRuntimeConfigCacheKey } from "../../config/runtime-snapshot.js";
@@ -142,14 +146,19 @@ function captureGenerationFacts(deps: ChatMetadataRuntimeDeps): PreparedGenerati
       if (fullModelCatalog && !fullCatalogAuth) {
         throw new Error("prepared full model catalog omitted its auth generation");
       }
+      const authStore = fullCatalogAuth?.authStore ??
+        deps.getPreparedAuthStore(owner.agentDir, owner.inheritedAuthDir) ?? {
+          version: 1,
+          profiles: {},
+        };
+      if (!fullCatalogAuth) {
+        // The runtime getter clones its store; keep the prepared owner's observation scope.
+        copyRuntimeAuthProfileUsageObserver(getPreparedModelRuntimeAuthStore(owner), authStore);
+      }
       return {
         agentId,
         owner,
-        authStore: fullCatalogAuth?.authStore ??
-          deps.getPreparedAuthStore(owner.agentDir, owner.inheritedAuthDir) ?? {
-            version: 1,
-            profiles: {},
-          },
+        authStore,
         authModes: fullCatalogAuth?.authModes ?? owner.authModes,
         authStoreRevision: `${deps.getAuthStoreRevision(owner.agentDir)}:${deps.getAuthStoreRevision(owner.inheritedAuthDir)}`,
         modelCatalog: fullModelCatalog ?? owner.modelCatalog,

--- a/src/gateway/server-methods/models-list-result.published.test.ts
+++ b/src/gateway/server-methods/models-list-result.published.test.ts
@@ -1,5 +1,12 @@
 import { expectDefined } from "@openclaw/normalization-core";
 import { describe, expect, it, vi } from "vitest";
+import { setRuntimeAuthProfileStoreSnapshot } from "../../agents/auth-profiles/runtime-snapshots.js";
+import type { AuthProfileStore } from "../../agents/auth-profiles/types.js";
+import {
+  bindRuntimeAuthProfileUsageObserver,
+  captureRuntimeAuthProfileUsageObserver,
+} from "../../agents/auth-profiles/usage-observer.js";
+import type { ModelDefinitionConfig } from "../../config/types.models.js";
 import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
 import {
   readPreparedCatalog,
@@ -68,27 +75,102 @@ describe("models.list published inventory", () => {
   });
 
   it.each(["default", "configured", "provider-config", "all"] as const)(
-    "reads the %s view without discovery",
+    "reads recovered auth in the %s view without discovery",
     async (view) => {
-      await withPublishedCatalog(async (context) => {
-        const published = expectDefined(
-          await readPreparedCatalog(context, "main"),
-          "Published catalog fixture must supply its owner",
-        );
-        const loadDeferred = vi.fn(async () => {
-          throw new Error("Ordinary inventory attempted discovery");
-        });
-        registerGatewayModelCatalogPrivateAccess(context.loadGatewayModelCatalogSnapshot, {
-          loadDeferred,
-          readPrepared: async () => published,
-        });
-        await buildModelsListResult({
-          source: { kind: "gateway", context },
-          agentId: "main",
-          params: { view },
-        });
-        expect(loadDeferred).not.toHaveBeenCalled();
-      });
+      await withOpenClawTestState(
+        {
+          layout: "state-only",
+          prefix: "published-catalog-recovery-",
+          env: { ANTHROPIC_API_KEY: undefined },
+        },
+        async (state) => {
+          const profileId = "anthropic:catalog";
+          const blocked: AuthProfileStore = {
+            version: 1,
+            profiles: {
+              [profileId]: {
+                type: "api_key",
+                provider: "anthropic",
+                key: "synthetic-catalog-key",
+              },
+            },
+            usageStats: { [profileId]: { blockedUntil: Date.now() + 86_400_000 } },
+          };
+          await state.writeAuthProfiles(blocked);
+          setRuntimeAuthProfileStoreSnapshot(blocked, state.agentDir());
+          const observe = captureRuntimeAuthProfileUsageObserver({
+            agentDir: state.agentDir(),
+            env: state.env,
+          });
+          const model: ModelDefinitionConfig = {
+            id: "published-model",
+            name: "Published model",
+            reasoning: false,
+            input: ["text"],
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+            maxTokens: 1024,
+          };
+          const context = createModelsListTestContext({
+            agentDir: state.agentDir(),
+            workspaceDir: state.workspaceDir,
+            catalogComplete: true,
+            preparedAuthModes: { anthropic: "api_key" },
+            catalog: [
+              {
+                id: model.id,
+                name: model.name,
+                provider: "anthropic",
+                api: "anthropic-messages",
+              },
+            ],
+            cfg: {
+              models: {
+                providers: {
+                  anthropic: {
+                    baseUrl: "https://api.anthropic.com",
+                    api: "anthropic-messages",
+                    models: [model],
+                  },
+                },
+              },
+              agents: {
+                defaults: {
+                  model: { primary: "anthropic/published-model" },
+                  modelPolicy: { allow: ["anthropic/*"] },
+                  models: { "anthropic/published-model": { agentRuntime: { id: "openclaw" } } },
+                },
+              },
+            },
+          });
+          const published = expectDefined(
+            await readPreparedCatalog(context, "main"),
+            "Published catalog fixture must supply its owner",
+          );
+          bindRuntimeAuthProfileUsageObserver(published.authStore, observe);
+          setRuntimeAuthProfileStoreSnapshot(
+            { ...blocked, usageStats: { [profileId]: { errorCount: 0 } } },
+            state.agentDir(),
+          );
+          const loadDeferred = vi.fn(async () => {
+            throw new Error("Ordinary inventory attempted discovery");
+          });
+          registerGatewayModelCatalogPrivateAccess(context.loadGatewayModelCatalogSnapshot, {
+            loadDeferred,
+            readPrepared: async () => published,
+          });
+          const result = await buildModelsListResult({
+            source: { kind: "gateway", context },
+            agentId: "main",
+            params: { view },
+          });
+          expect(result.models).toEqual([
+            expect.objectContaining({ id: "published-model", available: true }),
+          ]);
+          expect(result.models[0]).not.toHaveProperty("unavailableReason");
+          expect(result.models[0]).not.toHaveProperty("unavailableUntil");
+          expect(loadDeferred).not.toHaveBeenCalled();
+        },
+      );
     },
   );
 


### PR DESCRIPTION
## What Problem This Solves

Fixes model availability remaining blocked after an account successfully recovers from a quota limit, leaving its provider card at “Signed in” instead of “Ready.”

## User Impact

Recovered stored accounts become available again without restarting the Gateway or interrupting an active turn.

## Why This Change Was Made

Catalog discovery could finish with an older auth snapshot after recovery had already cleared the account’s block. Availability now observes current health for the same stored credential through the existing snapshot owner. Prepared credentials and model inventory remain stable; the existing metadata owner rebuilds only the availability projection when health changes.

## Evidence

- Four published model-list views fail with the original consumer and pass with the repair. These tests prove the consumer path; the separate Gateway run covers preparation and worker handoff.
- The unchanged two-case Linux fixture reproduced the automatic-recovery failure on the [original tree](https://github.com/openclaw/openclaw/actions/runs/34733152963). Both automatic recovery and saved-block clearing pass against the [candidate](https://github.com/openclaw/openclaw/actions/runs/34736425435), preserving the running Gateway and account. This uses a synthetic provider, Node 24.19.0, and Chromium 144.
- 22 focused regression tests, 82 owner/expiry siblings, and all 30 changed-file checks passed. The Linux run also passed the canonical CI-artifact build. That Linux tree precedes an explicit undefined return and the later type-only cleanup below. The 22 focused tests and all 30 checks passed after the first refinement; runtime output remains unchanged by the type cleanup.
- The first hosted core-lint run caught a file-length limit missed by targeted lint. Reusing the existing deferred-promise type removes the duplicate declaration and restores the unchanged 700-line limit. The emitted JavaScript is byte-identical; core types and that exact CI lint stripe pass after the cleanup.
- The startup-static fixture had replaced the full snapshot module, hiding real read APIs used by the repair. Its 12 failures reproduce on the previous head. Keeping the three intended stubs and exposing the remaining real exports passes 70 startup/runtime/lifecycle tests, core test types, and lint, with assertions unchanged.
- Fresh independent review completed all five passes on the complete updated candidate with no actionable findings.

Both Testbox leases were stopped after their commands joined. Wrapper results establish the test outcomes; lease cleanup can change the displayed Actions status. No live provider or quota-reset credit was used.
