### PR TITLE
perf(workers): skip configured Git author lookups

### DIFF
--- a/src/gateway/worker-environments/node-worker-workspace-fallback.test.ts
+++ b/src/gateway/worker-environments/node-worker-workspace-fallback.test.ts
@@ -242,40 +242,53 @@ describe("node worker workspace origin fallback", () => {
       label: "fully inherited identity",
       gitAuthor: undefined,
       expected: ["Gateway Repository Author", "gateway-author@example.invalid"],
+      lookups: ["user.name", "user.email"],
     },
     {
       label: "configured name with inherited email",
       gitAuthor: { name: "Configured Author" },
       expected: ["Configured Author", "gateway-author@example.invalid"],
+      lookups: ["user.email"],
     },
     {
       label: "inherited name with configured email",
       gitAuthor: { email: "configured@example.invalid" },
       expected: ["Gateway Repository Author", "configured@example.invalid"],
+      lookups: ["user.name"],
     },
-  ])("projects $label into a materialized Git workspace", async ({ gitAuthor, expected }) => {
-    const localPath = cleanWorkspace();
-    const exec = vi.fn<WorkspaceExec>(async () => ({
-      ...spawnResult(),
-      workspaceDir: REMOTE_WORKSPACE,
-    }));
-    const result = {
-      mode: "git" as const,
-      remoteWorkspaceDir: REMOTE_WORKSPACE,
-      manifestRef: MANIFEST_REF,
-    };
+    {
+      label: "fully configured identity",
+      gitAuthor: { name: "Configured Author", email: "configured@example.invalid" },
+      expected: ["Configured Author", "configured@example.invalid"],
+      lookups: [],
+    },
+  ])(
+    "projects $label into a materialized Git workspace",
+    async ({ gitAuthor, expected, lookups }) => {
+      const localPath = cleanWorkspace();
+      const exec = vi.fn<WorkspaceExec>(async () => ({
+        ...spawnResult(),
+        workspaceDir: REMOTE_WORKSPACE,
+      }));
+      const result = {
+        mode: "git" as const,
+        remoteWorkspaceDir: REMOTE_WORKSPACE,
+        manifestRef: MANIFEST_REF,
+      };
 
-    await expect(
-      createNodeWorkerWorkspaceFallback(exec).finalizeSync(
-        { localPath, sessionId: "session-1", generation: 1, ...(gitAuthor ? { gitAuthor } : {}) },
-        result,
-      ),
-    ).resolves.toEqual(result);
-    expect(exec.mock.calls.map(([command]) => command.argv.slice(-2))).toEqual([
-      ["user.name", expected[0]],
-      ["user.email", expected[1]],
-    ]);
-  });
+      await expect(
+        createNodeWorkerWorkspaceFallback(exec).finalizeSync(
+          { localPath, sessionId: "session-1", generation: 1, ...(gitAuthor ? { gitAuthor } : {}) },
+          result,
+        ),
+      ).resolves.toEqual(result);
+      expect(exec.mock.calls.map(([command]) => command.argv.slice(-2))).toEqual([
+        ["user.name", expected[0]],
+        ["user.email", expected[1]],
+      ]);
+      expect(runCommandWithTimeout.mock.calls.map(([argv]) => argv.at(-1))).toEqual(lookups);
+    },
+  );
 
   it("fails closed when a node rejects its Gateway Git author", async () => {
     const localPath = cleanWorkspace();

--- a/src/gateway/worker-environments/workspace-sync-helpers.ts
+++ b/src/gateway/worker-environments/workspace-sync-helpers.ts
@@ -319,11 +319,11 @@ export async function resolveWorkerWorkspaceGitAuthor(
     const result = await runTask([...git, `user.${key}`]);
     return workerWorkspaceCommandSucceeded(result) ? result.stdout.trim() : "";
   };
-  const [name, email] = await Promise.all([read("name"), read("email")]);
-  return {
-    name: request.gitAuthor?.name ?? name,
-    email: request.gitAuthor?.email ?? email,
-  };
+  const [name, email] = await Promise.all([
+    request.gitAuthor?.name ?? read("name"),
+    request.gitAuthor?.email ?? read("email"),
+  ]);
+  return { name, email };
 }
 
 export function stableWorkerPathComponent(value: string, length: number): string {

--- a/src/gateway/worker-environments/workspace-sync-tunnel.test.ts
+++ b/src/gateway/worker-environments/workspace-sync-tunnel.test.ts
@@ -105,6 +105,9 @@ describe("worker tunnel manager", () => {
           entry.argv.join("\0").includes("42+roboclaw-bot@users.noreply.github.com"),
       );
       expect(gitSetup?.argv.join("\0")).toContain("roboclaw-bot");
+      expect(
+        fake.runs.filter(({ argv }) => argv[0] === "git" && argv[3] === "config"),
+      ).toHaveLength(0);
     } finally {
       await handle.stop();
       await fs.rm(localPath, { recursive: true });
@@ -433,6 +436,7 @@ describe("worker tunnel manager", () => {
           source: { kind: "local", path: localPath },
           sessionId: "session:convergent-sync",
           generation: 1,
+          gitAuthor: { name: "Configured Author", email: "configured@example.invalid" },
         });
         let syncSettled = false;
         void syncing.then(
@@ -520,6 +524,15 @@ describe("worker tunnel manager", () => {
           groupAlive: false,
         });
         expect(result.mode).toBe("git");
+        expect(
+          fake.runs.filter(({ argv }) => argv[0] === "git" && argv[3] === "config"),
+        ).toHaveLength(0);
+        await expect(git(result.remoteWorkspaceDir, "config", "--get", "user.name")).resolves.toBe(
+          "Configured Author",
+        );
+        await expect(git(result.remoteWorkspaceDir, "config", "--get", "user.email")).resolves.toBe(
+          "configured@example.invalid",
+        );
         await expect(
           fs.readFile(path.join(result.remoteWorkspaceDir, "current.txt"), "utf8"),
         ).resolves.toBe("current\n");


### PR DESCRIPTION
## What Problem This Solves

Workspace sync launches local `git config` lookups even when the request already supplies the corresponding author fields.

## Solution

Resolve only missing author fields in the shared workspace-sync owner. Node-worker and SSH workspace paths retain the same validation and remote Git configuration behavior.

This head reconstructs the intended three-file change on current main and drops the unrelated Crabbox stack, which already landed through https://github.com/openclaw/openclaw/pull/146816.

## User Impact

Fully configured identities launch zero local author lookups. Partially configured identities launch one lookup, and fully inherited identities retain both lookups.

## Evidence

- Candidate focused tests: 25/25 passed in 7.54s.
- Baseline proof with only the production hunk reverted: 5 intended failures. Configured-name and configured-email cases performed 2 lookups instead of 1; fully configured node and tunnel paths performed 2 instead of 0.
- Same-host per-file benchmark with both revisions passing:
  - `node-worker-workspace-fallback.test.ts`: baseline 15/15 in 1.66s; candidate 16/16 in 2.88s.
  - `workspace-sync-tunnel.test.ts`: baseline 9/9 in 5.00s; candidate 9/9 in 6.21s.
- Remote workspace assertions still observe the configured name and email after transfer convergence.
- `git diff --check`
- Patch identity matches the independently reviewed repair commit.
- Prior scoped autoreview found no actionable issue.

Production is `+5/-5` (net zero). Tests are `+48/-22`. The file timings include added assertions and do not establish an end-to-end latency improvement; the deterministic metric is the reduced subprocess count.

Local `check:changed` passed conflict, ratchet, dependency, and formatting lanes, then stopped because the shared ordinary-worktree dependency link did not expose `import-meta-resolve`. Exact-head CI and a refreshed ClawSweeper review remain required before merge.
