### PR TITLE
fix(ci): restore type-routing fixture for direct boundary checks

### DIFF
--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -1752,13 +1752,20 @@ if (args[args.indexOf("--stripe") + 1] === process.env.FAIL_TYPE_STRIPE) process
     for (const directory of ["scripts/lib", "packages", "node_modules"]) {
       symlinkSync(path.resolve(directory), path.join(root, directory), "dir");
     }
-    writeFileSync(
-      path.join(root, "scripts/check-native-state-schema-version.mjs"),
-      `
+    writeFileSync(path.join(root, "scripts/tsx.mjs"), `import ${JSON.stringify(TSX_IMPORT)};\n`);
+    for (const script of [
+      "scripts/check-native-state-schema-version.mjs",
+      "scripts/check-extension-plugin-sdk-boundary.mts",
+    ]) {
+      writeFileSync(
+        path.join(root, script),
+        `
 import { appendFileSync } from "node:fs";
-appendFileSync(process.env.TYPE_CALLS, [process.env.TYPE_ROW, process.env.OPENCLAW_LOCAL_CHECK ?? "<unset>", "node scripts/check-native-state-schema-version.mjs"].join("\\t") + "\\n");
+const command = ["node", ...process.execArgv, ${JSON.stringify(script)}, ...process.argv.slice(2)].join(" ");
+appendFileSync(process.env.TYPE_CALLS, [process.env.TYPE_ROW, process.env.OPENCLAW_LOCAL_CHECK ?? "<unset>", command].join("\\t") + "\\n");
 `,
-    );
+      );
+    }
   }
   const scripts = Object.fromEntries(options.scripts.map((name) => [name, "true"]));
   if (options.types?.compose) {


### PR DESCRIPTION
Related: #146771

## What Problem This Solves

The CI type-routing fixture fails before recording the combined extension boundary check because its temporary repository does not provide the new Node preload or checker entrypoint.

## User Impact

Restores the CI routing test for the combined boundary command. There is no production behavior change.

## Why This Change Was Made

The fixture still executes the real workflow rows and boundary dispatcher. It now supplies the TypeScript preload and records both direct Node checker leaves, including Node flags and script arguments, using the existing synthetic command-recording boundary. The routing assertions and production checks remain unchanged.

## Evidence

- Reproduced the missing `scripts/tsx.mjs` failure on main `4a1777c2e05`; the existing targeted test passes after this change. The original Linux failure is visible in [CI run 34743286843](https://github.com/openclaw/openclaw/actions/runs/34743286843/job/103686618783).
- Workflow guards plus the boundary-runner suite with Bash 5.3.15: 592 passed and 2 skipped. The earlier macOS system-Bash-3.2 run had 590 passes, 2 skips, and two unrelated Android empty-array failures; those failures are retained and separately qualified. [Exact-head Linux CI](https://github.com/openclaw/openclaw/actions/runs/34744302121) passed: the repaired routing case took 401 ms, and all 568 workflow guards passed.
- Changed-file checks and independent P0–P2 review passed.
