### PR TITLE
fix(logging): keep stored log batches valid when masking secrets

### DIFF
--- a/src/gateway/server.logs-tail.test.ts
+++ b/src/gateway/server.logs-tail.test.ts
@@ -20,28 +20,35 @@ installConnectedControlUiServerSuite((started) => {
   ws = started.ws;
 });
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const pem = [
+  "-----BEGIN PRIVATE KEY-----",
+  "ABCDEF1234567890",
+  "-----END PRIVATE KEY-----",
+] as const;
+const record = (message: string) => JSON.stringify({ message });
 
 it("logs.tail masks complete stored batches while preserving JSON records and byte cursors", async () => {
   const dir = tempDirs.make("openclaw-gateway-log-batch-");
   const file = path.join(dir, "stored.log");
-  const pem = [
-    "-----BEGIN PRIVATE KEY-----",
-    "ABCDEF1234567890",
-    "-----END PRIVATE KEY-----",
-  ] as const;
-  const record = (message: string) => JSON.stringify({ message });
   const cases = [
     { lines: pem.map(record), json: [0, 1, 2] },
     { lines: [record(pem.join("\n"))], json: [0] },
     { lines: pem, json: [] },
     { lines: [record(pem[0]), pem[1], record(pem[2])], json: [0, 2] },
-    { lines: [record(pem[0]), pem[1], pem[1], pem[1], record(pem[2])], json: [0, 2], count: 3 },
+    { lines: [record(pem[0]), pem[1], pem[1], pem[1], record(pem[2])], json: [0, 4] },
+    {
+      lines: pem.map((message, index) =>
+        JSON.stringify({ message, ordinary: `keep-${index}`, sequence: index }),
+      ),
+      json: [0, 1, 2],
+    },
     { lines: [record("Authorization: Basic c2VjcmV0OnBhc3M=")], json: [0] },
     { lines: ["before", "[[],[],[]]", "Authorization: Basic c2VjcmV0OnBhc3M="], json: [1] },
+    { lines: [record("token=synthetic-credential-123456")], json: [0] },
   ];
   setLoggerOverride({ file, level: "silent", consoleLevel: "silent" });
   try {
-    for (const { lines, json, count = lines.length } of cases) {
+    for (const { lines, json } of cases) {
       const stored = `${lines.join("\n")}\n`;
       await fs.writeFile(file, stored);
       const response = await rpcReq<LogTailPayload>(ws, "logs.tail", { limit: 100 });
@@ -50,14 +57,28 @@ it("logs.tail masks complete stored batches while preserving JSON records and by
       const tail = response.payload;
       expect(tail.cursor).toBe(Buffer.byteLength(stored));
       expect(tail.size).toBe(Buffer.byteLength(stored));
-      expect(tail.lines).toHaveLength(count);
+      expect(tail.lines).toHaveLength(lines.length);
       expect(tail.lines.join("\n")).not.toContain(pem[1]);
       expect(tail.lines.join("\n")).not.toContain("c2VjcmV0OnBhc3M=");
+      expect(tail.lines.join("\n")).not.toContain("synthetic-credential-123456");
       for (const index of json) {
         const line = tail.lines[index];
         assert(line !== undefined);
         expect(() => JSON.parse(line)).not.toThrow();
+        const originalLine = lines[index];
+        assert(originalLine !== undefined);
+        const original = JSON.parse(originalLine);
+        if (!Array.isArray(original)) {
+          const masked = JSON.parse(line);
+          expect(Object.keys(masked)).toEqual(Object.keys(original));
+          expect(masked.message).toEqual(expect.any(String));
+          expect(masked.message.trim()).not.toBe("");
+          if (original.message === pem[0] || original.message === pem[2]) {
+            expect(masked.message).toBe(original.message);
+          }
+        }
       }
+      expect(await fs.readFile(file, "utf8")).toBe(stored);
       const next = await rpcReq<LogTailPayload>(ws, "logs.tail", { cursor: tail.cursor });
       expect(next.payload?.lines).toEqual([]);
     }
@@ -66,19 +87,18 @@ it("logs.tail masks complete stored batches while preserving JSON records and by
   }
 });
 
-it("logs.tail applies patterns and numeric secrets registered after the file was written", async () => {
+it("logs.tail applies current ordered patterns and secrets registered after the file was written", async () => {
   const dir = tempDirs.make("openclaw-gateway-log-policy-");
   const file = path.join(dir, "stored.log");
   const fresh = '{ "message": "already ***", "ordinary": 42 }';
-  await fs.writeFile(
-    file,
-    [JSON.stringify({ message: "MASKME PRIVATE_STORED", numeric: 73928164 }), fresh].join("\n") +
-      "\n",
-  );
   setLoggerOverride({ file, level: "silent", consoleLevel: "silent" });
-  applyLoggingConfig({ redactPatterns: ["MASKME", String.raw`/\*\*\* (PRIVATE_[A-Z]+)/g`] });
-  registerSecretValueForRedaction("73928164");
   try {
+    const stored =
+      [JSON.stringify({ message: "MASKME PRIVATE_STORED", numeric: 73928164 }), fresh].join("\n") +
+      "\n";
+    await fs.writeFile(file, stored);
+    applyLoggingConfig({ redactPatterns: ["MASKME", String.raw`/\*\*\* (PRIVATE_[A-Z]+)/g`] });
+    registerSecretValueForRedaction("73928164");
     const response = await rpcReq<LogTailPayload>(ws, "logs.tail", { limit: 100 });
     expect(response.ok).toBe(true);
     expect(response.payload?.lines.map((line) => JSON.parse(line))).toEqual([
@@ -86,11 +106,116 @@ it("logs.tail applies patterns and numeric secrets registered after the file was
       { message: "already ***", ordinary: 42 },
     ]);
     expect(response.payload?.lines[1]).toBe(fresh);
+    expect(response.payload?.cursor).toBe(Buffer.byteLength(stored));
+    expect(await fs.readFile(file, "utf8")).toBe(stored);
+
+    const containers = '[[],[]]\n{ "message": [[],[]] }\n{"message":"[[],[]]"}\n';
+    await fs.writeFile(file, containers);
+    registerSecretValueForRedaction("[[],[]]");
+    const containerResponse = await rpcReq<LogTailPayload>(ws, "logs.tail", { limit: 100 });
+    expect(containerResponse.ok).toBe(true);
+    assert(containerResponse.payload);
+    expect(containerResponse.payload.lines).toHaveLength(3);
+    for (const line of containerResponse.payload.lines) {
+      expect(line).not.toContain("[[],[]]");
+      expect(() => JSON.parse(line)).not.toThrow();
+    }
+    const [, containerObject, containerString] = containerResponse.payload.lines;
+    assert(containerObject !== undefined && containerString !== undefined);
+    expect(JSON.parse(containerObject).message).toBeDefined();
+    expect(JSON.parse(containerString).message).toBe("***");
+    expect(containerResponse.payload.cursor).toBe(Buffer.byteLength(containers));
+    expect(await fs.readFile(file, "utf8")).toBe(containers);
+
+    const ordered = "123456\nsuperprivate\n";
+    await fs.writeFile(file, ordered);
+    applyLoggingConfig({ redactPatterns: ["123456", String.raw`\*\*\*\n(superprivate)`] });
+    const orderedResponse = await rpcReq<LogTailPayload>(ws, "logs.tail", { limit: 100 });
+    expect(orderedResponse.ok).toBe(true);
+    expect(orderedResponse.payload?.lines).toEqual(['"***"', "***"]);
+    expect(orderedResponse.payload?.cursor).toBe(Buffer.byteLength(ordered));
+    expect(await fs.readFile(file, "utf8")).toBe(ordered);
   } finally {
     applyLoggingConfig(undefined);
     setLoggerOverride({ level: "silent", consoleLevel: "silent" });
   }
 });
+
+it.each(["raw", "JSON"])(
+  "logs.tail masks %s PEM bodies across selection windows and separate cursor polls",
+  async (format) => {
+    const dir = tempDirs.make("openclaw-gateway-log-pem-context-");
+    const file = path.join(dir, "stored.log");
+    const lines = format === "JSON" ? pem.map(record) : [...pem];
+    const messages = (tail: LogTailPayload) =>
+      tail.lines.map((line) => (format === "JSON" ? JSON.parse(line).message : line));
+    const stored = `${lines.join("\n")}\n`;
+    setLoggerOverride({ file, level: "silent", consoleLevel: "silent" });
+    try {
+      await fs.writeFile(file, stored);
+      const bodyAndFooterBytes = Buffer.byteLength(`${lines.slice(1).join("\n")}\n`);
+      const header = lines[0];
+      assert(header !== undefined);
+      const middleOfHeader = header.indexOf("PRIVATE") + 3;
+      for (const selection of [
+        { limit: 2 },
+        { maxBytes: bodyAndFooterBytes },
+        { maxBytes: Buffer.byteLength(stored) - middleOfHeader },
+      ]) {
+        const response = await rpcReq<LogTailPayload>(ws, "logs.tail", selection);
+        expect(response.ok).toBe(true);
+        assert(response.payload);
+        expect(response.payload).toMatchObject({
+          cursor: Buffer.byteLength(stored),
+          size: Buffer.byteLength(stored),
+          truncated: true,
+          reset: false,
+        });
+        expect(messages(response.payload)).toEqual([
+          expect.stringMatching(/^(?:\*\*\*|…redacted…)$/),
+          pem[2],
+        ]);
+        expect(response.payload.lines.join("\n")).not.toContain(pem[1]);
+        expect(await fs.readFile(file, "utf8")).toBe(stored);
+      }
+
+      for (const chunks of [[lines.slice(0, 2), lines.slice(2)], lines.map((line) => [line])]) {
+        let cursor = 0;
+        let written = "";
+        let sourceIndex = 0;
+        await fs.writeFile(file, "");
+        for (const chunk of chunks) {
+          const appended = `${chunk.join("\n")}\n`;
+          written += appended;
+          await fs.appendFile(file, appended);
+          const response = await rpcReq<LogTailPayload>(ws, "logs.tail", { cursor });
+          expect(response.ok).toBe(true);
+          assert(response.payload);
+          expect(response.payload).toMatchObject({
+            cursor: Buffer.byteLength(written),
+            size: Buffer.byteLength(written),
+            truncated: false,
+            reset: false,
+          });
+          const expected = chunk.map(() => {
+            const message = pem[sourceIndex++];
+            return message === pem[1] ? expect.stringMatching(/^(?:\*\*\*|…redacted…)$/) : message;
+          });
+          expect(messages(response.payload)).toEqual(expected);
+          expect(response.payload.lines.join("\n")).not.toContain(pem[1]);
+          expect(await fs.readFile(file, "utf8")).toBe(written);
+          cursor = response.payload.cursor;
+          const repeated = await rpcReq<LogTailPayload>(ws, "logs.tail", { cursor });
+          expect(repeated.ok).toBe(true);
+          expect(repeated.payload?.lines).toEqual([]);
+          expect(repeated.payload?.cursor).toBe(cursor);
+        }
+      }
+    } finally {
+      setLoggerOverride({ level: "silent", consoleLevel: "silent" });
+    }
+  },
+);
 
 it("tails configured rolling placeholders through authenticated Gateway RPC", async () => {
   const tempDir = tempDirs.make("openclaw-gateway-log-tail-");

--- a/src/gateway/server.logs-tail.test.ts
+++ b/src/gateway/server.logs-tail.test.ts
@@ -1,8 +1,16 @@
+import fs from "node:fs/promises";
 import path from "node:path";
-import { afterEach, expect, it } from "vitest";
+import { afterEach, assert, expect, it } from "vitest";
 import type { WebSocket } from "ws";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
-import { flushLogger, getChildLogger, setLoggerOverride } from "../logging/logger.js";
+import type { LogTailPayload } from "../logging/log-tail.js";
+import {
+  applyLoggingConfig,
+  flushLogger,
+  getChildLogger,
+  setLoggerOverride,
+} from "../logging/logger.js";
+import { registerSecretValueForRedaction } from "../logging/secret-redaction-registry.js";
 import { installGatewayTestHooks, rpcReq } from "./test-helpers.js";
 import { installConnectedControlUiServerSuite } from "./test-with-server.js";
 
@@ -12,6 +20,77 @@ installConnectedControlUiServerSuite((started) => {
   ws = started.ws;
 });
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+it("logs.tail masks complete stored batches while preserving JSON records and byte cursors", async () => {
+  const dir = tempDirs.make("openclaw-gateway-log-batch-");
+  const file = path.join(dir, "stored.log");
+  const pem = [
+    "-----BEGIN PRIVATE KEY-----",
+    "ABCDEF1234567890",
+    "-----END PRIVATE KEY-----",
+  ] as const;
+  const record = (message: string) => JSON.stringify({ message });
+  const cases = [
+    { lines: pem.map(record), json: [0, 1, 2] },
+    { lines: [record(pem.join("\n"))], json: [0] },
+    { lines: pem, json: [] },
+    { lines: [record(pem[0]), pem[1], record(pem[2])], json: [0, 2] },
+    { lines: [record(pem[0]), pem[1], pem[1], pem[1], record(pem[2])], json: [0, 2], count: 3 },
+    { lines: [record("Authorization: Basic c2VjcmV0OnBhc3M=")], json: [0] },
+    { lines: ["before", "[[],[],[]]", "Authorization: Basic c2VjcmV0OnBhc3M="], json: [1] },
+  ];
+  setLoggerOverride({ file, level: "silent", consoleLevel: "silent" });
+  try {
+    for (const { lines, json, count = lines.length } of cases) {
+      const stored = `${lines.join("\n")}\n`;
+      await fs.writeFile(file, stored);
+      const response = await rpcReq<LogTailPayload>(ws, "logs.tail", { limit: 100 });
+      expect(response.ok).toBe(true);
+      assert(response.payload);
+      const tail = response.payload;
+      expect(tail.cursor).toBe(Buffer.byteLength(stored));
+      expect(tail.size).toBe(Buffer.byteLength(stored));
+      expect(tail.lines).toHaveLength(count);
+      expect(tail.lines.join("\n")).not.toContain(pem[1]);
+      expect(tail.lines.join("\n")).not.toContain("c2VjcmV0OnBhc3M=");
+      for (const index of json) {
+        const line = tail.lines[index];
+        assert(line !== undefined);
+        expect(() => JSON.parse(line)).not.toThrow();
+      }
+      const next = await rpcReq<LogTailPayload>(ws, "logs.tail", { cursor: tail.cursor });
+      expect(next.payload?.lines).toEqual([]);
+    }
+  } finally {
+    setLoggerOverride({ level: "silent", consoleLevel: "silent" });
+  }
+});
+
+it("logs.tail applies patterns and numeric secrets registered after the file was written", async () => {
+  const dir = tempDirs.make("openclaw-gateway-log-policy-");
+  const file = path.join(dir, "stored.log");
+  const fresh = '{ "message": "already ***", "ordinary": 42 }';
+  await fs.writeFile(
+    file,
+    [JSON.stringify({ message: "MASKME PRIVATE_STORED", numeric: 73928164 }), fresh].join("\n") +
+      "\n",
+  );
+  setLoggerOverride({ file, level: "silent", consoleLevel: "silent" });
+  applyLoggingConfig({ redactPatterns: ["MASKME", String.raw`/\*\*\* (PRIVATE_[A-Z]+)/g`] });
+  registerSecretValueForRedaction("73928164");
+  try {
+    const response = await rpcReq<LogTailPayload>(ws, "logs.tail", { limit: 100 });
+    expect(response.ok).toBe(true);
+    expect(response.payload?.lines.map((line) => JSON.parse(line))).toEqual([
+      { message: "*** ***", numeric: "***" },
+      { message: "already ***", ordinary: 42 },
+    ]);
+    expect(response.payload?.lines[1]).toBe(fresh);
+  } finally {
+    applyLoggingConfig(undefined);
+    setLoggerOverride({ level: "silent", consoleLevel: "silent" });
+  }
+});
 
 it("tails configured rolling placeholders through authenticated Gateway RPC", async () => {
   const tempDir = tempDirs.make("openclaw-gateway-log-tail-");

--- a/src/logging/log-tail.test.ts
+++ b/src/logging/log-tail.test.ts
@@ -24,6 +24,7 @@ const operationalMetadataFailures = metadataBoundaries.flatMap((boundary) =>
 );
 
 const resolvedRedaction = { mode: "tools" as const, patterns: [/custom-secret-[a-z]+/g] };
+type RedactOptions = Parameters<typeof import("./redact.js").redactSensitiveLines>[1];
 type PositionalRead = (
   buffer: Buffer,
   offset: number,
@@ -32,10 +33,15 @@ type PositionalRead = (
 ) => Promise<{ bytesRead: number; buffer: Buffer }>;
 
 const { redactSensitiveLinesMock, resolveRedactOptionsMock } = vi.hoisted(() => ({
-  redactSensitiveLinesMock: vi.fn((lines: string[], options?: unknown) =>
-    options === resolvedRedaction
-      ? lines.map((line) => line.replace("custom-secret-abcdefghijklmnopqrstuvwxyz", "custom…wxyz"))
-      : lines,
+  redactSensitiveLinesMock: vi.fn(
+    (lines: string[], options?: RedactOptions, selectedLines?: readonly boolean[]) =>
+      lines
+        .filter((_, index) => selectedLines === undefined || selectedLines[index])
+        .map((line) =>
+          options?.patterns.some((pattern) => pattern.source === "custom-secret-[a-z]+")
+            ? line.replace("custom-secret-abcdefghijklmnopqrstuvwxyz", "custom…wxyz")
+            : line,
+        ),
   ),
   resolveRedactOptionsMock: vi.fn(() => resolvedRedaction),
 }));
@@ -44,8 +50,11 @@ vi.mock("./redact.js", async () => {
   const actual = await vi.importActual<typeof import("./redact.js")>("./redact.js");
   return {
     ...actual,
-    redactSensitiveLines: (lines: string[], options?: unknown) =>
-      redactSensitiveLinesMock(lines, options),
+    redactSensitiveLines: (
+      lines: string[],
+      options?: RedactOptions,
+      selectedLines?: readonly boolean[],
+    ) => redactSensitiveLinesMock(lines, options, selectedLines),
     resolveRedactOptions: () => resolveRedactOptionsMock(),
   };
 });
@@ -94,6 +103,7 @@ describe("readConfiguredLogTail", () => {
     expect(redactSensitiveLinesMock).toHaveBeenCalledWith(
       ["custom-secret-abcdefghijklmnopqrstuvwxyz", "second line"],
       resolvedRedaction,
+      [true, true],
     );
     expect(result.lines).toEqual(["custom…wxyz", "second line"]);
   });

--- a/src/logging/log-tail.ts
+++ b/src/logging/log-tail.ts
@@ -1,6 +1,7 @@
 // Log tail helpers read recent log lines with optional parsing and redaction.
 import fs from "node:fs/promises";
 import path from "node:path";
+import { StringDecoder } from "node:string_decoder";
 import { isMissingPathError } from "../infra/errno.js";
 import { readFileWindowFully } from "../infra/file-read.js";
 import { clamp } from "../utils.js";
@@ -76,6 +77,7 @@ async function readLogSlice(params: {
   limit: number;
   maxBytes: number;
   filter?: (line: string) => boolean;
+  redaction: ReturnType<typeof resolveRedactOptions>;
 }): Promise<Omit<LogTailPayload, "file">> {
   const size = (await fs.stat(params.file).catch(missingPathToNull))?.size ?? 0;
   const maxBytes = clamp(params.maxBytes, 1, MAX_BYTES);
@@ -125,6 +127,30 @@ async function readLogSlice(params: {
 
   const handle = await fs.open(params.file, "r");
   try {
+    const contexts = params.redaction.patterns.map((pattern) =>
+      pattern instanceof RegExp ? undefined : pattern.createContext?.(),
+    );
+    const consume = (text: string) => {
+      for (const context of contexts) {
+        context?.consume(text);
+      }
+    };
+    if (start > 0 && contexts.some(Boolean)) {
+      // Reconstruct matching context without retaining or tokenizing old file contents.
+      const prefixBuffer = Buffer.alloc(Math.min(start, DEFAULT_MAX_BYTES));
+      const decoder = new StringDecoder("utf8");
+      let offset = 0;
+      while (offset < start) {
+        const length = Math.min(prefixBuffer.length, start - offset);
+        const { bytesRead } = await handle.read(prefixBuffer, 0, length, offset);
+        if (bytesRead === 0) {
+          break;
+        }
+        consume(decoder.write(prefixBuffer.subarray(0, bytesRead)));
+        offset += bytesRead;
+      }
+      consume(decoder.end());
+    }
     let prefix = "";
     if (start > 0) {
       const prefixBuf = Buffer.alloc(1);
@@ -136,19 +162,25 @@ async function readLogSlice(params: {
     const buffer = Buffer.alloc(length);
     const bytesRead = await readFileWindowFully(handle, buffer, start);
     const text = buffer.toString("utf8", 0, bytesRead);
-    let lines = text.split("\n");
+    const lines = text.split("\n");
     lines.pop();
     if (start > 0 && prefix !== "\n") {
       // Drop the first partial line when starting in the middle of a file.
-      lines.shift();
+      const partial = lines.shift();
+      if (partial !== undefined) {
+        consume(`${partial}\n`);
+      }
     }
-    if (params.filter) {
-      // Sparse consumers inspect the full byte-bounded window before the shared line cap.
-      lines = lines.filter(params.filter);
-    }
-    if (lines.length > limit) {
+    const selected = lines.map((line) => params.filter?.(line) ?? true);
+    let selectedCount = selected.filter(Boolean).length;
+    if (selectedCount > limit) {
       truncated = true;
-      lines = lines.slice(lines.length - limit);
+      for (let index = 0; selectedCount > limit; index += 1) {
+        if (selected[index]) {
+          selected[index] = false;
+          selectedCount -= 1;
+        }
+      }
     }
 
     // Keep an unterminated record pending so a later read can emit it whole.
@@ -158,7 +190,16 @@ async function readLogSlice(params: {
     return {
       cursor,
       size,
-      lines,
+      lines: redactSensitiveLines(
+        lines,
+        {
+          ...params.redaction,
+          patterns: params.redaction.patterns.map(
+            (pattern, index) => contexts[index]?.pattern ?? pattern,
+          ),
+        },
+        selected,
+      ),
       truncated,
       reset,
       skippedBytes,
@@ -181,12 +222,11 @@ export async function readConfiguredLogTail(
     limit: params?.limit ?? DEFAULT_LIMIT,
     maxBytes: params?.maxBytes ?? DEFAULT_MAX_BYTES,
     filter,
+    redaction: resolveRedactOptions(),
   });
-  const redaction = resolveRedactOptions();
   return {
     file,
     ...result,
-    lines: redactSensitiveLines(result.lines, redaction),
   };
 }
 

--- a/src/logging/redact-json-tokens.ts
+++ b/src/logging/redact-json-tokens.ts
@@ -1,0 +1,217 @@
+import { expectDefined } from "@openclaw/normalization-core";
+import type { RedactionEdit } from "./redact-edit-composition.js";
+
+type RedactionScalarOrigin = { structured: boolean; primitiveMask: boolean };
+export type RedactionOrigins = {
+  value: RedactionScalarOrigin;
+  children: Map<string, RedactionOrigins>;
+};
+export type RedactionField = {
+  origin: RedactionScalarOrigin;
+  key: string;
+  path: readonly string[];
+  objectPath: boolean;
+  isKey: boolean;
+  string: boolean;
+  value: string;
+};
+export type ScalarToken = RedactionField & {
+  raw?: boolean;
+  start: number;
+  end: number;
+  escaped: boolean;
+  boundaries?: Map<number, number>;
+  encodedBoundaries?: number[];
+  rootKey?: string;
+  rootValueStart?: number;
+  edits: RedactionEdit[];
+  projectedEdits: RedactionEdit[];
+  currentValue: string;
+  currentStart: number;
+  currentEnd: number;
+  currentRaw?: string;
+  encodedEdits?: EncodedEdit[];
+  pending?: RedactionEdit[];
+};
+
+export type EncodedEdit = {
+  start: number;
+  end: number;
+  decodedStart: number;
+  decodedEnd: number;
+  sourceEnd: number;
+  sourceDecodedEnd: number;
+  replacement: string;
+};
+
+type FieldContext = Pick<RedactionField, "key" | "path" | "objectPath"> & {
+  origins?: RedactionOrigins;
+  origin: RedactionScalarOrigin;
+  rootKey?: string;
+  rootValueStart?: number;
+};
+type JsonContainer = {
+  array: boolean;
+  nextIndex: number;
+  context: FieldContext;
+  field?: FieldContext;
+};
+
+const JSON_TOKEN_RE = /"(?:[^"\\]|\\.)*"|-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?|true|false|null|[{}[\]]/g;
+
+export function readScalarTokens(text: string, origins: RedactionOrigins): ScalarToken[] {
+  const tokens: ScalarToken[] = [];
+  const containers: JsonContainer[] = [];
+  const root: FieldContext = {
+    key: "",
+    path: [],
+    origins,
+    origin: origins.value,
+    objectPath: true,
+  };
+  const valueContext = (parent: JsonContainer | undefined): FieldContext =>
+    !parent
+      ? root
+      : parent.array
+        ? {
+            ...parent.context,
+            origin: parent.context.origins?.value ?? parent.context.origin,
+            origins: parent.context.origins?.children.get(String(parent.nextIndex++)),
+          }
+        : expectDefined(parent.field, "JSON object field context");
+  for (const match of text.matchAll(JSON_TOKEN_RE)) {
+    const raw = match[0];
+    const parent = containers.at(-1);
+    if (raw === "{" || raw === "[") {
+      const context = valueContext(parent);
+      const array = raw === "[";
+      containers.push({
+        array,
+        nextIndex: 0,
+        context: array ? { ...context, objectPath: false } : context,
+      });
+      continue;
+    }
+    if (raw === "}" || raw === "]") {
+      containers.pop();
+      continue;
+    }
+    const start = match.index;
+    const end = start + raw.length;
+    const string = raw.startsWith('"');
+    const value: string = string ? JSON.parse(raw) : raw;
+    let next = end;
+    while (
+      text[next] === " " ||
+      text[next] === "\t" ||
+      text[next] === "\r" ||
+      text[next] === "\n"
+    ) {
+      next += 1;
+    }
+    const isKey = string && text[next] === ":";
+    let context: FieldContext;
+    if (isKey) {
+      const container = expectDefined(parent, "JSON property container");
+      const inherited = container.context;
+      context = {
+        key: "",
+        path: [],
+        origin: inherited.origin,
+        objectPath: false,
+        rootKey: inherited.rootKey,
+        rootValueStart: inherited.rootValueStart,
+      };
+      let valueStart = next + 1;
+      while (
+        text[valueStart] === " " ||
+        text[valueStart] === "\t" ||
+        text[valueStart] === "\r" ||
+        text[valueStart] === "\n"
+      ) {
+        valueStart += 1;
+      }
+      container.field = {
+        key: value,
+        path: [...inherited.path, value],
+        origins: inherited.origins?.children.get(value),
+        origin: inherited.origins?.value ?? inherited.origin,
+        objectPath: inherited.objectPath,
+        rootKey: containers.length === 1 ? value : inherited.rootKey,
+        rootValueStart: containers.length === 1 ? valueStart : inherited.rootValueStart,
+      };
+    } else {
+      context = valueContext(parent);
+    }
+    const origin: RedactionScalarOrigin = isKey
+      ? { structured: false, primitiveMask: false }
+      : (context.origins?.value ?? context.origin);
+    tokens.push({
+      ...context,
+      origin,
+      start,
+      end,
+      isKey,
+      string,
+      value,
+      escaped: string && raw.includes("\\"),
+      edits: [],
+      projectedEdits: [],
+      currentValue: value,
+      currentStart: start,
+      currentEnd: end,
+    });
+  }
+  return tokens;
+}
+
+export function readBatchTokens(input: string, origins: RedactionOrigins): ScalarToken[] {
+  const tokens: ScalarToken[] = [];
+  let offset = 0;
+  for (const line of input.split("\n")) {
+    let json = false;
+    try {
+      JSON.parse(line);
+      json = true;
+    } catch {
+      // Historical logs and journal output can mix JSON records with raw text.
+    }
+    if (json) {
+      for (const token of readScalarTokens(line, origins)) {
+        token.start += offset;
+        token.end += offset;
+        token.currentStart += offset;
+        token.currentEnd += offset;
+        tokens.push(token);
+      }
+    } else {
+      const previous = tokens.at(-1);
+      if (previous?.raw && previous.end + 1 === offset) {
+        previous.value += `\n${line}`;
+        previous.currentValue = previous.value;
+        previous.end = previous.currentEnd = offset + line.length;
+      } else {
+        tokens.push({
+          raw: true,
+          origin: origins.value,
+          key: "",
+          path: [],
+          objectPath: false,
+          isKey: false,
+          string: false,
+          value: line,
+          escaped: false,
+          start: offset,
+          end: offset + line.length,
+          currentStart: offset,
+          currentEnd: offset + line.length,
+          currentValue: line,
+          edits: [],
+          projectedEdits: [],
+        });
+      }
+    }
+    offset += line.length + 1;
+  }
+  return tokens;
+}

--- a/src/logging/redact-json-tokens.ts
+++ b/src/logging/redact-json-tokens.ts
@@ -17,6 +17,7 @@ export type RedactionField = {
 };
 export type ScalarToken = RedactionField & {
   raw?: boolean;
+  deferEncoding?: boolean;
   start: number;
   end: number;
   escaped: boolean;
@@ -55,6 +56,8 @@ type JsonContainer = {
   nextIndex: number;
   context: FieldContext;
   field?: FieldContext;
+  start: number;
+  tokenStart: number;
 };
 
 const JSON_TOKEN_RE = /"(?:[^"\\]|\\.)*"|-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?|true|false|null|[{}[\]]/g;
@@ -89,11 +92,31 @@ export function readScalarTokens(text: string, origins: RedactionOrigins): Scala
         array,
         nextIndex: 0,
         context: array ? { ...context, objectPath: false } : context,
+        start: match.index,
+        tokenStart: tokens.length,
       });
       continue;
     }
     if (raw === "}" || raw === "]") {
-      containers.pop();
+      const container = expectDefined(containers.pop(), "JSON container");
+      if (container.tokenStart === tokens.length) {
+        const end = match.index + 1;
+        const value = text.slice(container.start, end);
+        tokens.push({
+          ...container.context,
+          isKey: false,
+          string: false,
+          value,
+          start: container.start,
+          end,
+          escaped: false,
+          edits: [],
+          projectedEdits: [],
+          currentValue: value,
+          currentStart: container.start,
+          currentEnd: end,
+        });
+      }
       continue;
     }
     const start = match.index;
@@ -165,7 +188,11 @@ export function readScalarTokens(text: string, origins: RedactionOrigins): Scala
   return tokens;
 }
 
-export function readBatchTokens(input: string, origins: RedactionOrigins): ScalarToken[] {
+export function readBatchTokens(
+  input: string,
+  origins: RedactionOrigins,
+  preserveLines = false,
+): ScalarToken[] {
   const tokens: ScalarToken[] = [];
   let offset = 0;
   for (const line of input.split("\n")) {
@@ -178,6 +205,7 @@ export function readBatchTokens(input: string, origins: RedactionOrigins): Scala
     }
     if (json) {
       for (const token of readScalarTokens(line, origins)) {
+        token.deferEncoding = !token.string;
         token.start += offset;
         token.end += offset;
         token.currentStart += offset;
@@ -186,7 +214,7 @@ export function readBatchTokens(input: string, origins: RedactionOrigins): Scala
       }
     } else {
       const previous = tokens.at(-1);
-      if (previous?.raw && previous.end + 1 === offset) {
+      if (!preserveLines && previous?.raw && previous.end + 1 === offset) {
         previous.value += `\n${line}`;
         previous.currentValue = previous.value;
         previous.end = previous.currentEnd = offset + line.length;

--- a/src/logging/redact-json.ts
+++ b/src/logging/redact-json.ts
@@ -7,6 +7,14 @@ import {
   type RedactionEdit,
 } from "./redact-edit-composition.js";
 import {
+  readBatchTokens,
+  readScalarTokens,
+  type ScalarToken,
+  type EncodedEdit,
+  type RedactionOrigins,
+  type RedactionField,
+} from "./redact-json-tokens.js";
+import {
   iterateRedactMatches,
   type RedactMatch,
   type ResolvedRedactPattern,
@@ -16,11 +24,6 @@ export type RedactionTarget = {
   start: number;
   end: number;
   value: string;
-};
-type RedactionScalarOrigin = { structured: boolean; primitiveMask: boolean };
-export type RedactionOrigins = {
-  value: RedactionScalarOrigin;
-  children: Map<string, RedactionOrigins>;
 };
 export type RedactionEditSelector = (
   match: RedactMatch,
@@ -47,15 +50,6 @@ export function getPatternRedactionEdits(
   return edits;
 }
 
-export type RedactionField = {
-  origin: RedactionScalarOrigin;
-  key: string;
-  path: readonly string[];
-  objectPath: boolean;
-  isKey: boolean;
-  string: boolean;
-  value: string;
-};
 export type RedactionMessage = {
   text: string;
   contentLength: number;
@@ -68,155 +62,6 @@ export type RedactionMessage = {
     primitiveLength?: number;
   }[];
 };
-
-type ScalarToken = RedactionField & {
-  start: number;
-  end: number;
-  escaped: boolean;
-  boundaries?: Map<number, number>;
-  encodedBoundaries?: number[];
-  rootKey?: string;
-  rootValueStart?: number;
-  edits: RedactionEdit[];
-  projectedEdits: RedactionEdit[];
-  currentValue: string;
-  currentStart: number;
-  currentEnd: number;
-  currentRaw?: string;
-  encodedEdits?: EncodedEdit[];
-  pending?: RedactionEdit[];
-};
-
-type EncodedEdit = {
-  start: number;
-  end: number;
-  decodedStart: number;
-  decodedEnd: number;
-  sourceEnd: number;
-  sourceDecodedEnd: number;
-  replacement: string;
-};
-
-type FieldContext = Pick<RedactionField, "key" | "path" | "objectPath"> & {
-  origins?: RedactionOrigins;
-  origin: RedactionScalarOrigin;
-  rootKey?: string;
-  rootValueStart?: number;
-};
-type JsonContainer = {
-  array: boolean;
-  nextIndex: number;
-  context: FieldContext;
-  field?: FieldContext;
-};
-
-const JSON_TOKEN_RE = /"(?:[^"\\]|\\.)*"|-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?|true|false|null|[{}[\]]/g;
-
-function readScalarTokens(text: string, origins: RedactionOrigins): ScalarToken[] {
-  const tokens: ScalarToken[] = [];
-  const containers: JsonContainer[] = [];
-  const root: FieldContext = {
-    key: "",
-    path: [],
-    origins,
-    origin: origins.value,
-    objectPath: true,
-  };
-  const valueContext = (parent: JsonContainer | undefined): FieldContext =>
-    !parent
-      ? root
-      : parent.array
-        ? {
-            ...parent.context,
-            origin: parent.context.origins?.value ?? parent.context.origin,
-            origins: parent.context.origins?.children.get(String(parent.nextIndex++)),
-          }
-        : expectDefined(parent.field, "JSON object field context");
-  for (const match of text.matchAll(JSON_TOKEN_RE)) {
-    const raw = match[0];
-    const parent = containers.at(-1);
-    if (raw === "{" || raw === "[") {
-      const context = valueContext(parent);
-      const array = raw === "[";
-      containers.push({
-        array,
-        nextIndex: 0,
-        context: array ? { ...context, objectPath: false } : context,
-      });
-      continue;
-    }
-    if (raw === "}" || raw === "]") {
-      containers.pop();
-      continue;
-    }
-    const start = match.index;
-    const end = start + raw.length;
-    const string = raw.startsWith('"');
-    const value: string = string ? JSON.parse(raw) : raw;
-    let next = end;
-    while (
-      text[next] === " " ||
-      text[next] === "\t" ||
-      text[next] === "\r" ||
-      text[next] === "\n"
-    ) {
-      next += 1;
-    }
-    const isKey = string && text[next] === ":";
-    let context: FieldContext;
-    if (isKey) {
-      const container = expectDefined(parent, "JSON property container");
-      const inherited = container.context;
-      context = {
-        key: "",
-        path: [],
-        origin: inherited.origin,
-        objectPath: false,
-        rootKey: inherited.rootKey,
-        rootValueStart: inherited.rootValueStart,
-      };
-      let valueStart = next + 1;
-      while (
-        text[valueStart] === " " ||
-        text[valueStart] === "\t" ||
-        text[valueStart] === "\r" ||
-        text[valueStart] === "\n"
-      ) {
-        valueStart += 1;
-      }
-      container.field = {
-        key: value,
-        path: [...inherited.path, value],
-        origins: inherited.origins?.children.get(value),
-        origin: inherited.origins?.value ?? inherited.origin,
-        objectPath: inherited.objectPath,
-        rootKey: containers.length === 1 ? value : inherited.rootKey,
-        rootValueStart: containers.length === 1 ? valueStart : inherited.rootValueStart,
-      };
-    } else {
-      context = valueContext(parent);
-    }
-    const origin: RedactionScalarOrigin = isKey
-      ? { structured: false, primitiveMask: false }
-      : (context.origins?.value ?? context.origin);
-    tokens.push({
-      ...context,
-      origin,
-      start,
-      end,
-      isKey,
-      string,
-      value,
-      escaped: string && raw.includes("\\"),
-      edits: [],
-      projectedEdits: [],
-      currentValue: value,
-      currentStart: start,
-      currentEnd: end,
-    });
-  }
-  return tokens;
-}
 
 function stringBoundaries(text: string, token: ScalarToken): Map<number, number> {
   const boundaries = new Map<number, number>();
@@ -326,6 +171,10 @@ function firstIntersectingToken(tokens: ScalarToken[], start: number): number {
 }
 
 function updateCurrentToken(input: string, token: ScalarToken): void {
+  if (token.raw) {
+    token.currentRaw = token.currentValue;
+    return;
+  }
   const parts: string[] = [];
   const encodedEdits: EncodedEdit[] = [];
   let cursor = token.start + (token.string ? 1 : 0);
@@ -520,8 +369,9 @@ export function redactJsonRecord(
   prepEdits: (field: RedactionField) => RedactionEdit[],
   preserveDecodedField: (field: RedactionField) => boolean,
   message?: RedactionMessage,
+  batch = false,
 ): string {
-  const tokens = readScalarTokens(input, origins);
+  const tokens = batch ? readBatchTokens(input, origins) : readScalarTokens(input, origins);
   const decodedTokens = tokens.filter(
     (token) => !token.isKey && token.string && !preserveDecodedField(token),
   );
@@ -625,14 +475,19 @@ export function redactJsonRecord(
               break;
             }
             const value = token.currentValue;
-            if (!token.string && token.edits.length === 0) {
+            if (!token.raw && !token.string && token.edits.length === 0) {
               add(token, { start: 0, end: value.length, replacement: "***" });
               continue;
             }
-            let startPosition = Math.max(capture.start, token.currentStart + 1);
-            let start = currentDecodedBoundary(input, token, startPosition, replacementBoundaries);
-            let endPosition = Math.min(capture.end, token.currentEnd - 1);
-            let end = currentDecodedBoundary(input, token, endPosition, replacementBoundaries);
+            const padding = token.raw ? 0 : 1;
+            let startPosition = Math.max(capture.start, token.currentStart + padding);
+            let start = token.raw
+              ? startPosition - token.currentStart
+              : currentDecodedBoundary(input, token, startPosition, replacementBoundaries);
+            let endPosition = Math.min(capture.end, token.currentEnd - padding);
+            let end = token.raw
+              ? endPosition - token.currentStart
+              : currentDecodedBoundary(input, token, endPosition, replacementBoundaries);
             if (start === undefined || end === undefined) {
               while (start === undefined) {
                 start = currentDecodedBoundary(
@@ -660,17 +515,20 @@ export function redactJsonRecord(
               start,
               end,
               value: current.slice(
-                Math.max(captureStart, token.currentStart + 1),
-                Math.min(captureEnd, token.currentEnd - 1),
+                Math.max(captureStart, token.currentStart + padding),
+                Math.min(captureEnd, token.currentEnd - padding),
               ),
             }));
             if (!edit) {
               continue;
             }
             let replacement = "***";
-            if (capture.start >= token.currentStart + 1 && capture.end <= token.currentEnd - 1) {
+            if (
+              capture.start >= token.currentStart + padding &&
+              capture.end <= token.currentEnd - padding
+            ) {
               try {
-                replacement = JSON.parse(`"${edit.replacement}"`);
+                replacement = token.raw ? edit.replacement : JSON.parse(`"${edit.replacement}"`);
               } catch {
                 // A legacy hint can cut an escape; its selected span still receives a full mask.
               }

--- a/src/logging/redact-json.ts
+++ b/src/logging/redact-json.ts
@@ -20,6 +20,8 @@ import {
   type ResolvedRedactPattern,
 } from "./redact-pattern-runtime.js";
 
+export type { RedactionField, RedactionOrigins } from "./redact-json-tokens.js";
+
 export type RedactionTarget = {
   start: number;
   end: number;

--- a/src/logging/redact-json.ts
+++ b/src/logging/redact-json.ts
@@ -173,7 +173,7 @@ function firstIntersectingToken(tokens: ScalarToken[], start: number): number {
 }
 
 function updateCurrentToken(input: string, token: ScalarToken): void {
-  if (token.raw) {
+  if (token.raw || token.deferEncoding) {
     token.currentRaw = token.currentValue;
     return;
   }
@@ -371,9 +371,11 @@ export function redactJsonRecord(
   prepEdits: (field: RedactionField) => RedactionEdit[],
   preserveDecodedField: (field: RedactionField) => boolean,
   message?: RedactionMessage,
-  batch = false,
+  batch?: { preserveLines: boolean },
 ): string {
-  const tokens = batch ? readBatchTokens(input, origins) : readScalarTokens(input, origins);
+  const tokens = batch
+    ? readBatchTokens(input, origins, batch.preserveLines)
+    : readScalarTokens(input, origins);
   const decodedTokens = tokens.filter(
     (token) => !token.isKey && token.string && !preserveDecodedField(token),
   );
@@ -476,18 +478,22 @@ export function redactJsonRecord(
             if (token.currentStart >= capture.end) {
               break;
             }
+            if (batch && token.isKey) {
+              continue;
+            }
             const value = token.currentValue;
             if (!token.raw && !token.string && token.edits.length === 0) {
               add(token, { start: 0, end: value.length, replacement: "***" });
               continue;
             }
-            const padding = token.raw ? 0 : 1;
+            const unquoted = token.raw || token.deferEncoding;
+            const padding = unquoted ? 0 : 1;
             let startPosition = Math.max(capture.start, token.currentStart + padding);
-            let start = token.raw
+            let start = unquoted
               ? startPosition - token.currentStart
               : currentDecodedBoundary(input, token, startPosition, replacementBoundaries);
             let endPosition = Math.min(capture.end, token.currentEnd - padding);
-            let end = token.raw
+            let end = unquoted
               ? endPosition - token.currentStart
               : currentDecodedBoundary(input, token, endPosition, replacementBoundaries);
             if (start === undefined || end === undefined) {
@@ -509,7 +515,7 @@ export function redactJsonRecord(
               add(token, { start, end: maskEnd, replacement: "***" });
               continue;
             }
-            if (end < start) {
+            if (end < start || (batch && end === start)) {
               continue;
             }
             const { start: captureStart, end: captureEnd } = capture;
@@ -530,7 +536,7 @@ export function redactJsonRecord(
               capture.end <= token.currentEnd - padding
             ) {
               try {
-                replacement = token.raw ? edit.replacement : JSON.parse(`"${edit.replacement}"`);
+                replacement = unquoted ? edit.replacement : JSON.parse(`"${edit.replacement}"`);
               } catch {
                 // A legacy hint can cut an escape; its selected span still receives a full mask.
               }
@@ -579,5 +585,18 @@ export function redactJsonRecord(
       ]);
     }
   }
-  return current;
+  return applyRedactionEdits(
+    current,
+    tokens.flatMap((token) =>
+      token.deferEncoding && token.edits.length > 0
+        ? [
+            {
+              start: token.currentStart,
+              end: token.currentEnd,
+              replacement: JSON.stringify(token.currentValue),
+            },
+          ]
+        : [],
+    ),
+  );
 }

--- a/src/logging/redact-json.ts
+++ b/src/logging/redact-json.ts
@@ -373,9 +373,7 @@ export function redactJsonRecord(
   message?: RedactionMessage,
   batch?: { preserveLines: boolean },
 ): string {
-  const tokens = batch
-    ? readBatchTokens(input, origins, batch.preserveLines)
-    : readScalarTokens(input, origins);
+  let tokens = batch ? [] : readScalarTokens(input, origins);
   const decodedTokens = tokens.filter(
     (token) => !token.isKey && token.string && !preserveDecodedField(token),
   );
@@ -468,6 +466,10 @@ export function redactJsonRecord(
           });
           if (!capture || capture.end < capture.start) {
             continue;
+          }
+          // Batch rules need token coordinates only after a serialized match exists.
+          if (batch && tokens.length === 0) {
+            tokens = readBatchTokens(input, origins, batch.preserveLines);
           }
           for (
             let index = firstIntersectingToken(tokens, capture.start);

--- a/src/logging/redact-pattern-runtime.ts
+++ b/src/logging/redact-pattern-runtime.ts
@@ -36,6 +36,10 @@ export type RedactMatch = ReturnType<typeof readRedactMatch> & { replacement?: s
 type RedactMatcher = {
   readonly source: string;
   readonly exec: (text: string) => Iterable<RedactMatch>;
+  readonly createContext?: () => {
+    consume: (text: string) => void;
+    pattern: ResolvedRedactPattern;
+  };
 };
 export type ResolvedRedactPattern = RegExp | RedactMatcher;
 export type RedactPattern = string | ResolvedRedactPattern;

--- a/src/logging/redact-patterns.ts
+++ b/src/logging/redact-patterns.ts
@@ -8,6 +8,7 @@ import {
   HTTP_AUTH_SERIALIZED_QUOTE_PATTERN,
 } from "../../packages/acp-core/src/structured-auth-redaction.js";
 import type { RedactMatch, RedactPattern } from "./redact-pattern-runtime.js";
+import { PEM_REDACT_PATTERN_SOURCE } from "./redact-pem.js";
 
 export const PAYMENT_CREDENTIAL_ENV_KEYS = String.raw`CARD[_-]?NUMBER|CARD[_-]?CVC|CARD[_-]?CVV|CVC|CVV|SECURITY[_-]?CODE|PAYMENT[_-]?CREDENTIAL|SHARED[_-]?PAYMENT[_-]?TOKEN`;
 export const PAYMENT_CREDENTIAL_QUERY_KEYS = String.raw`card[-_]?number|card[-_]?cvc|card[-_]?cvv|cvc|cvv|security[-_]?code|payment[-_]?credential|shared[-_]?payment[-_]?token`;
@@ -65,8 +66,8 @@ const ENV_ASSIGNMENT_REDACT_PATTERN = String.raw`/\b[A-Z0-9_]*(?:KEY|TOKEN|SECRE
 const ESCAPED_ENV_ASSIGNMENT_REDACT_PATTERN = String.raw`/\b[A-Z0-9_]*(?:KEY|TOKEN|SECRET|PASSWORD|PASSWD|${PAYMENT_CREDENTIAL_ENV_KEYS})\b\s*[=:]\s*\\+(["'])([^\s"'\\]+)\\+\1/g`;
 // Quoted values may contain the other quote characters; only the matching closing quote ends
 // the value. The unquoted variant accepts one leading quote so unterminated values still mask.
-const STANDALONE_ASSIGNMENT_QUOTED_REDACT_PATTERN = String.raw`(^|[\s,;({\[])(?:${STANDALONE_ASSIGNMENT_SECRET_KEYS})=(["'\x60])((?:(?!\2)[^\r\n])+)\2`;
-const STANDALONE_ASSIGNMENT_REDACT_PATTERN = String.raw`(^|[\s,;({\[])(?:${STANDALONE_ASSIGNMENT_SECRET_KEYS})=(["'\x60]?[^\s&#"'\x60<>]+)`;
+const STANDALONE_ASSIGNMENT_QUOTED_REDACT_PATTERN = String.raw`(^|[\s,;({\["])(?:${STANDALONE_ASSIGNMENT_SECRET_KEYS})=(["'\x60])((?:(?!\2)[^\r\n])+)\2`;
+const STANDALONE_ASSIGNMENT_REDACT_PATTERN = String.raw`(^|[\s,;({\["])(?:${STANDALONE_ASSIGNMENT_SECRET_KEYS})=(["'\x60]?[^\s&#"'\x60<>]+)`;
 const CONFIG_QUOTED_ASSIGNMENT_SECRET_KEYS = String.raw`access[-_]?token|refresh[-_]?token|id[-_]?token|auth[-_]?token|hook[-_]?token|api[-_]?(?:key|secret)|secret[-_]?key|key[-_]?material|authorization|jwt|token|secret|password|passphrase|pass|passwd|${PAYMENT_CREDENTIAL_QUERY_KEYS}`;
 const CONFIG_QUOTED_ASSIGNMENT_REDACT_PATTERN = String.raw`/(^|[\s,{])(?:(?:${CONFIG_QUOTED_ASSIGNMENT_SECRET_KEYS})(?:\s*:\s*|\s+=\s*|=\s*)|[a-z0-9][a-z0-9._-]{0,79}[-_](?:${CONFIG_PREFIXED_PASSWORD_ASSIGNMENT_SECRET_KEYS})\s*[:=]\s*|[a-z0-9_.-]{1,80}\.(?:${CONFIG_ASSIGNMENT_SECRET_KEYS})\s*[:=]\s*)(["'\x60])((?:(?!\2)[^\r\n])+)\2/g`;
 const CONFIG_ASSIGNMENT_REDACT_PATTERN = String.raw`/(^|[\s,{])(?:${CONFIG_ASSIGNMENT_SECRET_KEYS})(?:\s*:\s*|\s+=\s*|=\s+)([^\s#"'\x60<>]+)/g`;
@@ -324,7 +325,7 @@ const DEFAULT_REDACT_FIELD_PATTERNS: readonly string[] = [
   CONFIG_DIRECT_ASSIGNMENT_REDACT_PATTERN,
   CONFIG_PREFIXED_PASSWORD_ASSIGNMENT_REDACT_PATTERN,
   CONFIG_NAMESPACED_ASSIGNMENT_REDACT_PATTERN,
-  String.raw`-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]+?-----END [A-Z ]*PRIVATE KEY-----`,
+  PEM_REDACT_PATTERN_SOURCE,
   String.raw`(^|[\s,{])["']?(?:${AWS_SECRET_ACCESS_KEY_FIELD_KEYS})["']?\s*[:=]\s*(["']?)([A-Za-z0-9/+=]{40})(?![A-Za-z0-9/+=])\2`,
 ];
 

--- a/src/logging/redact-pem.ts
+++ b/src/logging/redact-pem.ts
@@ -1,0 +1,194 @@
+import type { RedactMatch, ResolvedRedactPattern } from "./redact-pattern-runtime.js";
+
+export const PEM_REDACT_PATTERN_SOURCE = String.raw`-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]+?-----END [A-Z ]*PRIVATE KEY-----`;
+
+type Delimiter = { kind: "begin" | "end"; start: number; end: number };
+type Scanner = {
+  offset: number;
+  phase: "search" | "keyword" | "label" | "close";
+  dashes: number;
+  keyword: "BEGIN " | "END ";
+  keywordOffset: number;
+  start: number;
+  suffix: string;
+};
+type PemState = {
+  scanner: Scanner;
+  open?: { start: number; end: number };
+  matchEnd: number;
+};
+
+function createState(): PemState {
+  return {
+    scanner: {
+      offset: 0,
+      phase: "search",
+      dashes: 0,
+      keyword: "BEGIN ",
+      keywordOffset: 0,
+      start: 0,
+      suffix: "",
+    },
+    matchEnd: 0,
+  };
+}
+
+function resetScanner(scanner: Scanner, char: string): void {
+  scanner.phase = "search";
+  scanner.dashes = char === "-" ? 1 : 0;
+  scanner.suffix = "";
+}
+
+function* readDelimiters(text: string, scanner: Scanner): Iterable<Delimiter> {
+  for (let index = 0; index < text.length; index += 1) {
+    if (scanner.phase === "search" && scanner.dashes === 0) {
+      const nextDash = text.indexOf("-", index);
+      if (nextDash === -1) {
+        scanner.offset += text.length - index;
+        return;
+      }
+      scanner.offset += nextDash - index;
+      index = nextDash;
+    }
+    const code = text.charCodeAt(index);
+    const char = code >= 97 && code <= 122 ? String.fromCharCode(code - 32) : text.charAt(index);
+    const offset = scanner.offset++;
+    switch (scanner.phase) {
+      case "search":
+        if (char === "-") {
+          scanner.dashes = Math.min(5, scanner.dashes + 1);
+        } else if (scanner.dashes === 5 && (char === "B" || char === "E")) {
+          scanner.phase = "keyword";
+          scanner.keyword = char === "B" ? "BEGIN " : "END ";
+          scanner.keywordOffset = 1;
+          scanner.start = offset - 5;
+        } else {
+          scanner.dashes = 0;
+        }
+        break;
+      case "keyword":
+        if (char !== scanner.keyword.charAt(scanner.keywordOffset)) {
+          resetScanner(scanner, char);
+        } else if (++scanner.keywordOffset === scanner.keyword.length) {
+          scanner.phase = "label";
+          scanner.suffix = "";
+        }
+        break;
+      case "label":
+        if ((char >= "A" && char <= "Z") || char === " ") {
+          // The label is unbounded; only its fixed terminal phrase matters.
+          scanner.suffix = (scanner.suffix + char).slice(-"PRIVATE KEY".length);
+        } else if (char === "-" && scanner.suffix === "PRIVATE KEY") {
+          scanner.phase = "close";
+          scanner.dashes = 1;
+        } else {
+          resetScanner(scanner, char);
+        }
+        break;
+      case "close":
+        if (char !== "-") {
+          resetScanner(scanner, char);
+        } else if (++scanner.dashes === 5) {
+          scanner.phase = "search";
+          scanner.suffix = "";
+          // An unmatched delimiter can share these dashes with the next opener.
+          yield {
+            kind: scanner.keyword === "BEGIN " ? "begin" : "end",
+            start: scanner.start,
+            end: offset + 1,
+          };
+        }
+        break;
+    }
+  }
+}
+
+function consumeDelimiter(
+  state: PemState,
+  delimiter: Delimiter,
+): { start: number; end: number; bodyStart: number; bodyEnd: number } | undefined {
+  if (!state.open) {
+    if (delimiter.kind === "begin" && delimiter.start >= state.matchEnd) {
+      state.open = { start: delimiter.start, end: delimiter.end };
+    }
+    return undefined;
+  }
+  // The public expression requires at least one character between delimiters.
+  if (delimiter.kind !== "end" || delimiter.start <= state.open.end) {
+    return undefined;
+  }
+  const block = {
+    start: state.open.start,
+    end: delimiter.end,
+    bodyStart: state.open.end,
+    bodyEnd: delimiter.start,
+  };
+  state.open = undefined;
+  state.matchEnd = delimiter.end;
+  return block;
+}
+
+function* matchPem(text: string, context: PemState, incomplete: boolean): Iterable<RedactMatch> {
+  const state: PemState = {
+    ...context,
+    scanner: { ...context.scanner },
+    open: context.open && { ...context.open },
+  };
+  const origin = state.scanner.offset;
+  for (const delimiter of readDelimiters(text, state.scanner)) {
+    const block = consumeDelimiter(state, delimiter);
+    if (!block) {
+      continue;
+    }
+    const start = Math.max(0, (incomplete ? block.bodyStart : block.start) - origin);
+    const end = (incomplete ? block.bodyEnd : block.end) - origin;
+    if (end <= start) {
+      continue;
+    }
+    yield {
+      match: text.slice(start, end),
+      groups: [],
+      input: text,
+      offset: start,
+      ...(incomplete ? { replacement: "…redacted…" } : {}),
+    };
+  }
+  if (incomplete && state.open) {
+    const start = Math.max(0, state.open.end - origin);
+    if (start < text.length) {
+      yield {
+        match: text.slice(start),
+        groups: [],
+        input: text,
+        offset: start,
+        replacement: "…redacted…",
+      };
+    }
+  }
+}
+
+export const PEM_REDACT_MATCHER = {
+  source: PEM_REDACT_PATTERN_SOURCE,
+  exec(text: string): Iterable<RedactMatch> {
+    return matchPem(text, createState(), false);
+  },
+  createContext(): {
+    consume: (text: string) => void;
+    pattern: ResolvedRedactPattern;
+  } {
+    const state = createState();
+    return {
+      consume(text) {
+        for (const delimiter of readDelimiters(text, state.scanner)) {
+          consumeDelimiter(state, delimiter);
+        }
+      },
+      pattern: {
+        source: PEM_REDACT_PATTERN_SOURCE,
+        exec(text) {
+          return matchPem(text, state, true);
+        },
+      },
+    };
+  },
+};

--- a/src/logging/redact.ts
+++ b/src/logging/redact.ts
@@ -16,12 +16,13 @@ import {
 } from "./redact-edit-composition.js";
 import { modelVisibleToolTextRedactionState } from "./redact-internal-state.js";
 import { isFullContextToolPayloadRedaction } from "./redact-internal.js";
-import type { RedactionField, RedactionOrigins } from "./redact-json-tokens.js";
 import {
   redactJsonRecord,
   getPatternRedactionEdits,
   type RedactionMessage,
   type RedactionTarget,
+  type RedactionField,
+  type RedactionOrigins,
 } from "./redact-json.js";
 import {
   iterateRedactMatches,

--- a/src/logging/redact.ts
+++ b/src/logging/redact.ts
@@ -16,13 +16,12 @@ import {
 } from "./redact-edit-composition.js";
 import { modelVisibleToolTextRedactionState } from "./redact-internal-state.js";
 import { isFullContextToolPayloadRedaction } from "./redact-internal.js";
+import type { RedactionField, RedactionOrigins } from "./redact-json-tokens.js";
 import {
   redactJsonRecord,
   getPatternRedactionEdits,
-  type RedactionField,
   type RedactionMessage,
   type RedactionTarget,
-  type RedactionOrigins,
 } from "./redact-json.js";
 import {
   iterateRedactMatches,
@@ -1570,15 +1569,22 @@ export function getDefaultRedactPatterns(): string[] {
   return [...DEFAULT_REDACT_STRING_PATTERNS];
 }
 
-// Applies already-resolved redaction to a batch of lines without re-resolving options.
-// Lines are joined before redacting so multiline patterns (e.g. PEM blocks) can match across
-// line boundaries, then split back. Use this instead of mapping redactSensitiveText when
-// options are resolved once per request.
+// Match the complete batch, preserving JSON syntax through the transport's scalar editor.
 export function redactSensitiveLines(lines: string[], resolved: ResolvedRedactOptions): string[] {
   if (lines.length === 0 || resolved.mode === "off") {
     return lines;
   }
-  const exactRedactedLines = lines.map((line) => redactRegisteredSecretValues(line, maskToken));
-  return redactText(exactRedactedLines.join("\n"), resolved.patterns).split("\n");
+  return redactJsonRecord(
+    lines.join("\n"),
+    { value: { structured: false, primitiveMask: false }, children: new Map() },
+    [[], [...preparationPatterns, ...resolved.patterns]],
+    (match, pattern, project) => getRedactionEdit(match, pattern, undefined, project),
+    () => [],
+    () => [],
+    () => [],
+    () => true,
+    undefined,
+    true,
+  ).split("\n");
 }
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/logging/redact.ts
+++ b/src/logging/redact.ts
@@ -53,6 +53,7 @@ import {
   TOOL_PAYLOAD_AMBIGUOUS_ASSIGNMENT_PATTERNS,
   TOOL_PAYLOAD_REDACT_PATTERNS,
 } from "./redact-patterns.js";
+import { PEM_REDACT_MATCHER, PEM_REDACT_PATTERN_SOURCE } from "./redact-pem.js";
 import { redactRegisteredSecretValues } from "./secret-redaction-registry.js";
 import { shouldRedactStructuredAuthorizationCode } from "./structured-authorization-code.js";
 
@@ -176,6 +177,9 @@ function normalizeMode(value?: string): RedactSensitiveMode {
 }
 
 function parsePattern(raw: RedactPattern): ResolvedRedactPattern | null {
+  if (raw === PEM_REDACT_PATTERN_SOURCE) {
+    return PEM_REDACT_MATCHER;
+  }
   if (typeof raw !== "string" && !(raw instanceof RegExp)) {
     return raw;
   }
@@ -1571,9 +1575,13 @@ export function getDefaultRedactPatterns(): string[] {
 }
 
 // Match the complete batch, preserving JSON syntax through the transport's scalar editor.
-export function redactSensitiveLines(lines: string[], resolved: ResolvedRedactOptions): string[] {
+export function redactSensitiveLines(
+  lines: string[],
+  resolved: ResolvedRedactOptions,
+  selectedLines?: readonly boolean[],
+): string[] {
   if (lines.length === 0 || resolved.mode === "off") {
-    return lines;
+    return selectedLines ? lines.filter((_, index) => selectedLines[index]) : lines;
   }
   return redactJsonRecord(
     lines.join("\n"),
@@ -1585,7 +1593,9 @@ export function redactSensitiveLines(lines: string[], resolved: ResolvedRedactOp
     () => [],
     () => true,
     undefined,
-    true,
-  ).split("\n");
+    { preserveLines: selectedLines !== undefined },
+  )
+    .split("\n")
+    .filter((_, index) => selectedLines === undefined || selectedLines[index]);
 }
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */


### PR DESCRIPTION
Selection and masking stay together because both must use the same source ranges.

## What Problem This Solves

Stored-log reads can leak secrets at selection cuts or return broken, blank records.

## Why This Change Was Made

One editor masks values and captures contained inside a property name. Cross-record spans preserve ordinary keys. JSON encoding waits until ordered rules finish. The logger remains the file writer; reads do not rewrite logs.
The decision `where batch matches change values` is made by exactly one mechanism at `src/logging/redact-json.ts:461`.

## User Impact

PEM bodies stay masked across cursor, byte, line and channel cuts. Leading assignments also mask.

## Evidence

344 targeted tests pass. Real `gateway call logs.tail`, `logs --follow`, `channels logs` and browser checks pass. The 11.85 MB sparse/follow pair is 1.65×/1.10× baseline. With 118.5 MB of history and no decisive PEM marker, repeated polls measure 32.29 ms median / 42.16 ms p95, versus 0.61 / 0.93 ms baseline (52.63× median). Original-byte cursors and old-PEM masking controls pass.

The measured full-history cost is accepted for this diagnostic read path to preserve masking when a PEM opener predates the selected window. Cost still scales with retained history; these warm local measurements do not establish cold-storage or concurrent-reader limits.
Follow-up to closed #146190.
Reuses the editor from merged #146718.
AI-assisted.

## Compatibility

No config or protocol changes. Cursors stay byte-based. Context walks backward with bounded memory.

## Consumers

Gateway, CLI, Android diagnostics, channel logs and support exports receive valid masked records.
Control UI log view and Export visible/filtered receive valid masked records.

## Invalidation

Each read reconstructs context and uses current rules and registered secrets.

## Contention

No locks or writes added.

## Tests

Authenticated `logs.tail` tests cover late secret registration in property names, confined captures, ordinary keys across PEM spans, and byte cursors; writer and CLI siblings pass.

