### PR TITLE
improve: reduce startup pauses during registry inspection

### DIFF
--- a/src/commands/doctor-config-preflight-startup.ts
+++ b/src/commands/doctor-config-preflight-startup.ts
@@ -155,7 +155,7 @@ async function assertStartupStateMigrationReady(params: {
     await import("../state/openclaw-agent-db-registry.js");
   const targets = resolveAllAgentSessionStoreCandidateTargetsSync(params.cfg, {
     env: params.env,
-    registeredDatabases: inspectOpenClawRegisteredAgentDatabases({
+    registeredDatabases: await inspectOpenClawRegisteredAgentDatabases({
       env: params.env,
       includeIncompatibleSchemaVersions: true,
     }),

--- a/src/infra/state-migrations.doctor.ts
+++ b/src/infra/state-migrations.doctor.ts
@@ -2505,7 +2505,7 @@ export async function planLegacyStateMigrationsReadOnly(params: {
   let agentTargetRefusal: PreparedLegacyStateMigrationStep["refusal"];
   let agentTargetRefusalEndpoints: LegacyStateMigrationEndpoint[] = [];
   try {
-    registeredDatabases = inspectOpenClawRegisteredAgentDatabases({
+    registeredDatabases = await inspectOpenClawRegisteredAgentDatabases({
       env,
       includeIncompatibleSchemaVersions: true,
     });

--- a/src/state/openclaw-agent-db-registry-listing.ts
+++ b/src/state/openclaw-agent-db-registry-listing.ts
@@ -9,7 +9,7 @@ import {
   type OpenClawRegisteredAgentDatabase,
 } from "./openclaw-agent-db-contract.js";
 import {
-  withExistingOpenClawStateDatabaseArtifactPreservingReadOnly,
+  withExistingOpenClawStateDatabaseArtifactPreservingReadOnlyAsync,
   withExistingOpenClawStateDatabaseReadOnly,
 } from "./openclaw-state-db-readonly.js";
 import { detectOpenClawStateDatabaseSchemaMigrationsFromDatabase } from "./openclaw-state-db-schema-repair.js";
@@ -117,8 +117,16 @@ type AgentDatabaseRegistryListOptions = OpenClawStateDatabaseOptions & {
 
 function readRegisteredAgentDatabases(
   options: AgentDatabaseRegistryListOptions,
+  artifactPreserving: false,
+): OpenClawRegisteredAgentDatabase[];
+function readRegisteredAgentDatabases(
+  options: AgentDatabaseRegistryListOptions,
+  artifactPreserving: true,
+): Promise<OpenClawRegisteredAgentDatabase[]>;
+function readRegisteredAgentDatabases(
+  options: AgentDatabaseRegistryListOptions,
   artifactPreserving: boolean,
-): OpenClawRegisteredAgentDatabase[] {
+): OpenClawRegisteredAgentDatabase[] | Promise<OpenClawRegisteredAgentDatabase[]> {
   const pathname = resolveAgentDatabaseRegistryPath(options);
   const read = ({ db: database }: { db: import("node:sqlite").DatabaseSync }) => {
     const schemaMigrations = detectOpenClawStateDatabaseSchemaMigrationsFromDatabase(
@@ -155,24 +163,26 @@ function readRegisteredAgentDatabases(
       sizeBytes: row.size_bytes,
     }));
   };
-  const entries = artifactPreserving
-    ? withExistingOpenClawStateDatabaseArtifactPreservingReadOnly(read, options)
-    : withExistingOpenClawStateDatabaseReadOnly(read, options);
-  if (entries === undefined) {
-    if (hasUnavailableMissingSqlitePath(pathname)) {
-      throw new Error(`OpenClaw state database ${pathname} is unavailable.`);
+  const finish = (entries: OpenClawRegisteredAgentDatabase[] | undefined) => {
+    if (entries === undefined) {
+      if (hasUnavailableMissingSqlitePath(pathname)) {
+        throw new Error(`OpenClaw state database ${pathname} is unavailable.`);
+      }
+      return [];
     }
-    return [];
-  }
-  return options.includeIncompatibleSchemaVersions
-    ? entries
-    : entries.filter((entry) => entry.schemaVersion === OPENCLAW_AGENT_SCHEMA_VERSION);
+    return options.includeIncompatibleSchemaVersions
+      ? entries
+      : entries.filter((entry) => entry.schemaVersion === OPENCLAW_AGENT_SCHEMA_VERSION);
+  };
+  return artifactPreserving
+    ? withExistingOpenClawStateDatabaseArtifactPreservingReadOnlyAsync(read, options).then(finish)
+    : finish(withExistingOpenClawStateDatabaseReadOnly(read, options));
 }
 
 /** Inspect a copied registry without creating SQLite artifacts or runtime memo state. */
-export function inspectOpenClawRegisteredAgentDatabases(
+export async function inspectOpenClawRegisteredAgentDatabases(
   options: AgentDatabaseRegistryListOptions = {},
-): OpenClawRegisteredAgentDatabase[] {
+): Promise<OpenClawRegisteredAgentDatabase[]> {
   return readRegisteredAgentDatabases(options, true);
 }
 


### PR DESCRIPTION
## What Problem This Solves

Cold startup pauses the main thread while inspecting the registered-agent database snapshot.

## User Impact

Startup can remain responsive during snapshot preparation. This does not reduce snapshot work or promise faster startup overall. No configuration, schema migration, or user action is required.

## Why This Change Was Made

Startup admission and Doctor now await the existing artifact-preserving async reader. Ordinary registry listing remains synchronous and memoized, with shared ordering, decoding, schema filtering, and missing/unavailable handling. The normal merge preserves main’s shared registry-row owner and migrates the new backup ownership test with one `await`, retaining its backup/restore assertions.

## Evidence

- **Revised head `62c912d4`:** 50 focused tests, 27 cheap guards, and fresh Codex P2 passed. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34754302899) is green: both backup ownership tests and all 26 artifact-preservation tests passed, as did production types, both core-test type stripes, and both core lint stripes. The earlier local resource-limit failures remain preserved; those lanes were not repeatedly rerun locally.
- **Published updater × exact revised candidate:** [Package Acceptance](https://github.com/openclaw/openclaw/actions/runs/34754841366) passed one published-9.3 `legacy-operator-state` run in 530 seconds. Independent audit verified the actual candidate package (`f6f7784d06f7b1070b116b2dca475ca19c553d1cd44cc62315022d5b26ccf8d4`), its `62c912d4` build-info, and the maintained schema/survival, cron-owner, mock-provider turn, update-no-op, and later Doctor assertions. This addresses the revised-head proof obligations in [ClawSweeper’s review](https://github.com/openclaw/openclaw/pull/146754#issuecomment-5651318674), which found no code defect.
- **Proof limits:** only five outer survivor files were uploaded. Initial warning/consent classification and inner snapshots/PID traces are unavailable. Candidate plugin assertions precede schema checks, so convergence is not attributed exclusively to the installed updater. The manual first-hop cron probe starts the candidate Gateway before listing; no exhaustive pre-startup, auto-restart, or process-family proof is claimed.
- **Historical only:** the earlier `39d09faf` CI, full local build and upgrade result remain preserved, not relabeled as revised-head proof. Frozen-`6c4e02dd` Linux observations showed cold current/WAL event-loop gaps falling from 477–535 ms to 55–85 ms, with unchanged snapshots. Wall time, CPU, planner gaps and RSS were mixed: current-startup wall −0.55%/+3.37%, WAL wall +0.33%/+3.51%, planner CPU +26.10%/+2.96%, and reverse planner gap +6.84%. These one-call-per-process observations are not current-main timing or a universal speedup claim.
