### PR TITLE
fix: restore the CI boundary routing fixture

### DIFF
--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -1752,6 +1752,17 @@ if (args[args.indexOf("--stripe") + 1] === process.env.FAIL_TYPE_STRIPE) process
     for (const directory of ["scripts/lib", "packages", "node_modules"]) {
       symlinkSync(path.resolve(directory), path.join(root, directory), "dir");
     }
+    writeFileSync(path.join(root, "scripts/tsx.mjs"), "");
+    writeFileSync(
+      path.join(root, "scripts/check-extension-plugin-sdk-boundary.mts"),
+      `
+import { appendFileSync } from "node:fs";
+import path from "node:path";
+const script = path.relative(process.cwd(), process.argv[1]).split(path.sep).join("/");
+const command = ["node", ...process.execArgv, script, ...process.argv.slice(2)].join(" ");
+appendFileSync(process.env.TYPE_CALLS, [process.env.TYPE_ROW, process.env.OPENCLAW_LOCAL_CHECK ?? "<unset>", command].join("\\t") + "\\n");
+`,
+    );
     writeFileSync(
       path.join(root, "scripts/check-native-state-schema-version.mjs"),
       `


### PR DESCRIPTION
Related: #146771

## What Problem This Solves

The CI routing fixture fails after the boundary checks switch to a direct Node invocation because its temporary checkout lacks that command's preload and recorder.

## User Impact

There is no OpenClaw runtime behavior change. The existing CI guard can again verify that core test types have one owner and all other boundary commands still run.

## Why This Change Was Made

Add a fixture-local no-op preload and checker recorder that captures the actual Node options, script path and arguments. The real runner and Node invocation remain in use; the native-state recorder and every existing command, row and central type-owner assertion stay unchanged. No production fallback or test-selection change is introduced.

## Evidence

The exact failing test reproduced `ERR_MODULE_NOT_FOUND` for the fixture preload before the change and passed afterward. All 25 affected type-routing cases passed, as did formatting, targeted lint and diff checks. Fresh managed review found no actionable P0–P2 issue.

The original PR's selected Node jobs ran the checker and runner test files but omitted this downstream workflow fixture. The broader CI failure was preserved; no unchanged CI rerun was used. This is an eleven-line test-fixture repair for #146771, not a new performance improvement. The entire multi-workflow test file was not run locally; the affected fixture families were exercised under unchanged runtime limits.
