### PR TITLE
fix(computer): avoid extra observation turns after window actions

### DIFF
--- a/docs/nodes/computer-use.md
+++ b/docs/nodes/computer-use.md
@@ -49,7 +49,9 @@ CUA additionally exposes `get_recording_state`, `start_recording`, `stop_recordi
 
 On the macOS Peekaboo provider, screen-coordinate scrolling uses foreground wheel input at the requested coordinate or current pointer. Background scrolling requires a window and an element from its current observation; it never falls back to global wheel input.
 
-Modifier keys ride the `text` field on click and scroll actions (`shift`, `ctrl`, `alt`, `cmd`). After an input action the tool returns a fresh screenshot so the model can observe the result. When the screen is pixel-identical to the previous frame still in model context, the tool returns metadata only — "screen unchanged since previous frame" — and the previous `frameId` stays valid, so duplicate screenshots never re-enter model context. If more than one computer-capable node is connected, pass `node` explicitly.
+Modifier keys ride the `text` field on click and scroll actions (`shift`, `ctrl`, `alt`, `cmd`). After window input, providers advertising `get_window_state` return the action outcome followed by a fresh window observation. Use that observation's `observationId` and element references for the next action; no separate observation call is needed. If the follow-up fails, the original action outcome remains visible: observe again before another mutation, without repeating the input. Browser actions still require a separate browser observation.
+
+Other input actions return a fresh desktop screenshot so the model can observe the result. When the screen is pixel-identical to the previous frame still in model context, the tool returns metadata only — "screen unchanged since previous frame" — and the previous `frameId` stays valid, so duplicate screenshots never re-enter model context. If more than one computer-capable node is connected, pass `node` explicitly.
 
 Screenshots are kept **model-only**: they are never auto-delivered to the chat channel. Treat all on-screen content as untrusted input; the tool warns the model not to follow on-screen instructions that conflict with the user's request.
 

--- a/src/agents/tools/computer-tool-guidance.test.ts
+++ b/src/agents/tools/computer-tool-guidance.test.ts
@@ -43,6 +43,7 @@ describe("computer tool guidance", () => {
     expect(description).toContain("`query`, `depth`, and `maxElements` filters");
     expect(description).toContain('`effect:"confirmed"` > `unverifiable` > `suspected_noop`');
     expect(description).toContain("never blind-retry a mutation");
+    expect(description).toContain("without another observation call");
     expect(description).toContain("For window input");
     expect(description).toContain("untrusted input");
     expect(description).not.toMatch(
@@ -63,7 +64,7 @@ describe("computer tool guidance", () => {
     expect(desktopOnly).toContain("stale frameId");
     expect(desktopOnly).toContain("unchanged screen returns metadata only and reuses its frameId");
     expect(desktopOnly).not.toMatch(
-      /get_window_state|accessibility|elementRef|window pixels|deliveryMode:"background"|background_unavailable/,
+      /get_window_state|accessibility|elementRef|window pixels|deliveryMode:"background"|background_unavailable|without another observation call/,
     );
 
     const windowBackground = buildComputerToolDescription(

--- a/src/agents/tools/computer-tool-guidance.ts
+++ b/src/agents/tools/computer-tool-guidance.ts
@@ -176,6 +176,9 @@ export function buildComputerToolDescription(
     hasMutation
       ? 'Result precedence is `effect:"confirmed"` > `unverifiable` > `suspected_noop`; action evidence alone does not prove the user\'s goal. Re-observe before another mutation, and never blind-retry a mutation.'
       : "",
+    hasWindowState && hasMutation
+      ? "Window actions return a fresh observation when available; use its observationId and refs for the next action without another observation call."
+      : "",
     hasBackground
       ? "`background_unavailable`, `background_occluded`, and `off_space_or_ax_unresolved` are honest structured refusals: choose another advertised rung, not a harder retry."
       : "",

--- a/src/agents/tools/computer-tool-node.ts
+++ b/src/agents/tools/computer-tool-node.ts
@@ -128,7 +128,11 @@ function parseComputerActPayload(value: unknown): ComputerActResult {
   }
 }
 
-function computerActIdempotencyKey(params: { scope?: string; toolCallId: string }): string {
+function computerActIdempotencyKey(params: {
+  scope?: string;
+  toolCallId: string;
+  purpose?: "follow-up-observation";
+}): string {
   const stableScope = params.scope?.trim();
   const stableCallId = params.toolCallId.trim();
   if (!stableScope || !stableCallId) {
@@ -136,10 +140,15 @@ function computerActIdempotencyKey(params: { scope?: string; toolCallId: string 
     // scope and provider/fallback id, avoid collapsing unrelated actions.
     return crypto.randomUUID();
   }
-  const digest = crypto
-    .createHash("sha256")
-    .update(JSON.stringify([stableScope, stableCallId, COMPUTER_ACT_COMMAND]))
-    .digest("hex");
+  const parts = [stableScope, stableCallId, COMPUTER_ACT_COMMAND];
+  if (params.purpose) {
+    parts.push(params.purpose);
+  }
+  const digest = crypto.createHash("sha256").update(JSON.stringify(parts)).digest("hex");
+  // The automatic read shares a tool-call id with input, but must never replay its result.
+  if (params.purpose) {
+    return `computer.observation:v1:${digest}`;
+  }
   // `v1` versions this key's composition (scope + call id + command), not the
   // `computer.act` wire contract. Changing what goes into the digest needs a
   // new prefix so in-flight keys from an older node cannot collide.
@@ -482,6 +491,7 @@ export class ComputerToolSession {
     resolved: ResolvedComputerTarget;
     wireParams: ComputerActParams;
     toolCallId: string;
+    purpose?: "follow-up-observation";
     signal?: AbortSignal;
   }): Promise<ComputerActResult> {
     this.assertOpen();
@@ -518,6 +528,10 @@ export class ComputerToolSession {
       }
     }
     this.prepareScreenshotTarget(params.resolved.target);
+    if (params.purpose === "follow-up-observation") {
+      // Input may have changed the window. A failed refresh must not leave its old refs usable.
+      this.observationState = undefined;
+    }
     if (params.wireParams.action === "left_mouse_down") {
       this.heldButtonTarget = params.resolved.target;
     }
@@ -532,6 +546,7 @@ export class ComputerToolSession {
           idempotencyKey: computerActIdempotencyKey({
             scope: this.options.idempotencyScope,
             toolCallId: params.toolCallId,
+            purpose: params.purpose,
           }),
           signal: params.signal,
         }),

--- a/src/agents/tools/computer-tool-result.ts
+++ b/src/agents/tools/computer-tool-result.ts
@@ -188,6 +188,7 @@ export async function projectScreenshotResult(params: {
 
 export async function projectComputerActResult(params: {
   result: ComputerActResult;
+  precedingAction?: { action: ComputerToolAction; result: ComputerActResult };
   target: ComputerTarget;
   action: ComputerToolAction;
   referenceWidth: number;
@@ -229,14 +230,29 @@ export async function projectComputerActResult(params: {
   return {
     result: {
       content: [
+        ...(params.precedingAction
+          ? [
+              {
+                type: "text" as const,
+                text: computerActResultText(
+                  params.precedingAction.action,
+                  params.precedingAction.result,
+                ),
+              },
+            ]
+          : []),
         { type: "text", text: JSON.stringify({ action: params.action, ...result }) },
         ...content,
       ],
       details: {
         node: params.target.nodeId,
-        action: params.action,
+        action: params.precedingAction?.action ?? params.action,
         screenIndex: params.target.screenIndex,
-        result,
+        // Keep mutation evidence separate from the read's coordinate space and other metadata.
+        result: params.precedingAction
+          ? projectComputerActResultMetadata(params.precedingAction.result)
+          : result,
+        ...(params.precedingAction ? { followUpObservation: result } : {}),
         media: { outbound: false },
       },
     },

--- a/src/agents/tools/computer-tool.observation.test.ts
+++ b/src/agents/tools/computer-tool.observation.test.ts
@@ -1,0 +1,324 @@
+import { createHash } from "node:crypto";
+import { expectDefined } from "@openclaw/normalization-core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getImageMetadata } from "../../media/image-ops.js";
+import { createSolidPngBuffer } from "../../plugin-sdk/test-helpers/image-fixtures.js";
+import type { ComputerActResult } from "../../plugins/computer-use-contract.js";
+import type { ComputerToolTransport } from "./computer-tool-shared.js";
+import {
+  createVisionComputerTool,
+  resetComputerToolMocks,
+  sleepMock,
+  TINY_PNG_BASE64,
+  v2Descriptor,
+} from "./computer-tool.test-helpers.js";
+
+const actionResult: ComputerActResult = {
+  ok: true,
+  effect: "confirmed",
+  details: { route: "accessibility_action", deliveryMode: "background", evidence: "verified" },
+};
+
+function observationResult(index: number): ComputerActResult {
+  return {
+    ok: true,
+    observation: {
+      kind: "window",
+      observationId: `observation-${index}`,
+      elements: [
+        {
+          elementRef: `element-${index}`,
+          role: "button",
+          label: "Save",
+          bounds: { x: 0, y: 0, width: 1, height: 1 },
+        },
+      ],
+      base64: TINY_PNG_BASE64,
+      format: "png",
+      width: 1,
+      height: 1,
+    },
+    details: { coordinateSpace: "image-pixels" },
+  };
+}
+
+function createObservedTool(
+  options: {
+    inline?: boolean;
+    followUp?: () => ComputerActResult;
+  } = {},
+) {
+  let observations = 0;
+  let mutations = 0;
+  const cache = new Map<string, ComputerActResult>();
+  const computerUse = v2Descriptor(["get_window_state", "left_click"]);
+  const invoke = vi.fn<ComputerToolTransport["invoke"]>(async (request) => {
+    if (request.command !== "computer.act") {
+      throw new Error("Unexpected desktop capture");
+    }
+    const key = request.idempotencyKey!;
+    const cached = cache.get(key);
+    if (cached) {
+      return cached;
+    }
+    let result: ComputerActResult;
+    if (request.commandParams.action === "get_window_state") {
+      observations += 1;
+      result =
+        observations > 1 && options.followUp ? options.followUp() : observationResult(observations);
+    } else {
+      expect(request.commandParams).toMatchObject({
+        action: "left_click",
+        windowRef: "window-1",
+        observationId: `observation-${observations}`,
+      });
+      if (request.commandParams.elementRef) {
+        expect(request.commandParams.elementRef).toBe(`element-${observations}`);
+      }
+      mutations += 1;
+      result = options.inline
+        ? { ...observationResult(++observations), ...actionResult }
+        : actionResult;
+    }
+    cache.set(key, result);
+    return result;
+  });
+  const tool = createVisionComputerTool({
+    idempotencyScope: "run-1",
+    transport: {
+      computerUse,
+      resolveNode: async () => ({ nodeId: "desktop-1", computerUse }),
+      invoke,
+    },
+  });
+  const observe = () =>
+    tool.execute("observe", { action: "get_window_state", windowRef: "window-1" });
+  const click = (index: number, callId = `click-${index}`, signal?: AbortSignal) =>
+    tool.execute(
+      callId,
+      {
+        action: "left_click",
+        windowRef: "window-1",
+        observationId: `observation-${index}`,
+        elementRef: `element-${index}`,
+        deliveryMode: "background",
+      },
+      signal,
+    );
+  return { tool, invoke, observe, click, counts: () => ({ observations, mutations }) };
+}
+
+describe("computer targeted action observations", () => {
+  beforeEach(resetComputerToolMocks);
+
+  it("returns fresh refs and preserves input evidence without an extra model observation turn", async () => {
+    const fixture = createObservedTool();
+    await fixture.observe();
+    const result = await fixture.click(1);
+
+    expect(result.content.map((block) => block.type)).toEqual(["text", "text", "image"]);
+    expect(result.content[0]).toEqual({
+      type: "text",
+      text: JSON.stringify({ action: "left_click", ...actionResult }),
+    });
+    expect(result.content[1]).toEqual({
+      type: "text",
+      text: JSON.stringify({
+        action: "get_window_state",
+        ...observationResult(2),
+        observation: { ...observationResult(2).observation, base64: "[image]" },
+      }),
+    });
+    expect(result.details).toMatchObject({
+      action: "left_click",
+      result: actionResult,
+      followUpObservation: {
+        observation: { observationId: "observation-2" },
+        details: { coordinateSpace: "image-pixels" },
+      },
+    });
+    await fixture.click(2, "click-1:observation");
+    expect(fixture.counts()).toEqual({ observations: 3, mutations: 2 });
+    expect(sleepMock).toHaveBeenCalledTimes(2);
+    expect(sleepMock).toHaveBeenCalledWith(500, undefined);
+
+    const requests = fixture.invoke.mock.calls.map(([request]) => request);
+    const mutationRequest = expectDefined(requests[1], "first input request");
+    const observationRequest = expectDefined(requests[2], "automatic observation request");
+    const mutationKey = `computer.act:v1:${createHash("sha256")
+      .update(JSON.stringify(["run-1", "click-1", "computer.act"]))
+      .digest("hex")}`;
+    expect(mutationRequest.idempotencyKey).toBe(mutationKey);
+    expect(observationRequest.idempotencyKey).toMatch(/^computer\.observation:v1:/);
+    expect(new Set(requests.map((request) => request.idempotencyKey)).size).toBe(5);
+    expect(observationRequest.commandParams).toEqual({
+      action: "get_window_state",
+      executionId: mutationRequest.commandParams.executionId,
+      windowRef: "window-1",
+    });
+    await expect(fixture.click(1, "stale")).rejects.toThrow("COMPUTER_STALE_OBSERVATION");
+    expect(fixture.counts().mutations).toBe(2);
+  });
+
+  it("keeps direct and inline observations unchanged and avoids an additional read", async () => {
+    const fixture = createObservedTool({ inline: true });
+    const direct = await fixture.observe();
+    expect(direct.content[0]).toEqual({
+      type: "text",
+      text: JSON.stringify({
+        action: "get_window_state",
+        ...observationResult(1),
+        observation: { ...observationResult(1).observation, base64: "[image]" },
+      }),
+    });
+    const inline = await fixture.click(1);
+    expect(inline.content.map((block) => block.type)).toEqual(["text", "image"]);
+    expect(inline.details).toMatchObject({
+      action: "left_click",
+      result: { ...actionResult, observation: { observationId: "observation-2" } },
+    });
+    expect(inline.details).not.toHaveProperty("followUpObservation");
+    expect(fixture.invoke).toHaveBeenCalledTimes(2);
+    expect(sleepMock).not.toHaveBeenCalled();
+  });
+
+  it.each(["image-pixels", "global-logical-points"] as const)(
+    "binds the automatic observation's resized image using %s",
+    async (coordinateSpace) => {
+      const width = 1568;
+      const height = 784;
+      const fixture = createObservedTool({
+        followUp: () => ({
+          ...observationResult(2),
+          observation: {
+            ...observationResult(2).observation!,
+            base64: createSolidPngBuffer(width, height, { r: 70, g: 125, b: 180 }).toString(
+              "base64",
+            ),
+            width,
+            height,
+          },
+          details: { coordinateSpace },
+        }),
+      });
+      await fixture.observe();
+      const result = await fixture.click(1);
+      const image = result.content.find((block) => block.type === "image");
+      if (!image) {
+        throw new Error("Missing automatic window observation image");
+      }
+      const dimensions = await getImageMetadata(Buffer.from(image.data, "base64"));
+      if (!dimensions) {
+        throw new Error("Missing automatic window observation dimensions");
+      }
+      expect(dimensions.width).toBeLessThan(width);
+      const coordinate: [number, number] = [
+        Math.floor(dimensions.width / 2),
+        Math.floor(dimensions.height / 2),
+      ];
+      await fixture.tool.execute("next-pixel", {
+        action: "left_click",
+        windowRef: "window-1",
+        observationId: "observation-2",
+        coordinate,
+      });
+      const [coordinateRequest] = expectDefined(fixture.invoke.mock.calls[3], "coordinate input");
+      const sent = coordinateRequest.commandParams;
+      expect(sent.x).toBeCloseTo(
+        coordinate[0] * (coordinateSpace === "image-pixels" ? width / dimensions.width : 1),
+      );
+      expect(sent.y).toBeCloseTo(
+        coordinate[1] * (coordinateSpace === "image-pixels" ? height / dimensions.height : 1),
+      );
+    },
+  );
+
+  it.each([
+    [
+      "rejected",
+      () => {
+        throw new Error("window closed");
+      },
+    ],
+    [
+      "read aborted",
+      () => {
+        throw new DOMException("read cancelled", "AbortError");
+      },
+    ],
+    ["missing observation", () => ({ ok: true })],
+    ["unsuccessful", () => ({ ok: false, details: { reason: "unavailable" } })],
+  ] as const)(
+    "preserves input success after a %s follow-up and expires old refs",
+    async (_name, followUp) => {
+      const fixture = createObservedTool({ followUp });
+      await fixture.observe();
+      const result = await fixture.click(1, "click", new AbortController().signal);
+      expect(result.details).toMatchObject({ action: "left_click", result: actionResult });
+      expect(result.content[0]).toMatchObject({
+        text: expect.stringContaining("follow-up observation failed:"),
+      });
+      await expect(fixture.click(1, "stale")).rejects.toThrow("COMPUTER_STALE_OBSERVATION");
+      expect(fixture.counts()).toEqual({ observations: 2, mutations: 1 });
+    },
+  );
+
+  it("keeps caller cancellation authoritative without repeating input", async () => {
+    const controller = new AbortController();
+    const fixture = createObservedTool({
+      followUp: () => {
+        controller.abort(new Error("caller cancelled"));
+        controller.signal.throwIfAborted();
+        return observationResult(2);
+      },
+    });
+    await fixture.observe();
+    await expect(fixture.click(1, "click", controller.signal)).rejects.toThrow("caller cancelled");
+    expect(fixture.counts()).toEqual({ observations: 2, mutations: 1 });
+  });
+
+  it.each([
+    {
+      name: "screen input",
+      input: { action: "key", text: "Return" },
+      actions: ["key", "get_window_state"],
+    },
+    {
+      name: "unavailable window observation",
+      input: { action: "key", text: "Return", windowRef: "window-1" },
+      actions: ["key"],
+    },
+    {
+      name: "browser preparation",
+      input: { action: "browser_prepare", windowRef: "window-1" },
+      actions: ["browser_prepare", "get_window_state"],
+    },
+  ] as const)("retains desktop capture for $name", async ({ input, actions }) => {
+    const computerUse = v2Descriptor(["screenshot", ...actions]);
+    const invoke = vi.fn<ComputerToolTransport["invoke"]>(async (request) =>
+      request.command === "computer.act"
+        ? actionResult
+        : {
+            format: "png",
+            base64: TINY_PNG_BASE64,
+            displayFrameId: "display-1",
+            width: 1,
+            height: 1,
+          },
+    );
+    const tool = createVisionComputerTool({
+      transport: {
+        computerUse,
+        resolveNode: async () => ({ nodeId: "desktop-1", computerUse }),
+        invoke,
+      },
+    });
+    const result = await tool.execute("input", input);
+    expect(invoke.mock.calls.map(([request]) => request.command)).toEqual([
+      "computer.act",
+      "screen.snapshot",
+    ]);
+    expect(result.content.some((block) => block.type === "image")).toBe(true);
+    expect(sleepMock).toHaveBeenCalledWith(500, undefined);
+  });
+});

--- a/src/agents/tools/computer-tool.test-helpers.ts
+++ b/src/agents/tools/computer-tool.test-helpers.ts
@@ -100,10 +100,13 @@ export function readFrameId(result: { details?: unknown }): string {
   return frameId;
 }
 
-export function readLastComputerActParams(): Record<string, unknown> {
-  const call = callGatewayToolMock.mock.calls.findLast(
-    (entry) => (entry[2] as { command?: string }).command === COMPUTER_ACT_COMMAND,
-  );
+export function readLastComputerActParams(
+  action?: ComputerUseV2ActionName,
+): Record<string, unknown> {
+  const call = callGatewayToolMock.mock.calls.findLast((entry) => {
+    const body = entry[2] as ComputerActBody;
+    return body.command === COMPUTER_ACT_COMMAND && (!action || body.params?.action === action);
+  });
   const body = call?.[2] as { params?: Record<string, unknown> } | undefined;
   if (!body?.params) {
     throw new Error("missing computer.act request");

--- a/src/agents/tools/computer-tool.ts
+++ b/src/agents/tools/computer-tool.ts
@@ -234,8 +234,37 @@ export function createComputerTool(options?: {
           session.recordObservation(resolved, actResult, projected.imageCoordinates);
           return projected.result;
         }
+        // Browser preparation can launch a different window; its old native target is not an after-image.
+        const windowRef = "windowRef" in wireParams ? wireParams.windowRef : undefined;
+        const observeWindow =
+          windowRef &&
+          action !== "browser_prepare" &&
+          resolved.capabilities?.actions.includes("get_window_state");
         try {
           await sleep(AFTER_ACTION_SCREENSHOT_DELAY_MS, signal);
+          if (observeWindow) {
+            const observation = await session.invokeComputerAct({
+              resolved,
+              wireParams: { action: "get_window_state", executionId, windowRef },
+              toolCallId,
+              purpose: "follow-up-observation",
+              signal,
+            });
+            if (!observation.ok || !observation.observation?.observationId) {
+              throw new Error(computerActResultText("get_window_state", observation));
+            }
+            session.setTarget(resolved.target);
+            const projected = await projectComputerActResult({
+              result: observation,
+              precedingAction: { action, result: actResult },
+              target: resolved.target,
+              action: "get_window_state",
+              referenceWidth,
+              modelHasVision: options?.modelHasVision,
+            });
+            session.recordObservation(resolved, observation, projected.imageCoordinates);
+            return projected.result;
+          }
           return await captureAndDeliverScreenshot({
             noteLines: [computerActResultText(action, actResult)],
             resolved,
@@ -246,12 +275,12 @@ export function createComputerTool(options?: {
         } catch (err) {
           session.setTarget(resolved.target);
           signal?.throwIfAborted();
-          // Input landed; a failed follow-up screenshot should not fail the action.
+          // Input landed; a failed follow-up observation should not fail the action.
           return {
             content: [
               {
                 type: "text",
-                text: `${computerActResultText(action, actResult)}\nfollow-up screenshot failed: ${formatErrorMessage(err)}`,
+                text: `${computerActResultText(action, actResult)}\nfollow-up ${observeWindow ? "observation" : "screenshot"} failed: ${formatErrorMessage(err)}`,
               },
             ],
             details: {

--- a/src/agents/tools/computer-tool.v2.test.ts
+++ b/src/agents/tools/computer-tool.v2.test.ts
@@ -255,7 +255,7 @@ describe("createComputerTool v2 execution", () => {
               }
             : { coordinate, ...(action === "left_click_drag" ? { startCoordinate } : {}) }),
         });
-        const sent = readLastComputerActParams();
+        const sent = readLastComputerActParams(action);
         expect(sent[action === "zoom" ? "x2" : "x"]).toBeCloseTo(expectedX, 6);
         expect(sent[action === "zoom" ? "y2" : "y"]).toBeCloseTo(expectedY, 6);
         if (action !== "left_click") {
@@ -359,7 +359,7 @@ describe("createComputerTool v2 execution", () => {
       ).rejects.toThrow("COMPUTER_STALE_OBSERVATION");
       expect(callGatewayToolMock).not.toHaveBeenCalled();
       await tool.execute("element", { action: "left_click", ...refs, elementRef: "element-1" });
-      expect(readLastComputerActParams()).toMatchObject({
+      expect(readLastComputerActParams("left_click")).toMatchObject({
         action: "left_click",
         elementRef: "element-1",
       });
@@ -515,7 +515,7 @@ describe("createComputerTool v2 execution", () => {
         deliveryMode: "background",
       }),
     ).resolves.toBeDefined();
-    expect(readLastComputerActParams()).toEqual({
+    expect(readLastComputerActParams("left_click")).toEqual({
       action: "left_click",
       screenIndex: 0,
       refWidth: EFFECTIVE_REF_WIDTH,


### PR DESCRIPTION
## What Problem This Solves

Fixes an extra observation turn after targeted window input: the action returns a desktop screenshot, while the next window action needs fresh window observation IDs and element references.

## User Impact

Window actions now return their original outcome followed by a fresh window observation when the provider supports `get_window_state`, so the agent can continue using the returned references. Screen-only input and browser observation behavior remain unchanged.

## Why This Change Was Made

The shared computer tool already owns post-action observation. It now selects the targeted window read through that existing flow, retains the 500 ms settling delay, and uses a separate idempotency namespace for the automatic read. Original input evidence survives a failed follow-up; stale references expire, resized image coordinates stay bound to the fresh observation, and caller cancellation keeps its existing behavior.

Browser act-and-observe is a separate follow-up. This change is not presented as the cause or a measured fix for the sampled screen-only latency incident.

## Evidence

- Current head `c5faee8430e6b5bbee76b5c0d51bc3a10f1b5b51` preserves the reviewed production patch from `275cd988f35982f092df3d94cfce43af075d0e92` after refreshing its base. Test-only presence assertions and a coordinate tuple now satisfy strict indexed-access typing without weakening the checks. Independent review is clear; fresh exact-head CI is pending.
- Linux proof at `275cd988` used Node 24.19.0, pnpm 12.3.4, and CUA Driver 0.23.2: eight focused files / 142 tests passed, the original production implementation reproduced the fresh-reference regression, and `pnpm build` passed.
- The earlier changed gate passed formatting and early guards, then stopped at an unchanged unused import in `src/config/types.secrets.ts`. That issue was fixed separately in https://github.com/openclaw/openclaw/pull/146689 and is included in the refreshed base. No complete manual static-gate pass is claimed.
- Real computer-tool → Gateway → paired CUA-node → GTK proof passed. Two background edits required five progress invocations on the original implementation and three on the candidate. Fresh observations read back the expected text, returned references authorized the next edit, stale references were rejected, and cursor, foreground, and image checks passed.
- The native driver's original `effect=unverifiable`, accessibility route, and unknown delivery metadata were preserved. Actual effect was established by observation readback. This is bounded fixture and call-count proof, not an end-to-end Team latency measurement.
- The final test-only narrowing has not yet run on the clean Linux install; the local attempt stopped before test execution because the borrowed dependency install was incomplete. Required CI remains authoritative for that correction.

Production delta: +63 lines for window observation composition and result/idempotency ownership; tests/support +328 lines; docs +2 lines.
