### PR TITLE
fix(memory): admit shared index writes through the agent owner

### DIFF
--- a/docs/plugins/sdk-runtime/state-and-system.md
+++ b/docs/plugins/sdk-runtime/state-and-system.md
@@ -249,6 +249,15 @@ or hold admission across a provider call or an entire asynchronous hook. Recheck
 applicable manager/run ownership and cancellation inside the callback, immediately
 before mutation. Agent identity and handle equality are not authorization.
 
+For preparation that can repeat after SQLite lock contention,
+`runSqliteImmediateTransaction(db, prepare, options, admit)` accepts the same
+owner's admission callback. `prepare` runs before admission and returns a
+synchronous transaction callback. Pass `(write) =>
+withOpenClawAgentDatabaseWrite(databaseOptions, write, borrowedDb)` as `admit`;
+do not place asynchronous preparation inside the admitted callback. The helper
+rechecks transaction state after waiting and never repeats a callback that
+already entered its transaction.
+
 `withOpenClawAgentDatabaseWrite` does not start a transaction, grant an authority
 lease, or coordinate unrelated processes. Raw SQLite calls outside admission bypass it, and existing
 synchronous APIs do not become asynchronous automatically. A rejected stale-owner

--- a/docs/reference/database-schemas/storage-changes.md
+++ b/docs/reference/database-schemas/storage-changes.md
@@ -201,6 +201,13 @@ original environment when the caller's directory or environment changes. Doctor 
 pruning operations before continuing to the next agent. Read-only cache snapshots
 retain their existing synchronous owner and do not create missing databases.
 
+Memory managers admit writes on their exact borrowed agent connection. Provider
+calls and source preparation run before admission; generated-cache and source
+writes recheck their generation, revision, and source predicates after waiting.
+Full reindex publication attaches, replaces, and detaches the completed shadow
+inside one synchronous admitted operation. Manager close drains accepted syncs
+through provider preparation and final writes before releasing the borrow.
+
 ### Preserve the data and concurrency contracts
 
 An adapter must make these contracts explicit and verify them against a real

--- a/extensions/memory-core/src/memory/manager-database-context.ts
+++ b/extensions/memory-core/src/memory/manager-database-context.ts
@@ -1,10 +1,25 @@
 // Owns the published index state and the isolated lifetime of shadow reindex work.
 import { AsyncLocalStorage } from "node:async_hooks";
 import type { DatabaseSync } from "node:sqlite";
+import {
+  resolveStateDir,
+  resolveUserPath,
+} from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
+import { withOpenClawAgentDatabaseWrite } from "openclaw/plugin-sdk/sqlite-runtime";
 import { closeMemoryDatabase } from "./manager-db.js";
 import { MemorySourceIndexKernel } from "./manager-source-index-kernel.js";
 
 export class MemoryIndexDatabase {
+  static captureWriteOptions(agentId: string, databasePath: string, source?: MemoryIndexDatabase) {
+    const env = { ...(source?.writeOptions?.env ?? process.env) };
+    env.OPENCLAW_STATE_DIR = resolveStateDir(env);
+    return {
+      agentId,
+      path: source?.writeOptions?.path ?? resolveUserPath(databasePath),
+      env,
+    };
+  }
+
   readonly sourceIndex: MemorySourceIndexKernel;
   readonly vector: {
     enabled: boolean;
@@ -28,6 +43,7 @@ export class MemoryIndexDatabase {
     readonly db: DatabaseSync,
     readonly release: () => void = () => closeMemoryDatabase(db),
     readonly readOnly = false,
+    readonly writeOptions?: Parameters<typeof withOpenClawAgentDatabaseWrite>[0],
   ) {
     this.sourceIndex = new MemorySourceIndexKernel(db, this);
   }
@@ -41,6 +57,25 @@ const reindexDatabase = new AsyncLocalStorage<{
 
 export abstract class MemoryManagerDatabaseContext {
   protected abstract publishedDatabase: MemoryIndexDatabase;
+  protected closed = false;
+
+  protected async withDatabaseWrite<T>(write: () => T): Promise<T> {
+    const database = this.database;
+    const run = () => {
+      if (this.closed || database.closed || !database.db.isOpen || this.database !== database) {
+        throw new Error("Memory database owner closed or changed before write admission");
+      }
+      if (database.readOnly) {
+        throw new Error("Memory status managers are read-only");
+      }
+      return write();
+    };
+    // A shadow index is private to its awaited rebuild; only the published
+    // borrowed database shares the agent's reclamation/write admission owner.
+    return database.writeOptions
+      ? await withOpenClawAgentDatabaseWrite(database.writeOptions, run, database.db)
+      : run();
+  }
 
   protected get database(): MemoryIndexDatabase {
     const context = reindexDatabase.getStore();

--- a/extensions/memory-core/src/memory/manager-db.test.ts
+++ b/extensions/memory-core/src/memory/manager-db.test.ts
@@ -17,7 +17,7 @@ import {
   cleanupAgedMemoryReindexTempFiles,
   closeMemoryDatabase,
   openMemoryDatabaseAtPath,
-  publishMemoryDatabaseTables,
+  prepareMemoryDatabasePublication,
   readMemoryDatabaseRevision,
   MemoryIndexRevisionConflictError,
   resetMemoryDatabase,
@@ -34,6 +34,13 @@ function ensureTestMemorySchema(db: DatabaseSync, cacheEnabled = true, ftsEnable
 
 async function expectPathMissing(targetPath: string): Promise<void> {
   await expect(fs.access(targetPath)).rejects.toThrow("ENOENT");
+}
+
+async function publishPreparedMemoryDatabase(
+  params: Parameters<typeof prepareMemoryDatabasePublication>[0],
+): Promise<void> {
+  const publish = await prepareMemoryDatabasePublication(params);
+  publish();
 }
 
 describe("memory manager database publication", () => {
@@ -174,7 +181,7 @@ describe("memory manager database publication", () => {
         .run("new", 9, "when flying");
       sourceDb.close();
 
-      await publishMemoryDatabaseTables({
+      await publishPreparedMemoryDatabase({
         targetDb,
         sourcePath,
         sourceHasVectors: false,
@@ -209,7 +216,7 @@ describe("memory manager database publication", () => {
         .run("stale", "[]");
       sourceDb.close();
 
-      await publishMemoryDatabaseTables({
+      await publishPreparedMemoryDatabase({
         targetDb,
         sourcePath,
         sourceHasVectors: false,
@@ -261,7 +268,7 @@ describe("memory manager database publication", () => {
       const expectedRevision = readMemoryDatabaseRevision(targetDb);
       sourceDb.close();
 
-      await publishMemoryDatabaseTables({
+      await publishPreparedMemoryDatabase({
         targetDb,
         sourcePath,
         sourceHasVectors: false,
@@ -334,7 +341,7 @@ describe("memory manager database publication", () => {
       const expectedRevision = readMemoryDatabaseRevision(targetDb);
       sourceDb.close();
 
-      await publishMemoryDatabaseTables({
+      await publishPreparedMemoryDatabase({
         targetDb,
         sourcePath,
         sourceHasVectors: false,
@@ -408,7 +415,7 @@ describe("memory manager database publication", () => {
           return originalLoad(params);
         });
       try {
-        await publishMemoryDatabaseTables({
+        await publishPreparedMemoryDatabase({
           targetDb,
           sourcePath,
           sourceHasVectors: true,
@@ -461,7 +468,7 @@ describe("memory manager database publication", () => {
       concurrentDb.close();
       concurrentDb = undefined;
 
-      const publication = publishMemoryDatabaseTables({
+      const publication = publishPreparedMemoryDatabase({
         targetDb,
         sourcePath,
         sourceHasVectors: false,
@@ -510,7 +517,7 @@ describe("memory manager database publication", () => {
         .run("test", "model", "key", "shadow-hash", "[1]", 1, 2);
       sourceDb.close();
 
-      await publishMemoryDatabaseTables({
+      await publishPreparedMemoryDatabase({
         targetDb,
         sourcePath,
         sourceHasVectors: false,

--- a/extensions/memory-core/src/memory/manager-db.ts
+++ b/extensions/memory-core/src/memory/manager-db.ts
@@ -215,19 +215,15 @@ function replaceMemoryPathFtsTable(db: DatabaseSync): void {
   );
 }
 
-/** Publish a completed shadow memory index without replacing the shared agent database file. */
-export async function publishMemoryDatabaseTables(params: {
+/** Prepare a shadow publication; its caller admits the synchronous commit on the borrowed owner. */
+export async function prepareMemoryDatabasePublication(params: {
   targetDb: DatabaseSync;
   sourcePath: string;
   metaKey: string;
   expectedRevision: number;
   sourceHasVectors: boolean;
   vectorExtensionPath?: string;
-}): Promise<void> {
-  ensureMemoryRecallMetadataSchema(params.targetDb);
-  // Existing pre-provenance databases lack the provenance table the publish
-  // below writes to; ensure it (idempotent) alongside the recall columns.
-  ensureMemoryChunkProvenance(params.targetDb);
+}): Promise<() => void> {
   if (params.sourceHasVectors && !hasSqliteVecExtension(params.targetDb)) {
     const loaded = await loadSqliteVecExtension({
       db: params.targetDb,
@@ -240,37 +236,40 @@ export async function publishMemoryDatabaseTables(params: {
       );
     }
   }
-  // The target can be shared with sessions and other managers. Never leave an
-  // attached shadow on it across an await or outside the synchronous publication.
-  params.targetDb.prepare(`ATTACH DATABASE ? AS ${MEMORY_REINDEX_SCHEMA}`).run(params.sourcePath);
-  try {
-    runSqliteImmediateTransactionSync(params.targetDb, () => {
-      const liveRevision = readMemoryDatabaseRevision(params.targetDb);
-      if (liveRevision !== params.expectedRevision) {
-        throw new MemoryIndexRevisionConflictError(
-          `Memory index changed while full reindex was building ` +
-            `(expected revision ${params.expectedRevision}, found ${liveRevision}); retry the full reindex.`,
+  return () => {
+    ensureMemoryRecallMetadataSchema(params.targetDb);
+    // Existing pre-provenance databases need this before the publication writes it.
+    ensureMemoryChunkProvenance(params.targetDb);
+    // Admission precedes ATTACH; no shadow attachment or transaction crosses an await.
+    params.targetDb.prepare(`ATTACH DATABASE ? AS ${MEMORY_REINDEX_SCHEMA}`).run(params.sourcePath);
+    try {
+      runSqliteImmediateTransactionSync(params.targetDb, () => {
+        const liveRevision = readMemoryDatabaseRevision(params.targetDb);
+        if (liveRevision !== params.expectedRevision) {
+          throw new MemoryIndexRevisionConflictError(
+            `Memory index changed while full reindex was building ` +
+              `(expected revision ${params.expectedRevision}, found ${liveRevision}); retry the full reindex.`,
+          );
+        }
+        const publishesPathFts = tableExists(
+          params.targetDb,
+          MEMORY_REINDEX_SCHEMA,
+          MEMORY_INDEX_PATHS_FTS_TABLE,
         );
-      }
-      const publishesPathFts = tableExists(
-        params.targetDb,
-        MEMORY_REINDEX_SCHEMA,
-        MEMORY_INDEX_PATHS_FTS_TABLE,
-      );
-      // Bulk source replacement must not fire one FTS5 scan per old row.
-      // Restore the schema-owned triggers only after the derived table is replaced.
-      dropMemoryPathFtsTriggers(params.targetDb);
-      params.targetDb
-        .prepare("DELETE FROM main.memory_index_meta WHERE key = ?")
-        .run(params.metaKey);
-      params.targetDb
-        .prepare(
-          `INSERT INTO main.memory_index_meta (key, value)
+        // Bulk source replacement must not fire one FTS5 scan per old row.
+        // Restore the schema-owned triggers only after the derived table is replaced.
+        dropMemoryPathFtsTriggers(params.targetDb);
+        params.targetDb
+          .prepare("DELETE FROM main.memory_index_meta WHERE key = ?")
+          .run(params.metaKey);
+        params.targetDb
+          .prepare(
+            `INSERT INTO main.memory_index_meta (key, value)
            SELECT key, value FROM ${MEMORY_REINDEX_SCHEMA}.memory_index_meta WHERE key = ?`,
-        )
-        .run(params.metaKey);
+          )
+          .run(params.metaKey);
 
-      params.targetDb.exec(`
+        params.targetDb.exec(`
         DELETE FROM main.memory_index_sources;
         INSERT INTO main.memory_index_sources (id, path, source, hash, mtime, size)
         SELECT id, path, source, hash, mtime, size
@@ -299,28 +298,29 @@ export async function publishMemoryDatabaseTables(params: {
         FROM ${MEMORY_REINDEX_SCHEMA}.memory_index_chunk_provenance;
       `);
 
-      replaceVirtualTable({
-        db: params.targetDb,
-        tableName: "memory_index_chunks_fts",
-        columns: "text, id, path, source, model, start_line, end_line",
+        replaceVirtualTable({
+          db: params.targetDb,
+          tableName: "memory_index_chunks_fts",
+          columns: "text, id, path, source, model, start_line, end_line",
+        });
+        replaceMemoryPathFtsTable(params.targetDb);
+        if (publishesPathFts) {
+          ensureMemoryPathFtsTriggers(params.targetDb);
+        }
+        replaceVirtualTable({
+          db: params.targetDb,
+          tableName: "memory_index_chunks_vec",
+          columns: "id, embedding",
+          // A vector-disabled connection may not have sqlite-vec loaded and cannot
+          // drop an old virtual table. Missing vector metadata forces a strict
+          // rebuild before that table can be queried again.
+          ignoreDropErrorWhenSourceMissing: true,
+        });
       });
-      replaceMemoryPathFtsTable(params.targetDb);
-      if (publishesPathFts) {
-        ensureMemoryPathFtsTriggers(params.targetDb);
-      }
-      replaceVirtualTable({
-        db: params.targetDb,
-        tableName: "memory_index_chunks_vec",
-        columns: "id, embedding",
-        // A vector-disabled connection may not have sqlite-vec loaded and cannot
-        // drop an old virtual table. Missing vector metadata forces a strict
-        // rebuild before that table can be queried again.
-        ignoreDropErrorWhenSourceMissing: true,
-      });
-    });
-  } finally {
-    params.targetDb.exec(`DETACH DATABASE ${MEMORY_REINDEX_SCHEMA}`);
-  }
+    } finally {
+      params.targetDb.exec(`DETACH DATABASE ${MEMORY_REINDEX_SCHEMA}`);
+    }
+  };
 }
 
 /** Remove one closed shadow memory database and its journal-mode sidecars. */

--- a/extensions/memory-core/src/memory/manager-embedding-ops.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-ops.ts
@@ -379,13 +379,18 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
        )`,
     );
     while (excess() > 0) {
-      await runSqliteImmediateTransaction(this.db, async () => () => {
-        // Purges can reduce the cache while admission waits; retain the newest cap.
-        const currentExcess = excess();
-        if (currentExcess > 0) {
-          remove.run(Math.min(currentExcess, EMBEDDING_CACHE_PRUNE_BATCH_SIZE));
-        }
-      });
+      await runSqliteImmediateTransaction(
+        this.db,
+        async () => () => {
+          // Purges can reduce the cache while admission waits; retain the newest cap.
+          const currentExcess = excess();
+          if (currentExcess > 0) {
+            remove.run(Math.min(currentExcess, EMBEDDING_CACHE_PRUNE_BATCH_SIZE));
+          }
+        },
+        undefined,
+        (write) => this.withDatabaseWrite(write),
+      );
       await new Promise<void>((resolve) => {
         setImmediate(resolve);
       });
@@ -639,6 +644,40 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
     }
   }
 
+  private async withGeneratedEmbeddingCacheWrite(
+    generation: MemorySemanticProviderGeneration,
+    write: () => void,
+  ): Promise<void> {
+    await this.withPublishedDatabase(async () => {
+      if (
+        this.syncProviderGeneration !== generation ||
+        generation.cacheWritesInvalidated ||
+        generation.database.closed ||
+        this.database !== generation.database
+      ) {
+        return;
+      }
+      // Rebuilds use a shadow index, but generated results belong to the exact
+      // published owner captured by the generation, including after admission.
+      await this.withDatabaseWrite(() =>
+        runSqliteImmediateTransactionSync(generation.database.db, () => {
+          if (
+            this.syncProviderGeneration !== generation ||
+            generation.cacheWritesInvalidated ||
+            generation.database.closed
+          ) {
+            return;
+          }
+          if (readMemoryDatabaseRevision(generation.database.db) !== generation.databaseRevision) {
+            generation.cacheWritesInvalidated = true;
+            return;
+          }
+          write();
+        }),
+      );
+    });
+  }
+
   private async persistGeneratedEmbeddings(
     candidates: MemoryEmbeddingCacheCandidate[],
     embeddings: number[][],
@@ -670,23 +709,12 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
       ) {
         // Separate successful batches can disagree. Neither dimension is authoritative;
         // discard this identity's ambiguous cache so retries can recover after restart.
-        await withMemoryWorkspaceLock(this.workspaceDir, async () => {
-          if (
-            this.syncProviderGeneration !== generation ||
-            generation.cacheWritesInvalidated ||
-            generation.database.closed
-          ) {
-            return;
-          }
-          runSqliteImmediateTransactionSync(generation.database.db, () => {
-            if (
-              readMemoryDatabaseRevision(generation.database.db) === generation.databaseRevision
-            ) {
-              clearMemoryEmbeddingCacheIdentities(generation.database.db, generation.identities);
-            }
+        await withMemoryWorkspaceLock(this.workspaceDir, () =>
+          this.withGeneratedEmbeddingCacheWrite(generation, () => {
+            clearMemoryEmbeddingCacheIdentities(generation.database.db, generation.identities);
             generation.cacheWritesInvalidated = true;
-          });
-        });
+          }),
+        );
       }
       throw new Error(
         "memory embeddings: malformed vector response (count, dimensions, or coordinates)",
@@ -732,18 +760,7 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
       if (accepted.length === 0) {
         return;
       }
-      runSqliteImmediateTransactionSync(generation.database.db, () => {
-        if (
-          this.syncProviderGeneration !== generation ||
-          generation.cacheWritesInvalidated ||
-          generation.database.closed
-        ) {
-          return;
-        }
-        if (readMemoryDatabaseRevision(generation.database.db) !== generation.databaseRevision) {
-          generation.cacheWritesInvalidated = true;
-          return;
-        }
+      await this.withGeneratedEmbeddingCacheWrite(generation, () => {
         upsertMemoryEmbeddingCache({
           db: generation.database.db,
           enabled: true,
@@ -916,58 +933,77 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
     vectorReady: boolean,
   ): Promise<void> {
     await withMemoryWorkspaceLock(this.workspaceDir, async () => {
-      const published = await runSqliteImmediateTransaction(this.db, async () => {
-        if (source === "memory") {
-          // The lock excludes purge and promotion writers while the exact file
-          // snapshot is validated and its derived index records are committed.
-          const current = await buildFileEntry(
-            entry.absPath,
-            this.workspaceDir,
-            this.settings.multimodal,
-          );
-          if (current?.hash !== entry.hash) {
-            this.dirty = true;
-            log.debug("memory source changed while indexing; queued incremental retry", {
-              path: entry.path,
-            });
-            return undefined;
-          }
-        }
-        const now = Date.now();
-        const model = generation?.provider?.model ?? "fts-only";
-        return () => {
-          const result = this.database.sourceIndex.replace(
-            {
-              entry,
-              chunks,
-              embeddings,
-              model,
-              now,
-              vectorReady,
-              ...(source === "sessions"
-                ? {
-                    source,
-                    agentId: this.agentId,
-                    sessionId: expectDefined(entry.sessionId, "memory index session identity"),
-                  }
-                : { source }),
-            },
-            (generation?.database ?? this.database).sourceIndex,
-          );
-          if (result === "forgotten") {
-            this.markFailedFullReindexRetry({ memory: false, sessions: true });
-            throw new Error(
-              "A session was forgotten while memory indexing was running; retry the memory index.",
+      const published = await runSqliteImmediateTransaction(
+        this.db,
+        async () => {
+          if (source === "memory") {
+            // The lock excludes purge and promotion writers while the exact file
+            // snapshot is validated and its derived index records are committed.
+            const current = await buildFileEntry(
+              entry.absPath,
+              this.workspaceDir,
+              this.settings.multimodal,
             );
+            if (current?.hash !== entry.hash) {
+              this.dirty = true;
+              log.debug("memory source changed while indexing; queued incremental retry", {
+                path: entry.path,
+              });
+              return undefined;
+            }
           }
-          return true;
-        };
-      });
+          const now = Date.now();
+          const model = generation?.provider?.model ?? "fts-only";
+          return () => {
+            if (
+              generation &&
+              this.db === generation.database.db &&
+              readMemoryDatabaseRevision(this.db) !== generation.databaseRevision
+            ) {
+              generation.cacheWritesInvalidated = true;
+            }
+            const result = this.database.sourceIndex.replace(
+              {
+                entry,
+                chunks,
+                embeddings,
+                model,
+                now,
+                vectorReady,
+                ...(source === "sessions"
+                  ? {
+                      source,
+                      agentId: this.agentId,
+                      sessionId: expectDefined(entry.sessionId, "memory index session identity"),
+                    }
+                  : { source }),
+              },
+              (generation?.database ?? this.database).sourceIndex,
+            );
+            if (result === "forgotten") {
+              this.markFailedFullReindexRetry({ memory: false, sessions: true });
+              throw new Error(
+                "A session was forgotten while memory indexing was running; retry the memory index.",
+              );
+            }
+            return {
+              databaseRevision:
+                generation && this.db === generation.database.db
+                  ? readMemoryDatabaseRevision(generation.database.db)
+                  : undefined,
+            };
+          };
+        },
+        undefined,
+        (write) => this.withDatabaseWrite(write),
+      );
       if (!published) {
         return;
       }
-      if (generation && this.db === generation.database.db) {
-        generation.databaseRevision = readMemoryDatabaseRevision(generation.database.db);
+      if (generation && published.databaseRevision !== undefined) {
+        // Admission can resume another writer before this continuation runs.
+        // Adopt only the revision captured by our committed publication.
+        generation.databaseRevision = published.databaseRevision;
       }
       this.database.vectorDegradedWriteWarningShown = logMemoryVectorDegradedWrite({
         vectorEnabled: this.vector.enabled,

--- a/extensions/memory-core/src/memory/manager-registry.test.ts
+++ b/extensions/memory-core/src/memory/manager-registry.test.ts
@@ -6,8 +6,8 @@ import { createManagerIndexFixture } from "./manager-index.test-support.js";
 import {
   closeAllMemoryIndexManagers,
   closeMemoryIndexManagersForAgent,
-  MemoryIndexManager as RuntimeMemoryIndexManager,
-} from "./manager.js";
+} from "./manager-runtime.js";
+import { MemoryIndexManager as RuntimeMemoryIndexManager } from "./manager.js";
 
 const { closeAllMemorySearchManagers, getMemorySearchManager } = await import("./index.js");
 

--- a/extensions/memory-core/src/memory/manager-runtime.ts
+++ b/extensions/memory-core/src/memory/manager-runtime.ts
@@ -1,6 +1,17 @@
 // Memory Core plugin module implements manager runtime behavior.
-export {
-  closeAllMemoryIndexManagers,
-  closeMemoryIndexManagersForAgent,
-  MemoryIndexManager,
-} from "./manager.js";
+import { getMemoryIndexManagerRegistry, MemoryIndexManager } from "./manager.js";
+
+export { MemoryIndexManager };
+
+export async function closeAllMemoryIndexManagers(): Promise<void> {
+  const registry = getMemoryIndexManagerRegistry();
+  registry.embeddingProbeCache.clear();
+  await registry.closeAll();
+}
+
+export async function closeMemoryIndexManagersForAgent(params: { agentId: string }): Promise<void> {
+  const registry = getMemoryIndexManagerRegistry();
+  for (const purpose of ["default", "maintenance"] as const) {
+    await registry.closeForAgent({ ...params, purpose });
+  }
+}

--- a/extensions/memory-core/src/memory/manager-search-orchestration.ts
+++ b/extensions/memory-core/src/memory/manager-search-orchestration.ts
@@ -5,9 +5,11 @@ import {
   resolveUserPath,
 } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
 import {
+  readMemoryFile,
   MEMORY_INDEX_FTS_TABLE,
   MEMORY_INDEX_VECTOR_TABLE,
   MEMORY_SEARCH_DEADLINE_CONTROL,
+  type MemoryReadResult,
   type MemorySearchManager,
   type MemorySearchResult,
   type MemorySource,
@@ -79,6 +81,20 @@ export abstract class MemorySearchOrchestration extends MemoryKeywordRetrieval {
         : undefined,
     });
     return selectResults(results);
+  }
+
+  async readFile(params: {
+    relPath: string;
+    from?: number;
+    lines?: number;
+  }): Promise<MemoryReadResult> {
+    return await readMemoryFile({
+      workspaceDir: this.workspaceDir,
+      extraPaths: this.settings.extraPaths,
+      relPath: params.relPath,
+      from: params.from,
+      lines: params.lines,
+    });
   }
 
   private async searchCandidates(

--- a/extensions/memory-core/src/memory/manager-source-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-source-sync-ops.ts
@@ -66,9 +66,14 @@ export abstract class MemoryManagerSourceSyncOps extends MemoryManagerSessionSyn
     source: MemorySource,
     expectedHash = resolveMemorySourceExistingHash({ db: this.db, path: pathname, source }),
   ): Promise<void> {
-    await runSqliteImmediateTransaction(this.db, async () => () => {
-      this.database.sourceIndex.deleteIfCurrent({ path: pathname, source, expectedHash });
-    });
+    await runSqliteImmediateTransaction(
+      this.db,
+      async () => () => {
+        this.database.sourceIndex.deleteIfCurrent({ path: pathname, source, expectedHash });
+      },
+      undefined,
+      (write) => this.withDatabaseWrite(write),
+    );
   }
 
   private async deleteStaleSourceFiles(
@@ -299,6 +304,8 @@ export abstract class MemoryManagerSourceSyncOps extends MemoryManagerSessionSyn
                 entry.path,
                 entry.hash,
               ).changes === 1,
+            undefined,
+            (write) => this.withDatabaseWrite(write),
           ))
         ) {
           throw new MemoryIndexRevisionConflictError(

--- a/extensions/memory-core/src/memory/manager-sync-base.ts
+++ b/extensions/memory-core/src/memory/manager-sync-base.ts
@@ -123,7 +123,6 @@ export abstract class MemoryManagerSyncBase extends MemoryManagerDatabaseContext
   protected fallbackReason?: string;
   protected intervalTimer: NodeJS.Timeout | null = null;
   protected memoryWatchPressureStartupTimer: NodeJS.Timeout | null = null;
-  protected closed = false;
   protected dirty = false;
   // A success clears only the failure visible when it started. This keeps a
   // concurrent failure visible even when older or no-op work settles later.
@@ -202,6 +201,10 @@ export abstract class MemoryManagerSyncBase extends MemoryManagerDatabaseContext
     this.clearMemoryRetryState();
     this.clearSessionRetryState();
     return snapshot;
+  }
+
+  adoptReindexRetryState(snapshot: MemoryReindexRetryState): void {
+    this.restoreReindexRetryState(snapshot);
   }
 
   protected restoreReindexRetryState(snapshot: MemoryReindexRetryState): void {
@@ -468,7 +471,7 @@ export abstract class MemoryManagerSyncBase extends MemoryManagerDatabaseContext
       if (persistedMeta && persistedMeta.vectorDims !== this.vector.dims) {
         this.vector.dims = persistedMeta.vectorDims;
       }
-      this.ensureVectorTable(dimensions);
+      await this.withDatabaseWrite(() => this.ensureVectorTable(dimensions));
     }
     return ready;
   }
@@ -502,7 +505,10 @@ export abstract class MemoryManagerSyncBase extends MemoryManagerDatabaseContext
         this.markConfiguredSourcesForFullReindex();
         return false;
       }
-      if (!this.database.readOnly && this.dropLegacyVectorTable()) {
+      if (
+        !this.database.readOnly &&
+        (await this.withDatabaseWrite(() => this.dropLegacyVectorTable()))
+      ) {
         // A broad dirty sync can skip unchanged files whose source hashes were
         // migrated. Force the next sync to republish the derived vector rows.
         this.dirty = true;

--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -24,7 +24,7 @@ import {
   cleanupAgedMemoryReindexTempFiles,
   memoryDatabaseTableExists,
   openMemoryDatabaseAtPath,
-  publishMemoryDatabaseTables,
+  prepareMemoryDatabasePublication,
   readMemoryDatabaseRevision,
   removeMemoryDatabaseFiles,
 } from "./manager-db.js";
@@ -606,7 +606,7 @@ export abstract class MemoryManagerSyncOps extends MemoryManagerSourceSyncOps {
             nextMeta.vectorDims = this.vector.dims;
           }
 
-          this.writeMeta(nextMeta);
+          await this.withDatabaseWrite(() => this.writeMeta(nextMeta));
           return {
             nextMeta,
             vectorIndexComplete,
@@ -620,7 +620,7 @@ export abstract class MemoryManagerSyncOps extends MemoryManagerSourceSyncOps {
 
       await withMemoryWorkspaceLock(this.workspaceDir, async () => {
         await withMemoryIndexPublishGeneration(dbPath, async () => {
-          await publishMemoryDatabaseTables({
+          const publish = await prepareMemoryDatabasePublication({
             targetDb: originalDb,
             sourcePath: tempDbPath,
             metaKey: MEMORY_INDEX_META_KEY,
@@ -628,14 +628,16 @@ export abstract class MemoryManagerSyncOps extends MemoryManagerSourceSyncOps {
             sourceHasVectors: rebuilt.hasVectors,
             vectorExtensionPath: shadow.vector.extensionPath,
           });
+          await this.withDatabaseWrite(() => {
+            publish();
+            if (rebuilt.vectorIndexComplete) {
+              // Publish completeness only after the shadow tables committed.
+              markMemoryVectorIndexClean(originalDb);
+            }
+          });
         });
       });
 
-      if (rebuilt.vectorIndexComplete) {
-        // Publish completeness only after the shadow tables committed. A crash
-        // before this point leaves the rebuild marker conservative and retryable.
-        markMemoryVectorIndexClean(originalDb);
-      }
       this.database.lastMetaSerialized = null;
       this.resetVectorState();
       this.fts.available = shadow.fts.available;

--- a/extensions/memory-core/src/memory/manager.borrowed-connection.test.ts
+++ b/extensions/memory-core/src/memory/manager.borrowed-connection.test.ts
@@ -13,14 +13,16 @@ import {
   ensureMemoryChunkProvenance,
   loadSqliteVecExtension,
 } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
-import { deleteSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
+import { deleteSessionEntry, upsertSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
+import { withSessionTranscriptWriteLock } from "openclaw/plugin-sdk/session-transcript-runtime";
 import * as sqliteRuntime from "openclaw/plugin-sdk/sqlite-runtime";
 import { closeOpenClawAgentDatabasesForTest } from "openclaw/plugin-sdk/sqlite-runtime-testing";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { recordMemorySessionTombstones } from "../memory-entry-origins.js";
 import { MemoryIndexRevisionConflictError } from "./manager-db.js";
 import { createManagerIndexFixture } from "./manager-index.test-support.js";
-import { closeAllMemoryIndexManagers, MemoryIndexManager } from "./manager.js";
+import { closeAllMemoryIndexManagers } from "./manager-runtime.js";
+import { MemoryIndexManager } from "./manager.js";
 
 const { closeAllMemorySearchManagers, getMemorySearchManager } = await import("./index.js");
 
@@ -212,6 +214,62 @@ describe("memory manager shared agent connection", () => {
     await first.close();
     await replacement.sync({ reason: "test", force: true });
     expect((await replacement.search("Alpha")).length).toBeGreaterThan(0);
+  });
+
+  it("rejects queued maintenance without reopening its retired source connection", async () => {
+    const cfg = createConfig();
+    const source = await fixture.getFreshManager(cfg, "cli");
+    const sourcePath = source.status().dbPath;
+    const target = {
+      agentId: "main",
+      sessionKey: "agent:main:maintenance-admission",
+      sessionId: "maintenance-admission",
+    };
+    await upsertSessionEntry({
+      ...target,
+      entry: { sessionId: target.sessionId, updatedAt: Date.now() },
+    });
+    const entered = createDeferred<void>();
+    const released = createDeferred<void>();
+    const queued = createDeferred<void>();
+    const writer = withSessionTranscriptWriteLock(target, async () => {
+      entered.resolve();
+      await released.promise;
+      closeOpenClawAgentDatabasesForTest();
+    });
+    await entered.promise;
+    const admit = sqliteRuntime.withOpenClawAgentDatabaseWrite;
+    vi.spyOn(sqliteRuntime, "withOpenClawAgentDatabaseWrite").mockImplementation(
+      (options, write, expectedDatabase) => {
+        const result = admit(options, write, expectedDatabase);
+        queued.resolve();
+        return result;
+      },
+    );
+    const prepare = vi.spyOn(DatabaseSync.prototype, "prepare");
+    const creating = MemoryIndexManager.get({
+      cfg,
+      agentId: "main",
+      purpose: "maintenance",
+      maintenanceSource: source,
+    });
+    void creating.catch(() => undefined);
+    try {
+      await Promise.race([queued.promise, creating]);
+      released.resolve();
+      await expect(creating).rejects.toThrow(/connection is unavailable|closed or changed/);
+      expect(
+        prepare.mock.contexts.filter(
+          (database) =>
+            database instanceof DatabaseSync &&
+            database.isOpen &&
+            database.location() === sourcePath,
+        ),
+      ).toEqual([]);
+    } finally {
+      released.resolve();
+      await Promise.allSettled([writer, creating]);
+    }
   });
 
   it("serves published hits while dirty maintenance setup meets a separate writer lock", async () => {

--- a/extensions/memory-core/src/memory/manager.fts-only-reindex.test.ts
+++ b/extensions/memory-core/src/memory/manager.fts-only-reindex.test.ts
@@ -10,7 +10,8 @@ import { closeOpenClawAgentDatabasesForTest } from "openclaw/plugin-sdk/sqlite-r
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { closeAllMemorySearchManagers, getMemorySearchManager } from "./index.js";
 import type { MemoryIndexMeta } from "./manager-reindex-state.js";
-import { closeAllMemoryIndexManagers, type MemoryIndexManager } from "./manager.js";
+import { closeAllMemoryIndexManagers } from "./manager-runtime.js";
+import type { MemoryIndexManager } from "./manager.js";
 import "./test-runtime-mocks.js";
 
 let providerConstructionError: Error | null = null;

--- a/extensions/memory-core/src/memory/manager.legacy-migration-cleanup.test.ts
+++ b/extensions/memory-core/src/memory/manager.legacy-migration-cleanup.test.ts
@@ -15,7 +15,8 @@ import {
 } from "openclaw/plugin-sdk/sqlite-runtime-testing";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import "./test-runtime-mocks.js";
-import { closeAllMemoryIndexManagers, MemoryIndexManager } from "./manager.js";
+import { closeAllMemoryIndexManagers } from "./manager-runtime.js";
+import { MemoryIndexManager } from "./manager.js";
 
 const originalStateDir = process.env.OPENCLAW_STATE_DIR;
 

--- a/extensions/memory-core/src/memory/manager.reindex-recovery.test.ts
+++ b/extensions/memory-core/src/memory/manager.reindex-recovery.test.ts
@@ -3,13 +3,19 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
+import { setImmediate as yieldToEventLoop } from "node:timers/promises";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
 import { resetPluginStateStoreForTests } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import { registerEmbeddingProvider } from "openclaw/plugin-sdk/plugin-test-runtime";
+import { upsertSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
+import { withSessionTranscriptWriteLock } from "openclaw/plugin-sdk/session-transcript-runtime";
 import { resolveOpenClawAgentSqlitePath } from "openclaw/plugin-sdk/sqlite-runtime";
+import * as sqliteRuntime from "openclaw/plugin-sdk/sqlite-runtime";
 import { closeOpenClawAgentDatabasesForTest } from "openclaw/plugin-sdk/sqlite-runtime-testing";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import "./test-runtime-mocks.js";
+import { recordMemorySessionTombstones } from "../memory-entry-origins.js";
 import type { EmbeddingProvider } from "./embeddings.js";
 import { resetMemoryDatabase } from "./manager-db.js";
 import { waitForMemoryReindexLock } from "./manager-reindex-lock.js";
@@ -150,6 +156,28 @@ describe("memory manager reindex recovery", () => {
     return manager;
   }
 
+  async function reservePublishedWriter(mutate?: () => void | Promise<void>) {
+    const target = {
+      agentId: "main",
+      sessionKey: "agent:main:cache-admission",
+      sessionId: "cache-admission",
+    };
+    await upsertSessionEntry({
+      ...target,
+      entry: { sessionId: target.sessionId, updatedAt: Date.now() },
+    });
+    const entered = createDeferred<void>();
+    const released = createDeferred<void>();
+    const done = withSessionTranscriptWriteLock(target, async () => {
+      entered.resolve();
+      await released.promise;
+      await mutate?.();
+    });
+    void done.catch(() => undefined);
+    await Promise.race([entered.promise, done]);
+    return { done, release: released.resolve };
+  }
+
   it("restores retry state after a shadow full reindex fails late", async () => {
     const memoryManager = await openManager(
       createCfg({
@@ -270,7 +298,7 @@ describe("memory manager reindex recovery", () => {
     ).toBeGreaterThan(0);
   });
 
-  it("recovers when separate provider batches disagree on dimensions", async () => {
+  it("waits for the published writer before clearing conflicting dimensions and recovers", async () => {
     const cfg = createCfg({ sources: ["memory"], cacheEnabled: true });
     const memoryManager = await openManager(cfg);
     await memoryManager.sync({ reason: "cli", force: true });
@@ -287,12 +315,42 @@ describe("memory manager reindex recovery", () => {
       (provider, model, provider_key, hash, embedding, dims, updated_at)
       VALUES ('unrelated', 'unrelated', 'unrelated', 'keep', '[1,0]', 2, 1)`)
       .run();
+    const queued = createDeferred<void>();
+    const admit = sqliteRuntime.withOpenClawAgentDatabaseWrite;
+    let reservation: Awaited<ReturnType<typeof reservePublishedWriter>> | undefined;
+    vi.spyOn(sqliteRuntime, "withOpenClawAgentDatabaseWrite").mockImplementation(
+      (options, write, expectedDatabase) => {
+        const result = admit(options, write, expectedDatabase);
+        if (reservation && expectedDatabase === harness.db) {
+          queued.resolve();
+        }
+        return result;
+      },
+    );
     const embed = vi
       .spyOn(harness.provider, "embedBatch")
-      .mockImplementationOnce(async (inputs) => inputs.map(() => [0, 1]));
-    await expect(memoryManager.sync({ reason: "cli", force: true })).rejects.toThrow(
-      "malformed vector response",
-    );
+      .mockImplementationOnce(async (inputs) => inputs.map(() => [0, 1]))
+      .mockImplementationOnce(async (inputs) => {
+        reservation = await reservePublishedWriter();
+        return inputs.map(() => [0, 1, 0]);
+      });
+    const sync = memoryManager.sync({ reason: "cli", force: true });
+    void sync.catch(() => undefined);
+    try {
+      await Promise.race([queued.promise, sync]);
+      expect(
+        harness.db
+          .prepare("SELECT hash FROM memory_embedding_cache WHERE provider = 'openai'")
+          .all().length,
+      ).toBeGreaterThan(0);
+      reservation?.release();
+      await reservation?.done;
+      await expect(sync).rejects.toThrow("malformed vector response");
+    } finally {
+      reservation?.release();
+      await reservation?.done;
+      await sync.catch(() => undefined);
+    }
     expect(embed.mock.calls.length).toBeGreaterThan(1);
     expect(harness.db.prepare("SELECT provider FROM memory_embedding_cache").all()).toEqual([
       { provider: "unrelated" },
@@ -306,6 +364,120 @@ describe("memory manager reindex recovery", () => {
         .prepare("SELECT DISTINCT dims FROM memory_embedding_cache WHERE provider = 'openai'")
         .all(),
     ).toEqual([{ dims: 3 }]);
+  });
+
+  it.each(["commit", "purge", "replace"] as const)(
+    "revalidates generated cache writes after published writer admission (%s)",
+    async (scenario) => {
+      const cfg = createCfg({ sources: ["memory"], cacheEnabled: true });
+      const memoryManager = await openManager(cfg);
+      await memoryManager.sync({ reason: "cli", force: true });
+      const harness = memoryManager as unknown as ReindexHarness;
+      const publishedDb = harness.db;
+      if (!harness.provider) {
+        throw new Error("fixture provider missing");
+      }
+      await fs.writeFile(path.join(memoryDir, "alpha.md"), "New reusable alpha memory.");
+      const queued = createDeferred<void>();
+      const admit = sqliteRuntime.withOpenClawAgentDatabaseWrite;
+      let reservation: Awaited<ReturnType<typeof reservePublishedWriter>> | undefined;
+      let replacementDb: DatabaseSync | undefined;
+      vi.spyOn(sqliteRuntime, "withOpenClawAgentDatabaseWrite").mockImplementation(
+        (options, write, expectedDatabase) => {
+          const result = admit(options, write, expectedDatabase);
+          if (reservation && expectedDatabase === publishedDb) {
+            queued.resolve();
+          }
+          return result;
+        },
+      );
+      vi.spyOn(harness.provider, "embedBatch").mockImplementationOnce(async (inputs) => {
+        reservation = await reservePublishedWriter(() => {
+          if (scenario === "purge") {
+            recordMemorySessionTombstones({
+              agentId: "main",
+              sessionIds: ["forgotten-during-embedding"],
+            });
+          } else if (scenario === "replace") {
+            closeOpenClawAgentDatabasesForTest();
+            replacementDb = sqliteRuntime.openOpenClawAgentDatabase({ agentId: "main" }).db;
+          }
+        });
+        return inputs.map(() => [0, 1, 0]);
+      });
+      const sync = memoryManager.sync({ reason: "cli", force: true });
+      void sync.catch(() => undefined);
+      try {
+        await Promise.race([queued.promise, sync]);
+        expect(publishedDb.prepare("SELECT hash FROM memory_embedding_cache").all()).toEqual([]);
+        reservation?.release();
+        await reservation?.done;
+        if (scenario === "commit") {
+          await expect(sync).resolves.toBeUndefined();
+          expect(publishedDb.prepare("SELECT text FROM memory_index_chunks").all()).toEqual([
+            { text: "New reusable alpha memory." },
+          ]);
+          expect(publishedDb.prepare("SELECT embedding FROM memory_embedding_cache").all()).toEqual(
+            [{ embedding: "[0,1,0]" }],
+          );
+        } else {
+          await expect(sync).rejects.toThrow(
+            scenario === "replace" ? /closed or changed/ : /Memory index changed/,
+          );
+          expect(
+            (replacementDb ?? publishedDb).prepare("SELECT hash FROM memory_embedding_cache").all(),
+          ).toEqual([]);
+        }
+      } finally {
+        reservation?.release();
+        await reservation?.done;
+        await sync.catch(() => undefined);
+      }
+    },
+  );
+
+  it("drains accepted sync through provider and writer waits before closing", async () => {
+    const memoryManager = await openManager(createCfg({ sources: ["memory"], cacheEnabled: true }));
+    await memoryManager.sync({ reason: "baseline", force: true });
+    const harness = memoryManager as unknown as ReindexHarness; // SAFETY: this fixture owns the manager and provider.
+    if (!harness.provider) {
+      throw new Error("fixture provider missing");
+    }
+    await fs.writeFile(path.join(memoryDir, "alpha.md"), "Accepted sync survives close.");
+    const entered = createDeferred<void>();
+    const releaseProvider = createDeferred<void>();
+    vi.spyOn(harness.provider, "embedBatch").mockImplementationOnce(async (inputs) => {
+      entered.resolve();
+      await releaseProvider.promise;
+      return inputs.map(() => [0, 1, 0]);
+    });
+    const sync = memoryManager.sync({ reason: "closing", force: true });
+    void sync.catch(() => undefined);
+    let reservation: Awaited<ReturnType<typeof reservePublishedWriter>> | undefined;
+    let close: Promise<void> | undefined;
+    let closed = false;
+    try {
+      await Promise.race([entered.promise, sync]);
+      reservation = await reservePublishedWriter();
+      close = memoryManager.close().then(() => {
+        closed = true;
+      });
+      void close.catch(() => undefined);
+      await yieldToEventLoop();
+      expect(closed).toBe(false);
+      releaseProvider.resolve();
+      await yieldToEventLoop();
+      expect(closed).toBe(false);
+      reservation.release();
+      await Promise.all([sync, close, reservation.done]);
+      expect(harness.db.prepare("SELECT text FROM memory_index_chunks").all()).toEqual([
+        { text: "Accepted sync survives close." },
+      ]);
+    } finally {
+      releaseProvider.resolve();
+      reservation?.release();
+      await Promise.allSettled([sync, close, reservation?.done]);
+    }
   });
 
   it("retains completed embeddings across a failed rebuild and manager restart", async () => {

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -9,20 +9,21 @@ import {
   type ResolvedMemorySearchConfig,
 } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
 import {
-  readMemoryFile,
   MEMORY_EMBEDDING_CACHE_TABLE,
   MEMORY_INDEX_FTS_TABLE,
   MEMORY_INDEX_VECTOR_TABLE,
   type MemoryIndexIdentityState,
   type MemoryProviderStatus,
-  type MemoryReadResult,
   type MemorySearchManager,
   type MemorySessionSyncTarget,
   type MemorySyncParams,
 } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 import { normalizeAgentId } from "openclaw/plugin-sdk/routing";
 import { createPluginRuntimeStore } from "openclaw/plugin-sdk/runtime-store";
-import { borrowOpenClawAgentDatabase } from "openclaw/plugin-sdk/sqlite-runtime";
+import {
+  borrowOpenClawAgentDatabase,
+  withOpenClawAgentDatabaseWrite,
+} from "openclaw/plugin-sdk/sqlite-runtime";
 import { runInMemoryBackgroundContext } from "./background-context.js";
 import type { MemoryCoreAcquireLocalService } from "./embedding-local-service.js";
 import type { EmbeddingProvider, EmbeddingProviderRequest } from "./embeddings.js";
@@ -56,7 +57,6 @@ import {
   collectMemoryStorageStatus,
   resolveStatusProviderInfo,
 } from "./manager-status-state.js";
-import type { MemoryReindexRetryState } from "./manager-sync-base.js";
 import {
   enqueueMemoryTargetedSessionSync,
   hasTargetedSessionSyncParams,
@@ -64,18 +64,6 @@ import {
 import { resolvePersistedMemoryVectorIndexState } from "./manager-vector-rebuild-state.js";
 
 const log = createSubsystemLogger("memory");
-
-export async function closeAllMemoryIndexManagers(): Promise<void> {
-  getMemoryIndexManagerRegistry().embeddingProbeCache.clear();
-  await getMemoryIndexManagerRegistry().closeAll();
-}
-
-export async function closeMemoryIndexManagersForAgent(params: { agentId: string }): Promise<void> {
-  const registry = getMemoryIndexManagerRegistry();
-  for (const purpose of ["default", "maintenance"] as const) {
-    await registry.closeForAgent({ ...params, purpose });
-  }
-}
 
 export class MemoryIndexManager extends MemorySearchOrchestration implements MemorySearchManager {
   private readonly managerRegistry: MemoryManagerRegistry<MemoryIndexManager>;
@@ -171,30 +159,48 @@ export class MemoryIndexManager extends MemorySearchOrchestration implements Mem
             purpose,
             acquireLocalService: params.acquireLocalService,
           });
+          const databaseOptions = MemoryIndexDatabase.captureWriteOptions(
+            agentId,
+            settings.store.databasePath,
+            source?.publishedDatabase,
+          );
           return {
             key,
             create: async () => {
-              const manager = new MemoryIndexManager({
-                managerRegistry,
-                cacheKey: key,
-                cfg,
-                agentId,
-                workspaceDir,
-                settings,
-                providerRequirement,
-                purpose,
-                acquireLocalService: params.acquireLocalService,
-                maintenanceSource: source,
-              });
-              managerRegistry.track(manager, key);
+              let manager: MemoryIndexManager | undefined;
               try {
+                const create = () => {
+                  manager = new MemoryIndexManager({
+                    managerRegistry,
+                    cacheKey: key,
+                    cfg,
+                    agentId,
+                    workspaceDir,
+                    settings,
+                    providerRequirement,
+                    purpose,
+                    acquireLocalService: params.acquireLocalService,
+                    maintenanceSource: source,
+                    databaseOptions,
+                  });
+                  managerRegistry.track(manager, key);
+                  return manager;
+                };
+                manager =
+                  purpose === "status"
+                    ? create()
+                    : await withOpenClawAgentDatabaseWrite(
+                        databaseOptions,
+                        create,
+                        source?.publishedDatabase.db,
+                      );
                 if (params.inspectSources) {
                   await manager.inspectDiagnosticSourceState();
                 }
                 return manager;
               } catch (error) {
                 try {
-                  await manager.close();
+                  await manager?.close();
                 } catch (cleanupError) {
                   throw new AggregateError(
                     [error, cleanupError],
@@ -223,26 +229,29 @@ export class MemoryIndexManager extends MemorySearchOrchestration implements Mem
     purpose: MemoryIndexManagerPurpose;
     acquireLocalService?: MemoryCoreAcquireLocalService;
     maintenanceSource?: MemoryIndexManager;
+    databaseOptions: Parameters<typeof withOpenClawAgentDatabaseWrite>[0] & { path: string };
   }) {
     super();
     this.managerRegistry = params.managerRegistry;
     const source = params.maintenanceSource;
-    const effectiveSettings =
-      source?.settings ?? resolveEffectiveMemorySearchSettings(params.settings);
+    const effectiveSettings = resolveEffectiveMemorySearchSettings(params.settings);
+    const dbPath = params.databaseOptions.path;
     this.cacheKey = params.cacheKey;
     this.acquireLocalService = params.acquireLocalService;
     this.purpose = params.purpose;
     this.cfg = params.cfg;
     this.agentId = params.agentId;
     this.workspaceDir = params.workspaceDir;
-    this.settings = effectiveSettings;
+    this.settings = {
+      ...effectiveSettings,
+      store: { ...effectiveSettings.store, databasePath: dbPath },
+    };
     this.providerRequirement = params.providerRequirement;
     this.requestedProvider = effectiveSettings.provider;
     this.providerLifecycle = createPendingMemoryProviderLifecycle(this.requestedProvider);
     for (const memorySource of effectiveSettings.sources) {
       this.sources.add(memorySource);
     }
-    const dbPath = resolveUserPath(effectiveSettings.store.databasePath);
     const vectorEnabled = effectiveSettings.store.vector.enabled;
     const readOnly = this.purpose === "status";
     if (source && (!source.publishedDatabase.db.isOpen || this.purpose !== "maintenance")) {
@@ -250,12 +259,17 @@ export class MemoryIndexManager extends MemorySearchOrchestration implements Mem
     }
     const connection = readOnly
       ? openMemoryDatabaseReadOnlyAtPath(dbPath, vectorEnabled, this.agentId)
-      : borrowOpenClawAgentDatabase({ agentId: this.agentId, path: dbPath });
+      : borrowOpenClawAgentDatabase(params.databaseOptions);
     if (source && connection.db !== source.publishedDatabase.db) {
       connection.release();
       throw new Error("Memory maintenance source connection changed");
     }
-    this.publishedDatabase = new MemoryIndexDatabase(connection.db, connection.release, readOnly);
+    this.publishedDatabase = new MemoryIndexDatabase(
+      connection.db,
+      connection.release,
+      readOnly,
+      params.databaseOptions,
+    );
     try {
       this.providerKey = this.computeProviderKey();
       this.cache = {
@@ -278,14 +292,13 @@ export class MemoryIndexManager extends MemorySearchOrchestration implements Mem
       if (meta?.vectorDims) {
         this.vector.dims = meta.vectorDims;
       }
-      const initialIndexIdentity = this.resolveCurrentIndexIdentityState({
+      this.indexIdentityState = this.resolveCurrentIndexIdentityState({
         meta,
         providerKeyKnown: false,
       });
-      this.indexIdentityState = initialIndexIdentity;
       this.indexIdentityDirty =
-        initialIndexIdentity.status === "mismatched" ||
-        (initialIndexIdentity.status === "missing" && this.sources.has("memory"));
+        this.indexIdentityState.status === "mismatched" ||
+        (this.indexIdentityState.status === "missing" && this.sources.has("memory"));
       const transient = isTransientMemoryIndexManagerPurpose(this.purpose);
       const invalidatedSources = new Set(
         (
@@ -327,28 +340,23 @@ export class MemoryIndexManager extends MemorySearchOrchestration implements Mem
     if (this.purpose === "status") {
       throw new Error("Memory status managers are read-only");
     }
-    return await this.withPublishedDatabase(() => this.syncPublished(params));
-  }
-
-  adoptReindexRetryState(snapshot: MemoryReindexRetryState): void {
-    this.restoreReindexRetryState(snapshot);
-  }
-
-  private async syncPublished(params?: MemorySyncParams): Promise<void> {
     if (this.closing || this.closed) {
       return;
     }
-    if (
-      hasTargetedSessionSyncParams(params) &&
-      (this.queuedSessionSync !== null ||
-        this.queuedArchiveFiles.size > 0 ||
-        this.queuedSessions.size > 0)
-    ) {
-      // A failed queued batch stays manager-owned. Route the next targeted
-      // call through the queue even while idle so it adopts that retained work.
-      return await this.enqueueTargetedSessionSync(params);
-    }
-    return await this.syncAdmitted(params);
+    // Close must drain accepted syncs through provider initialization and final writes.
+    return await this.withManagerOperation(async () => {
+      if (
+        hasTargetedSessionSyncParams(params) &&
+        (this.queuedSessionSync !== null ||
+          this.queuedArchiveFiles.size > 0 ||
+          this.queuedSessions.size > 0)
+      ) {
+        // A failed queued batch stays manager-owned. Route the next targeted
+        // call through the queue even while idle so it adopts that retained work.
+        return await this.enqueueTargetedSessionSync(params);
+      }
+      return await this.syncAdmitted(params);
+    });
   }
 
   protected async syncPublishedIndexInBackground(params: { reason: string }): Promise<void> {
@@ -511,20 +519,6 @@ export class MemoryIndexManager extends MemorySearchOrchestration implements Mem
       },
       targets,
     );
-  }
-
-  async readFile(params: {
-    relPath: string;
-    from?: number;
-    lines?: number;
-  }): Promise<MemoryReadResult> {
-    return await readMemoryFile({
-      workspaceDir: this.workspaceDir,
-      extraPaths: this.settings.extraPaths,
-      relPath: params.relPath,
-      from: params.from,
-      lines: params.lines,
-    });
   }
 
   status(): MemoryProviderStatus {
@@ -724,12 +718,13 @@ export class MemoryIndexManager extends MemorySearchOrchestration implements Mem
   }
 }
 
+// Provider layers depend on registry contracts; concrete assembly stays with this manager.
 const managerRegistryStore = createPluginRuntimeStore<MemoryManagerRegistry<MemoryIndexManager>>({
   key: "memory-core:manager-registry",
   errorMessage: "Memory manager registry is not initialized",
 });
 
-function getMemoryIndexManagerRegistry(): MemoryManagerRegistry<MemoryIndexManager> {
+export function getMemoryIndexManagerRegistry(): MemoryManagerRegistry<MemoryIndexManager> {
   let registry = managerRegistryStore.tryGetRuntime();
   if (!registry) {
     registry = new MemoryManagerRegistry(getMemoryManagerLifecycle());

--- a/scripts/lib/vitest-build-prerequisites.mts
+++ b/scripts/lib/vitest-build-prerequisites.mts
@@ -194,6 +194,12 @@ const runtimeConsumers = [
     dir: "",
   },
   {
+    file: "src/config/sessions/session-accessor.sqlite-reclamation-memory.test.ts",
+    configs: ["test/vitest/vitest.runtime-config.config.ts"],
+    mode: "runtime",
+    dir: "src",
+  },
+  {
     file: "src/gateway/server.chat-cli-auth.test.ts",
     configs: [
       "test/vitest/vitest.gateway-server-isolated.config.ts",

--- a/src/config/sessions/session-accessor.sqlite-reclamation-memory.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-reclamation-memory.test.ts
@@ -1,0 +1,176 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { setImmediate } from "node:timers/promises";
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { runSqliteImmediateTransactionSync } from "../../infra/sqlite-transaction.js";
+import { resetPluginStateStoreForTests } from "../../plugin-sdk/plugin-state-test-runtime.js";
+import {
+  cleanupPluginLoaderFixturesForTest,
+  clearPluginLoaderCache,
+} from "../../plugins/loader.test-fixtures.js";
+import {
+  closeActiveMemorySearchManagersCore,
+  getActiveMemorySearchManagerCore,
+} from "../../plugins/memory-runtime.js";
+import { resetStandaloneMemoryRegistrySlot } from "../../plugins/memory-runtime.test-support.js";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  openOpenClawAgentDatabase,
+} from "../../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import {
+  deleteSessionEntryLifecycle,
+  loadSessionEntry,
+  replaceSessionEntry,
+} from "./session-accessor.js";
+import { replaceTranscriptEvents } from "./session-accessor.sqlite-transcript-write.js";
+
+const checkpoint = vi.hoisted(() => ({
+  startForeground: undefined as (() => void) | undefined,
+  authorizations: [] as Promise<void>[],
+}));
+
+vi.mock("./session-accessor.sqlite-archive.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./session-accessor.sqlite-archive.js")>();
+  return {
+    ...actual,
+    runSqliteTranscriptArchiveWorkerOperation: (
+      params: Parameters<typeof actual.runSqliteTranscriptArchiveWorkerOperation>[0],
+    ) =>
+      actual.runSqliteTranscriptArchiveWorkerOperation({
+        ...params,
+        onCommitRequest: params.onCommitRequest
+          ? () => {
+              checkpoint.startForeground?.();
+              // Let prepared foreground continuations run before the queued parent
+              // authorizer, while the actual reclamation Worker holds its writer lock.
+              const authorization = setImmediate().then(() => {
+                params.onCommitRequest?.();
+              });
+              checkpoint.authorizations.push(authorization);
+              void authorization.catch(() => {});
+            }
+          : undefined,
+      }),
+  };
+});
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+describe("reclamation with the public memory runtime", () => {
+  let workspace: string;
+  let closeManager: (() => Promise<void>) | undefined;
+
+  afterAll(cleanupPluginLoaderFixturesForTest);
+
+  beforeEach(async () => {
+    clearPluginLoaderCache();
+    resetStandaloneMemoryRegistrySlot();
+    const root = await fs.realpath(tempDirs.make("openclaw-reclamation-memory-"));
+    workspace = path.join(root, "workspace");
+    await fs.mkdir(workspace);
+    await fs.writeFile(
+      path.join(workspace, "MEMORY.md"),
+      "A retained memory independent of the deleted session.",
+    );
+    vi.stubEnv("OPENCLAW_STATE_DIR", path.join(root, "state"));
+  });
+
+  afterEach(async () => {
+    checkpoint.startForeground = undefined;
+    await Promise.allSettled(checkpoint.authorizations.splice(0));
+    await closeManager?.();
+    closeManager = undefined;
+    await closeActiveMemorySearchManagersCore();
+    resetStandaloneMemoryRegistrySlot();
+    clearPluginLoaderCache();
+    closeOpenClawAgentDatabasesForTest();
+    resetPluginStateStoreForTests();
+    closeOpenClawStateDatabaseForTest();
+    vi.unstubAllEnvs();
+  });
+
+  it("settles borrowed cache cleanup and guarded deletion without blocking the authorizer", async () => {
+    const cfg: OpenClawConfig = {
+      plugins: {
+        enabled: true,
+        allow: ["memory-core"],
+        slots: { memory: "memory-core" },
+      },
+      memory: {
+        search: {
+          provider: "none",
+          cache: { enabled: true },
+          store: { vector: { enabled: false } },
+        },
+      },
+      agents: { defaults: { workspace }, list: [{ id: "main", default: true }] },
+    };
+    const acquired = await getActiveMemorySearchManagerCore({
+      cfg,
+      agentId: "main",
+      purpose: "cli",
+    });
+    const manager = acquired.manager;
+    if (!manager?.sync) {
+      throw new Error(acquired.error ?? "expected the builtin memory manager");
+    }
+    closeManager = manager.close?.bind(manager);
+    const sync = manager.sync.bind(manager);
+    await sync({ reason: "prepare-published-index", force: true });
+    const initial = manager.status();
+    const storePath = initial.dbPath;
+    const maxEntries = initial.cache?.maxEntries;
+    if (!storePath || !maxEntries) {
+      throw new Error("expected a borrowed database with the runtime cache bound");
+    }
+    const { db } = openOpenClawAgentDatabase({ agentId: "main", path: storePath });
+    const sessionKey = "agent:main:memory-reclamation";
+    const sessionId = "memory-reclamation";
+    await replaceSessionEntry(
+      { agentId: "main", storePath, sessionKey },
+      { sessionId, updatedAt: 1 },
+    );
+    await replaceTranscriptEvents({ agentId: "main", storePath, sessionKey, sessionId }, [
+      { type: "session", id: sessionId, content: "retire this unrelated session" },
+    ]);
+    const insert = db.prepare(`INSERT INTO memory_embedding_cache
+      (provider, model, provider_key, hash, embedding, dims, updated_at)
+      VALUES ('fixture', 'fixture-model', 'fixture-owner', ?, '[1]', 1, ?)`);
+    runSqliteImmediateTransactionSync(db, () => {
+      for (let index = 0; index <= maxEntries; index += 1) {
+        insert.run(`entry-${index}`, index);
+      }
+    });
+    expect(manager.status().cache?.entries).toBe(maxEntries + 1);
+    let write: Promise<void> | undefined;
+    checkpoint.startForeground = () => {
+      write = sync({ reason: "reclamation-overlap" });
+      void write.catch(() => {});
+    };
+    const deletion = await deleteSessionEntryLifecycle({
+      archiveTranscript: true,
+      commitGuard: () => {},
+      storePath,
+      target: { canonicalKey: sessionKey, storeKeys: [sessionKey] },
+    }).then(
+      (result) => ({ result }),
+      (error: unknown) => ({ error }),
+    );
+    const outcomes = await Promise.allSettled(write ? [write] : []);
+    const authorizations = await Promise.allSettled(checkpoint.authorizations);
+    expect(outcomes).toEqual([{ status: "fulfilled", value: undefined }]);
+    expect(deletion).toMatchObject({ result: { deleted: true } });
+    expect(authorizations).toEqual([{ status: "fulfilled", value: undefined }]);
+    expect(loadSessionEntry({ agentId: "main", sessionKey, storePath })).toBeUndefined();
+    expect(manager.status().cache?.entries).toBe(maxEntries);
+    expect(
+      db
+        .prepare("SELECT hash FROM memory_embedding_cache WHERE hash IN (?, ?)")
+        .all("entry-0", `entry-${maxEntries}`),
+    ).toEqual([{ hash: `entry-${maxEntries}` }]);
+    expect(manager.status().chunks).toBeGreaterThan(0);
+  });
+});

--- a/src/infra/sqlite-transaction.test.ts
+++ b/src/infra/sqlite-transaction.test.ts
@@ -5,6 +5,7 @@ import type { Readable } from "node:stream";
 import { isMainThread, threadId } from "node:worker_threads";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { createDeferredCore } from "../shared/deferred.js";
 import { getNodeSqliteKysely } from "./kysely-sync.js";
 import { requireNodeSqlite } from "./node-sqlite.js";
 import {
@@ -826,6 +827,103 @@ describe("runSqliteImmediateTransaction", () => {
       expect(write).not.toHaveBeenCalled();
       expect(db.isOpen).toBe(false);
       expect(writer.prepare("SELECT id FROM entries").all()).toEqual([]);
+    },
+  );
+
+  it("preserves a failed rollback caught while waiting for owner admission", async () => {
+    const db = createDatabase();
+    db.exec("PRAGMA max_page_count=3");
+    const entered = createDeferredCore();
+    const release = createDeferredCore();
+    const write = vi.fn(() => "unexpected");
+    const pending = runSqliteImmediateTransaction(
+      db,
+      async () => write,
+      undefined,
+      async (admittedWrite) => {
+        entered.resolve();
+        await release.promise;
+        return admittedWrite();
+      },
+    );
+    let primaryError: unknown;
+    try {
+      await entered.promise;
+      try {
+        runSqliteImmediateTransactionSync(db, () =>
+          runSqliteImmediateTransactionSync(db, () =>
+            db.prepare("INSERT INTO entries VALUES ('full', zeroblob(65536))").run(),
+          ),
+        );
+      } catch (error) {
+        primaryError = error;
+      }
+      expect(primaryError).toMatchObject({ errcode: 13 });
+      expect(db.isOpen).toBe(false);
+      release.resolve();
+      await expect(pending).rejects.toBe(primaryError);
+      expect(write).not.toHaveBeenCalled();
+    } finally {
+      release.resolve();
+      await pending.catch(() => undefined);
+    }
+  });
+
+  it("waits for the owner's admission before beginning a prepared write", async () => {
+    const db = createDatabase();
+    const admissionStarted = createDeferredCore();
+    const releaseAdmission = createDeferredCore();
+    const pending = runSqliteImmediateTransaction(
+      db,
+      async () => () => {
+        db.prepare("INSERT INTO entries(id, value) VALUES ('admitted', 'value')").run();
+        return "committed";
+      },
+      undefined,
+      async (write) => {
+        admissionStarted.resolve();
+        await releaseAdmission.promise;
+        return write();
+      },
+    );
+    try {
+      const first = await Promise.race([
+        admissionStarted.promise.then(() => "admission"),
+        pending.then(() => "committed"),
+      ]);
+      expect(first).toBe("admission");
+      expect(db.isTransaction).toBe(false);
+      expect(readEntries(db)).toEqual([]);
+      releaseAdmission.resolve();
+      await expect(pending).resolves.toBe("committed");
+      expect(readEntries(db)).toEqual(["admitted"]);
+    } finally {
+      releaseAdmission.resolve();
+      await pending.catch(() => undefined);
+    }
+  });
+
+  it.each(["retired", "transaction"])(
+    "does not write after owner admission is %s",
+    async (state) => {
+      const db = createDatabase();
+      const write = vi.fn(() => "unexpected");
+      await expect(
+        runSqliteImmediateTransaction(
+          db,
+          async () => write,
+          undefined,
+          async (admittedWrite) => {
+            if (state === "retired") {
+              throw new Error("owner retired");
+            }
+            db.exec("BEGIN");
+            return admittedWrite();
+          },
+        ),
+      ).rejects.toThrow(state === "retired" ? "owner retired" : /transaction/);
+      expect(write).not.toHaveBeenCalled();
+      expect(db.isTransaction).toBe(state === "transaction");
     },
   );
 

--- a/src/infra/sqlite-transaction.ts
+++ b/src/infra/sqlite-transaction.ts
@@ -404,6 +404,7 @@ export async function runSqliteImmediateTransaction<T>(
   db: DatabaseSync,
   prepare: () => Promise<(() => T) | undefined>,
   options?: SqliteTransactionOptions,
+  admit: (write: () => T) => T | Promise<T> = (write) => write(),
 ): Promise<T | undefined> {
   assertTransactionUsable(db);
   if (db.isTransaction) {
@@ -421,21 +422,28 @@ export async function runSqliteImmediateTransaction<T>(
       return undefined;
     }
     try {
-      return runWithSqliteBusyTimeout(
-        db,
-        0,
-        (restore) =>
-          runSqliteImmediateTransactionSync(
-            db,
-            () => {
-              entered = true;
-              restore();
-              return operation();
-            },
-            options,
-          ),
-        { lockFailureReporting: "suppress" },
-      );
+      return await admit(() => {
+        assertTransactionUsable(db);
+        // Owner admission may wait; never join a transaction opened during that wait.
+        if (db.isTransaction) {
+          throw new Error("Asynchronous SQLite preparation cannot join an existing transaction");
+        }
+        return runWithSqliteBusyTimeout(
+          db,
+          0,
+          (restore) =>
+            runSqliteImmediateTransactionSync(
+              db,
+              () => {
+                entered = true;
+                restore();
+                return operation();
+              },
+              options,
+            ),
+          { lockFailureReporting: "suppress" },
+        );
+      });
     } catch (error) {
       if (entered || !isSqliteLockError(error) || performance.now() >= deadline) {
         throw error;

--- a/src/state/openclaw-memory-write-admission.test.ts
+++ b/src/state/openclaw-memory-write-admission.test.ts
@@ -1,0 +1,190 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi, type MockInstance } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type {
+  OpenKeyedStoreOptions,
+  PluginStateKeyedStore,
+} from "../plugin-sdk/plugin-state-runtime.js";
+import {
+  createPluginStateKeyedStoreForTests,
+  resetPluginStateStoreForTests,
+} from "../plugin-sdk/plugin-state-test-runtime.js";
+import type { MemoryPluginRuntime } from "../plugins/registry-contribution-types.js";
+import { createDeferredCore } from "../shared/deferred.js";
+import { recordAgentDatabaseAdmissions } from "./agent-database-admission.js";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  openOpenClawAgentDatabase,
+} from "./openclaw-agent-db.js";
+import {
+  runOpenClawAgentWriteAdmission,
+  SQLITE_SESSION_WRITER_QUEUES,
+} from "./openclaw-agent-write-admission.js";
+import { closeOpenClawStateDatabaseForTest } from "./openclaw-state-db.js";
+
+const { configureMemoryCoreDreamingState, getMemorySearchManager, memoryRuntime } =
+  await vi.importActual<{
+    configureMemoryCoreDreamingState: (
+      open: <T>(options: OpenKeyedStoreOptions) => PluginStateKeyedStore<T>,
+    ) => void;
+    getMemorySearchManager: MemoryPluginRuntime["getMemorySearchManager"];
+    memoryRuntime: MemoryPluginRuntime;
+  }>("../../extensions/memory-core/runtime-api.js");
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+describe("memory manager state owner capture", () => {
+  let root: string;
+  let workspace: string;
+  let config: OpenClawConfig;
+  let originalEnv: NodeJS.ProcessEnv;
+  let otherEnv: NodeJS.ProcessEnv;
+  let cwd: MockInstance<() => string>;
+
+  beforeEach(async () => {
+    root = await fs.realpath(tempDirs.make("openclaw-memory-write-owner-"));
+    workspace = path.join(root, "workspace");
+    await fs.mkdir(workspace);
+    await fs.writeFile(path.join(workspace, "MEMORY.md"), "Original memory.");
+    originalEnv = { OPENCLAW_STATE_DIR: path.join(root, "state") };
+    otherEnv = { OPENCLAW_STATE_DIR: path.join(root, "other", "state") };
+    configureMemoryCoreDreamingState(<T>(options: OpenKeyedStoreOptions) =>
+      createPluginStateKeyedStoreForTests<T>("memory-core", { ...options, env: originalEnv }),
+    );
+    vi.stubEnv("OPENCLAW_STATE_DIR", originalEnv.OPENCLAW_STATE_DIR);
+    config = {
+      plugins: { enabled: false },
+      agents: { defaults: { workspace }, list: [{ id: "main" }] },
+      memory: { search: { provider: "none", store: { vector: { enabled: false } } } },
+    };
+    openOpenClawAgentDatabase({ agentId: "main", env: originalEnv });
+    // Warm the supported runtime entry before the test controls queue admission.
+    const warm = await getMemorySearchManager({ cfg: config, agentId: "main", purpose: "status" });
+    expect(warm.manager).not.toBeNull();
+    await warm.manager?.close?.();
+    vi.stubEnv("OPENCLAW_STATE_DIR", "state");
+    cwd = vi.spyOn(process, "cwd").mockReturnValue(root);
+  });
+
+  afterEach(async () => {
+    recordAgentDatabaseAdmissions([], { env: originalEnv });
+    recordAgentDatabaseAdmissions([], { env: otherEnv });
+    await memoryRuntime.closeAllMemorySearchManagers?.();
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+    closeOpenClawAgentDatabasesForTest();
+    resetPluginStateStoreForTests();
+    closeOpenClawStateDatabaseForTest();
+    configureMemoryCoreDreamingState(() => {
+      throw new Error("memory test state is closed");
+    });
+  });
+
+  function refuse(env: NodeJS.ProcessEnv) {
+    recordAgentDatabaseAdmissions(
+      [
+        {
+          agentId: "main",
+          paths: [],
+          embeddedOwnerId: "other",
+          code: "agent-database-ownership-mismatch",
+          reason: "fixture state owner refuses this agent",
+          repairHint: "fixture refusal",
+        },
+      ],
+      { env },
+    );
+  }
+
+  it("keeps creation on its admitted state owner after cwd changes", async () => {
+    const database = openOpenClawAgentDatabase({ agentId: "main", env: originalEnv });
+    refuse(otherEnv);
+    const entered = createDeferredCore();
+    const release = createDeferredCore();
+    const blocker = runOpenClawAgentWriteAdmission(
+      { agentId: "main", path: database.path, env: originalEnv },
+      async () => {
+        entered.resolve();
+        await release.promise;
+      },
+    );
+    await entered.promise;
+    const creating = getMemorySearchManager({ cfg: config, agentId: "main", purpose: "cli" });
+    try {
+      await vi.waitFor(() => {
+        expect(SQLITE_SESSION_WRITER_QUEUES.get(database.path)?.pending.length).toBeGreaterThan(0);
+      });
+      cwd.mockReturnValue(path.join(root, "other"));
+      release.resolve();
+      const result = await creating;
+      expect(result.error).toBeUndefined();
+      expect(result.manager).not.toBeNull();
+      expect(result.manager?.status().dbPath).toBe(database.path);
+      await result.manager?.close?.();
+    } finally {
+      release.resolve();
+      await Promise.allSettled([creating, blocker]);
+    }
+  });
+
+  it("keeps replacement on the state owner chosen before prior manager close", async () => {
+    const acquired = await getMemorySearchManager({ cfg: config, agentId: "main" });
+    const manager = acquired.manager;
+    if (!manager?.close) {
+      throw new Error(acquired.error ?? "Expected a closable memory manager");
+    }
+    const originalClose = manager.close.bind(manager);
+    const entered = createDeferredCore();
+    const release = createDeferredCore();
+    vi.spyOn(manager, "close").mockImplementation(async () => {
+      entered.resolve();
+      await release.promise;
+      await originalClose();
+    });
+    refuse(otherEnv);
+    const creating = getMemorySearchManager({
+      cfg: {
+        ...config,
+        memory: { search: { ...config.memory?.search, query: { minScore: 0.01 } } },
+      },
+      agentId: "main",
+    });
+    try {
+      await Promise.race([
+        entered.promise,
+        creating.then(() => {
+          throw new Error("Replacement skipped its previous manager's close");
+        }),
+      ]);
+      cwd.mockReturnValue(path.join(root, "other"));
+      release.resolve();
+      const result = await creating;
+      expect(result.error).toBeUndefined();
+      expect(result.manager).not.toBeNull();
+      await result.manager?.close?.();
+    } finally {
+      release.resolve();
+      await Promise.allSettled([creating]);
+    }
+  });
+
+  it("rechecks retained writes against their original state owner after cwd changes", async () => {
+    const acquired = await getMemorySearchManager({ cfg: config, agentId: "main", purpose: "cli" });
+    const manager = acquired.manager;
+    if (!manager?.sync) {
+      throw new Error(acquired.error ?? "Expected a writable memory manager");
+    }
+    await manager.sync({ reason: "baseline", force: true });
+    const database = openOpenClawAgentDatabase({ agentId: "main", env: originalEnv });
+    const before = database.db.prepare("SELECT text FROM memory_index_chunks").all();
+    await fs.writeFile(path.join(workspace, "MEMORY.md"), "Changed after admission was revoked.");
+    refuse(originalEnv);
+    cwd.mockReturnValue(path.join(root, "other"));
+    await expect(manager.sync({ reason: "revoked", force: true })).rejects.toThrow(
+      "fixture state owner refuses this agent",
+    );
+    expect(database.db.prepare("SELECT text FROM memory_index_chunks").all()).toEqual(before);
+  });
+});

--- a/test/scripts/ci-test-timings.test.ts
+++ b/test/scripts/ci-test-timings.test.ts
@@ -32,6 +32,7 @@ import {
   createCompactSplitTimingGeneration,
   runtimePlacementTimingKey,
 } from "../../scripts/lib/vitest-shard-metadata.mts";
+import { fullSuiteVitestShards } from "../vitest/vitest.test-shards.mjs";
 
 function uiLog(files: Record<string, number>, overhead = 0.6) {
   const body = Object.values(files).reduce((sum, value) => sum + value, 0);
@@ -173,23 +174,52 @@ describe("runtime placement observations", () => {
   it.each(["push", "pull-request"] as const)(
     "admits complete %s runtime placement without changing inventories or precise capacity",
     (compactMode) => {
-      const blacksmith = testTimings.readCompactGroupTimings("blacksmith");
-      const withoutPlacement = Object.fromEntries(
-        Object.entries(blacksmith).filter(([entry]) => !entry.startsWith("runtime-placement#")),
-      );
-      const spy = vi.spyOn(testTimings, "readCompactGroupTimings");
+      const originalShards = fullSuiteVitestShards.slice();
+      const runtimeConfig = "test/vitest/vitest.runtime-config.config.ts";
+      const infrastructure = "test/vitest/vitest.infra.config.ts";
+      const configs = new Set([
+        runtimeConfig,
+        infrastructure,
+        "test/vitest/vitest.gateway-methods.config.ts",
+      ]);
+      const spy = vi.spyOn(testTimings, "readCompactGroupTimings").mockReturnValue({});
       const options = {
         compactMode,
         runnerBackend: "hybrid",
         includeReleaseOnlyPluginShards: false,
       };
       try {
-        spy.mockImplementation((profile) => (profile === "blacksmith" ? withoutPlacement : {}));
+        fullSuiteVitestShards.splice(
+          0,
+          fullSuiteVitestShards.length,
+          ...originalShards
+            .map((shard) => ({
+              ...shard,
+              projects: shard.projects.filter((config) => configs.has(config)),
+            }))
+            .filter((shard) => shard.projects.length > 0),
+        );
         const before = createNodeTestShardBundles(options);
+        const runtimeGroups = before
+          .flatMap((job) => job.groups)
+          .filter((group) => group.pretestBuildMode === "runtime");
+        expect(runtimeGroups).toHaveLength(3);
         const selected = ["src/config/state-startup-corpus.test.ts"];
         const preciseBefore = createSelectedNodeTestShardBundles(selected, {
           runnerBackend: "hybrid",
         });
+        // Synthetic costs follow the emitted readers; recorded measurements belong
+        // to their exact historical membership and must not be reused after growth.
+        const blacksmith = Object.fromEntries(
+          runtimeGroups.map((group) => [
+            runtimePlacementTimingKey(group)!,
+            group.configs.includes(runtimeConfig)
+              ? 200
+              : group.configs.includes(infrastructure)
+                ? 300
+                : 20,
+          ]),
+        );
         spy.mockImplementation((profile) => (profile === "blacksmith" ? blacksmith : {}));
         const after = createNodeTestShardBundles(options);
         if (compactMode === "pull-request") {
@@ -239,6 +269,26 @@ describe("runtime placement observations", () => {
         expect(crossing.every((group) => group.env?.OPENCLAW_VITEST_MAX_WORKERS === "2")).toBe(
           true,
         );
+        const configReader = runtimeGroups.find((group) => group.configs.includes(runtimeConfig))!;
+        spy.mockImplementation((profile) =>
+          profile === "blacksmith"
+            ? Object.fromEntries(
+                Object.entries(blacksmith).filter(
+                  ([entry]) => entry !== runtimePlacementTimingKey(configReader),
+                ),
+              )
+            : {},
+        );
+        const unmeasured = createNodeTestShardBundles(options);
+        expect(unmeasured.map((job) => [job.checkName, job.runner, job.groups])).toEqual(
+          before.map((job) => [job.checkName, job.runner, job.groups]),
+        );
+        const readerJob = unmeasured.find((job) =>
+          job.groups.some((group) => group.configs.includes(runtimeConfig)),
+        )!;
+        // The 300s sibling costs 261s in hybrid plus one 100s build. Unknown readers
+        // retain a positive cost instead of disappearing from that shared estimate.
+        expect(readerJob.predictedSeconds).toBeGreaterThan(361);
         spy.mockImplementation((profile) =>
           profile === "blacksmith"
             ? Object.fromEntries(
@@ -257,6 +307,7 @@ describe("runtime placement observations", () => {
         expect(unfit.some((job) => (job.predictedSeconds ?? 0) > 440)).toBe(true);
       } finally {
         spy.mockRestore();
+        fullSuiteVitestShards.splice(0, fullSuiteVitestShards.length, ...originalShards);
       }
     },
   );

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -254,6 +254,15 @@ describe("test runtime prerequisites", () => {
     [
       "runtime-config",
       ["config/config-startup-corpus.test.ts", "config/state-startup-corpus.test.ts"],
+      "runtime",
+    ],
+    [
+      "runtime-config",
+      [
+        "config/config-startup-corpus.test.ts",
+        "config/state-startup-corpus.test.ts",
+        "config/sessions/session-accessor.sqlite-reclamation-memory.test.ts",
+      ],
       undefined,
     ],
     ["agents-core", ["simple-completion-runtime.plugin-scope.test.ts"], "runtime"],


### PR DESCRIPTION
Related: #130741. Builds on #146491 and #146563.

## What Problem This Solves

Memory indexing could enter synchronous database writes while session cleanup owned the writer, delaying Gateway work. Queued syncs could also outlive manager shutdown or reopen a retired source connection.

## Why This Change Was Made

Route published memory writes through the existing per-agent admission owner, retaining the selected state root and exact borrowed connection. Prepare embeddings and source data before admission, then recheck source, generation, and revision predicates before writing. Shadow publication keeps ATTACH, transaction, and DETACH in one synchronous admitted operation. Registry ownership remains in its existing module and public facade.

## User Impact

Conflicting memory writes wait asynchronously, accepted syncs settle before manager shutdown, and stale borrowed handles fail without reopening a replacement. Existing schemas, retention, FIFO ordering, and integrity checks remain intact.

## Evidence

Regressions reproduced premature cache writes, lost shutdown ownership, state-root retargeting, and retired-source reopening. Focused memory, transaction, lifecycle, and real reclamation-worker overlap tests pass, along with the component build and independent review.

Every production file in this repair is unchanged from the previous reviewed head. The refreshed integration preserves main's timing assertions for both push and pull-request modes, using synthetic costs matched to current group membership. Seven selected timing/prerequisite cases and all 63 memory-search cases passed, along with scoped types, lint, documentation checks, and a fresh independent P1 review.

The prior full canonical gate, 99 integration cases, 119 fixture cases, and normal build remain separately bound evidence; that full build and those suites were not rerun for this refresh. Exact-head CI follows publication. The real-OpenAI Swarm campaign remains outstanding, and this component proof does not establish the overall 500 ms target.
