### PR TITLE
fix(ci): restore routing proof for consolidated boundary checks

### DIFF
--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -1752,6 +1752,16 @@ if (args[args.indexOf("--stripe") + 1] === process.env.FAIL_TYPE_STRIPE) process
     for (const directory of ["scripts/lib", "packages", "node_modules"]) {
       symlinkSync(path.resolve(directory), path.join(root, directory), "dir");
     }
+    copyFileSync("scripts/tsx.mjs", path.join(root, "scripts/tsx.mjs"));
+    // The consolidated SDK check runs through Node, outside the pnpm recorder.
+    writeFileSync(
+      path.join(root, "scripts/check-extension-plugin-sdk-boundary.mts"),
+      `
+import { appendFileSync } from "node:fs";
+const command = "node --import ./scripts/tsx.mjs scripts/check-extension-plugin-sdk-boundary.mts " + process.argv.slice(2).join(" ");
+appendFileSync(process.env.TYPE_CALLS, [process.env.TYPE_ROW, process.env.OPENCLAW_LOCAL_CHECK ?? "<unset>", command].join("\\t") + "\\n");
+`,
+    );
     writeFileSync(
       path.join(root, "scripts/check-native-state-schema-version.mjs"),
       `


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/pull/146771

## What Problem This Solves

Fixes the CI routing regression test failing after the plugin SDK boundary checks were consolidated into one Node command.

## User Impact

No product behavior changes. Unrelated PRs can complete the existing CI routing guard again.

## Why This Change Was Made

The fixture already records package-manager commands, but the consolidated check runs directly through Node. Supply its real TypeScript preload and a recording checker that captures the actual arguments, preserving the existing exit-status, command-inventory, and type-owner assertions.

## Evidence

- Reproduced the missing-preload failure on base `0f23fae715b83f0ca9d7db09cef68f81d6ff1159`; the unchanged routing regression passes with this repair.
- All 17 selected routing and type-owner cases passed with Node 26.7 and Vitest 5 using the repository test wrapper.
- Targeted formatting, diff checks, and independent autoreview through P2 passed. Production delta: zero; fixture delta: 10 lines.
- Full-file and required static validation remain covered by the pending PR CI run.
