### PR TITLE
fix: restore CI boundary routing fixture

### DIFF
--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -1752,6 +1752,16 @@ if (args[args.indexOf("--stripe") + 1] === process.env.FAIL_TYPE_STRIPE) process
     for (const directory of ["scripts/lib", "packages", "node_modules"]) {
       symlinkSync(path.resolve(directory), path.join(root, directory), "dir");
     }
+    // This fixture checks command routing; child guard implementations only record invocation.
+    writeFileSync(path.join(root, "scripts/tsx.mjs"), "");
+    writeFileSync(
+      path.join(root, "scripts/check-extension-plugin-sdk-boundary.mts"),
+      `
+import { appendFileSync } from "node:fs";
+const command = ["node", ...process.execArgv, "scripts/check-extension-plugin-sdk-boundary.mts", ...process.argv.slice(2)].join(" ");
+appendFileSync(process.env.TYPE_CALLS, [process.env.TYPE_ROW, process.env.OPENCLAW_LOCAL_CHECK ?? "<unset>", command].join("\\t") + "\\n");
+`,
+    );
     writeFileSync(
       path.join(root, "scripts/check-native-state-schema-version.mjs"),
       `


### PR DESCRIPTION
Superseded by the canonical fixture repair in #146702, merged as 49c3d463e19f589d4669d628a402fac3cad07ffe at 07:17:55 UTC while this independent review was finishing. Current main contains the preload and recording-checker repair with unchanged routing assertions. Closing this duplicate without merging or launching another CI workload; local proof and the unshipped branch are preserved.

## What Problem This Solves

Fixes CI routing tests failing with a missing `scripts/tsx.mjs` after #146771 switched the extension boundary checks to a direct Node invocation.

## User Impact

CI can validate type-owner and boundary-check routing again. This changes only the synthetic test fixture; production checks and their assertions stay intact.

## Why This Change Was Made

The fixture already records child guard invocations instead of executing their implementations. Add the matching preload and recording child for the new boundary command, preserving its actual Node arguments and `--all` flag.

## Evidence

- Reproduced the [hosted failure](https://github.com/openclaw/openclaw/actions/runs/34743858232/job/103688103996) through the unchanged named routing test: `ERR_MODULE_NOT_FOUND` for `scripts/tsx.mjs`.
- The repaired fixture passes all 14 selected routing cases, including central checks, declared typechecks, workload preservation, and first-stripe failure handling. No assertions, deadlines, or expected results changed.
- Installed formatter and `git diff --check` pass. Fresh source review is scoped-clean across all three evidence batches (P0-P2); exact-head hosted checks are pending.
- Local proof used the current boundary runner with byte-identical fixture/CI/planner dependencies in the existing trusted runtime. A full local build or broad static rerun was not needed for this fixture-only change; hosted CI covers the final integration.

Related: #146812
