### PR TITLE
fix(secrets): stop buffered upload writes after cancellation

### DIFF
--- a/src/secrets/egress-proxy/proxy-forward.test.ts
+++ b/src/secrets/egress-proxy/proxy-forward.test.ts
@@ -1,10 +1,13 @@
-import { IncomingMessage, ServerResponse } from "node:http";
-import { Agent } from "node:https";
+import { IncomingMessage, ServerResponse, type ClientRequest } from "node:http";
+import { Agent, request as httpsRequest } from "node:https";
 import { Socket } from "node:net";
-import type { Readable, Writable } from "node:stream";
+import { Writable, type Readable } from "node:stream";
 import { setImmediate } from "node:timers/promises";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import { resolveSecretSentinel, sealSecretSentinel } from "../sentinel.js";
 import { createSecretEgressBodyBudget, forwardSecretEgressRequest } from "./proxy-forward.js";
+
+vi.mock("node:https", { spy: true });
 
 describe("secret egress forwarding resource ownership", () => {
   it.each([undefined, 0])(
@@ -59,4 +62,100 @@ describe("secret egress forwarding resource ownership", () => {
       }
     },
   );
+
+  it.each([
+    ["run revocation", "drain"],
+    ["run revocation", "next turn"],
+    ["proxy stop", "drain"],
+    ["proxy stop", "next turn"],
+    ["client disconnect", "drain"],
+    ["client disconnect", "next turn"],
+  ] as const)("stops buffered submission after %s while waiting for %s", async (cause, wait) => {
+    const secret = "synthetic-buffered-secret";
+    const body = Buffer.concat([
+      Buffer.alloc(128 * 1024, 120),
+      Buffer.from(sealSecretSentinel(secret, { label: "buffered-cancellation" }) + "tail"),
+    ]);
+    const request = new IncomingMessage(new Socket());
+    request.headers = { "content-length": String(body.length) };
+    request.method = "POST";
+    request.on("error", () => {});
+    const response = new ServerResponse(request);
+    const agent = new Agent();
+    const resources: Array<Readable | Writable> = [];
+    const submitted: Buffer[] = [];
+    let completeWrite: (error?: Error | null) => void = () => {};
+    let firstWrite: () => void = () => {};
+    const started = new Promise<void>((resolve) => {
+      firstWrite = resolve;
+    });
+    // Real Writable backpressure controls transport admission without relying on
+    // platform socket buffers or adding a test-only production hook.
+    const upstream = new Writable({
+      highWaterMark: wait === "drain" ? 1 : body.length + 1,
+      write(chunk: Buffer, _encoding, callback) {
+        submitted.push(Buffer.from(chunk));
+        completeWrite = callback;
+        firstWrite();
+      },
+    });
+    vi.mocked(httpsRequest).mockReturnValueOnce(upstream as unknown as ClientRequest);
+    const releaseBody = vi.fn();
+    const audit = vi.fn();
+    let active = true;
+    try {
+      forwardSecretEgressRequest({
+        request,
+        response,
+        host: "localhost",
+        upstreamTlsAgent: agent,
+        prepareRequest: () => ({
+          target: new URL("https://localhost:1/"),
+          headers: {},
+          substituted: false,
+        }),
+        acquireBody: () => releaseBody,
+        isActive: () => active,
+        ownResource: (resource) => {
+          resources.push(resource);
+          return resource;
+        },
+        releaseResponse() {},
+        resolveSentinel: resolveSecretSentinel,
+        audit,
+      });
+      request.push(body);
+      request.push(null);
+      await started;
+      expect(releaseBody).not.toHaveBeenCalled();
+      if (cause === "client disconnect") {
+        response.emit("close");
+      } else {
+        active = false;
+        if (cause === "proxy stop") {
+          for (const resource of resources) {
+            resource.destroy();
+          }
+        }
+      }
+      completeWrite();
+      await setImmediate();
+      await setImmediate();
+      const sent = Buffer.concat(submitted);
+      expect(sent.length).toBeLessThan(body.length);
+      expect(sent.includes(secret)).toBe(false);
+      expect(sent.includes("tail")).toBe(false);
+      expect(upstream.destroyed).toBe(true);
+      expect(upstream.writableEnded).toBe(false);
+      expect(releaseBody).toHaveBeenCalledOnce();
+      expect(audit).not.toHaveBeenCalled();
+    } finally {
+      for (const resource of resources) {
+        resource.destroy();
+      }
+      request.destroy();
+      response.destroy();
+      agent.destroy();
+    }
+  });
 });

--- a/src/secrets/egress-proxy/proxy-forward.ts
+++ b/src/secrets/egress-proxy/proxy-forward.ts
@@ -16,6 +16,7 @@ import {
 export const REFUSAL_BODY = "Secret egress proxy refused the request.\n";
 const UPSTREAM_ERROR_BODY = "Secret egress proxy could not reach the upstream host.\n";
 const MAX_BUFFERED_REQUEST_BODY_BYTES = 100 * 1024 * 1024;
+const BUFFERED_REQUEST_WRITE_BYTES = 64 * 1024;
 
 export type UpgradeRequest = { stream: PassThrough };
 export type RequestHandler = (
@@ -230,7 +231,38 @@ function sendSecretEgressRequest(
     upstream.end();
   } else if (body !== undefined) {
     bodyTransform.destroy();
-    upstream.end(body);
+    const bufferedBody = body;
+    let offset = 0;
+    let scheduled: ReturnType<typeof setImmediate> | undefined;
+    const writeBody = () => {
+      scheduled = undefined;
+      if (refused || !forward.isActive() || upstream.destroyed) {
+        upstream.destroy();
+        return;
+      }
+      if (offset === bufferedBody.length) {
+        upstream.off("close", stopSending);
+        upstream.end();
+        return;
+      }
+      const chunk = bufferedBody.subarray(offset, offset + BUFFERED_REQUEST_WRITE_BYTES);
+      offset += chunk.length;
+      // Yield even when the transport accepts more, so revocation can prevent
+      // handing later plaintext slices to the upstream transport.
+      if (upstream.write(chunk)) {
+        scheduled = setImmediate(writeBody);
+      } else {
+        upstream.once("drain", writeBody);
+      }
+    };
+    const stopSending = () => {
+      if (scheduled) {
+        clearImmediate(scheduled);
+      }
+      upstream.off("drain", writeBody);
+    };
+    upstream.once("close", stopSending);
+    writeBody();
   } else {
     forward.request.pipe(bodyTransform).pipe(upstream);
   }


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/pull/144902

## What Problem This Solves

Resolves a problem where canceling a buffered protected-egress upload could leave its entire prepared body already submitted to the upstream transport. This follow-up tightens cancellation granularity after the fixed-length upload correction in the linked PR.

## Why This Change Was Made

Submit the prepared body in 64 KiB slices, honoring backpressure and yielding between accepted writes. Check current run activity, refusal, and transport destruction before every slice and final end. Cancel pending continuations on close and release the sender's buffer closure on successful completion.

The change preserves measured Content-Length, substitution, TLS verification, destination binding, admission limits, and finish/close reservation ownership. Same-run binding replacement semantics are unchanged.

## User Impact

Run revocation, proxy stop, and client disconnect can stop later buffered slices from being handed to the upstream transport. Bytes already submitted remain in flight; this does not promise recall of already-sent data.

## Evidence

- Six deterministic cancellation cases using a controlled real Writable cover both drain and next-turn continuation. All six fail on the original implementation because the later substituted value is submitted. All six pass with this change, with no later secret/tail, end, or forwarded audit, and a released reservation.
- All 101 tests across five focused egress files pass locally, including existing real CONNECT/TLS, binary/framing, lifecycle, WebSocket, and 100 MiB byte-identity coverage.
- The local borrowed install has an older Vitest patch and formatter than current pins, so those results are diagnostic. Local `check:changed` passed ten initial gates, then stopped at config-doc generation because that install lacks `import-meta-resolve`. No shared dependencies were changed. Exact-head hosted CI is required before landing.
- Isolated autoreview completed with no actionable P0/P1 findings. The change is limited to the forwarding owner and its focused test file.

## Final Qualification

- Exact-head [CI attempt 2](https://github.com/openclaw/openclaw/actions/runs/34748428845/attempts/2), [CodeQL attempt 2](https://github.com/openclaw/openclaw/actions/runs/34748428847/attempts/2), Critical Quality, and OpenGrep pass at `50e1f8afec30382d900925cc82ea5a053f9435b6`. Earlier runner/upload service failures were resolved by failed-only reruns without changing the patch.
- [ClawSweeper revision 2](https://github.com/openclaw/openclaw/pull/146840#issuecomment-5651936209) covers this exact head with no findings or remaining pre-merge items.
- Production +32 lines; tests +99. The added sender state enforces bounded, cancellation-aware writes and cleans up drain/immediate continuations. No configuration or authorization boundary changes.
