### PR TITLE
refactor: remove redundant WhatsApp auth-store runtime casts

### DIFF
--- a/extensions/whatsapp/src/auth-store.test.ts
+++ b/extensions/whatsapp/src/auth-store.test.ts
@@ -288,7 +288,7 @@ describe("auth-store", () => {
 
       const runtime = createRuntimeSpies();
 
-      await expect(logoutWeb({ authDir, runtime: runtime as never })).resolves.toBe(true);
+      await expect(logoutWeb({ authDir, runtime })).resolves.toBe(true);
       expect(fsSync.existsSync(authDir)).toBe(false);
     });
   });
@@ -328,9 +328,9 @@ describe("auth-store", () => {
 
     try {
       hoisted.oauthDir = authDir;
-      await expect(
-        logoutWeb({ authDir, isLegacyAuthDir: true, runtime: runtime as never }),
-      ).rejects.toThrow("EACCES");
+      await expect(logoutWeb({ authDir, isLegacyAuthDir: true, runtime })).rejects.toThrow(
+        "EACCES",
+      );
       expect(fsSync.existsSync(authDir)).toBe(true);
       expect(fsSync.existsSync(path.join(authDir, "oauth.json"))).toBe(true);
     } finally {
@@ -393,7 +393,7 @@ describe("auth-store", () => {
     fsSync.writeFileSync(path.join(authDir, "notes.txt"), "keep me", "utf-8");
     const runtime = createRuntimeSpies();
 
-    await expect(logoutWeb({ authDir, runtime: runtime as never })).resolves.toBe(false);
+    await expect(logoutWeb({ authDir, runtime })).resolves.toBe(false);
     expect(fsSync.existsSync(authDir)).toBe(true);
     expect(fsSync.existsSync(path.join(authDir, "notes.txt"))).toBe(true);
   });


### PR DESCRIPTION
## What Problem This Solves

WhatsApp auth-store tests cast an already-compatible runtime fixture to `never` at three logout call sites.

## User Impact

No user-visible change. Production code is unchanged; test code is +5/-5.

## Why This Change Was Made

Pass the existing shared runtime spies directly while retaining all credential, error, filesystem-preservation and cleanup assertions.

## Evidence

All 24 cases in the auth-store and logout suites passed in the original baseline and final formatted candidate on macOS with Node 26.5. The baseline was reused unchanged. An initial format failure was corrected with the repository formatter, followed by the 24-case candidate rerun, successful formatting/type-aware lint and all 19 normal remote changed checks. Lease, capsule, processes and the exact owned temporary directory were verified closed. Existing Windows conditions remain unchanged; no live WhatsApp or performance claim.
