### PR TITLE
fix(settings): preserve drafts after failed configuration recovery

### DIFF
--- a/src/gateway/server-methods/config.read-recovery.test.ts
+++ b/src/gateway/server-methods/config.read-recovery.test.ts
@@ -2,11 +2,26 @@ import { writeFileSync } from "node:fs";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
 import { createTempDirTracker } from "../../../test/helpers/temp-dir.js";
-import { readConfigGetResponse } from "../config-get-response.js";
+import { ConfigWritePostCommitError } from "../../config/io.write-errors.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { invalidateConfigGetResponseCache, readConfigGetResponse } from "../config-get-response.js";
 import { configHandlers } from "./config.js";
 import { createConfigHandlerHarness, createConfigWriteSnapshot } from "./config.test-helpers.js";
 
+const write = vi.hoisted(() => vi.fn());
+vi.mock("../../config/io.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../config/io.js")>()),
+  readConfigFileSnapshotForWrite: async () => createConfigWriteSnapshot({}),
+}));
+vi.mock("./config-write-flow.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./config-write-flow.js")>()),
+  commitGatewayConfigWrite: write,
+}));
+vi.mock("../../secrets/runtime.js", () => ({
+  prepareSecretsRuntimeSnapshot: async ({ config }: { config: OpenClawConfig }) => ({ config }),
+}));
 vi.mock("../config-get-response.js", () => ({
   readConfigGetResponse: vi.fn(),
   invalidateConfigGetResponseCache: vi.fn(),
@@ -15,14 +30,15 @@ const dirs = createTempDirTracker();
 afterEach(dirs.cleanup);
 
 it.each([
-  { exists: false, valid: true, backup: true, recovery: true },
-  { exists: true, valid: false, backup: true, recovery: true },
-  { exists: false, valid: true, backup: false, recovery: false },
-  { exists: true, valid: false, backup: false, recovery: false },
-  { exists: true, valid: true, backup: true, recovery: false },
+  { exists: false, valid: true, backup: true },
+  { exists: true, valid: false, backup: true },
+  { exists: false, valid: true, backup: false },
+  { exists: true, valid: false, backup: false },
+  { exists: true, valid: true, backup: true },
+  { exists: true, valid: true, backup: false },
 ])(
-  "config.get preserves recovery for every reader: %j",
-  async ({ exists, valid, backup, recovery }) => {
+  "config.get preserves diagnostics without inferring rollback from a backup: %j",
+  async ({ exists, valid, backup }) => {
     const configPath = path.join(dirs.make("config-read-recovery-"), "openclaw.json");
     const recoveryBackupPath = `${configPath}.bak`;
     if (backup) {
@@ -33,23 +49,84 @@ it.each([
       path: configPath,
       exists,
       valid,
+      issues: valid ? [] : [{ path: "gateway.port", message: "Expected number, received string" }],
       configRevisionHash: "revision",
       appliedConfigHash: null,
     };
     vi.mocked(readConfigGetResponse).mockResolvedValue(snapshot);
     const { options, respond } = createConfigHandlerHarness({ method: "config.get" });
     await expectDefined(configHandlers["config.get"], "registered config.get")(options);
-    if (recovery) {
-      expect(respond).toHaveBeenCalledWith(
-        false,
-        undefined,
-        expect.objectContaining({
-          code: "UNAVAILABLE",
-          details: { configPath, recoveryBackupPath, rollbackStatus: "unknown" },
-        }),
-      );
-    } else {
-      expect(respond).toHaveBeenCalledWith(true, snapshot, undefined);
-    }
+    expect(respond).toHaveBeenCalledWith(true, snapshot, undefined);
   },
 );
+
+it("config.get keeps recorded publication failure across an older read and reconciles a fresh valid read", async () => {
+  const writeHarness = createConfigHandlerHarness({
+    method: "config.set",
+    params: { raw: "{}", baseHash: "base-hash" },
+  });
+  const getHarness = () =>
+    createConfigHandlerHarness({
+      method: "config.get",
+      contextOverrides: {
+        configRevisionProjector: writeHarness.options.context.configRevisionProjector,
+      },
+    });
+  const valid = {
+    ...createConfigWriteSnapshot({}).snapshot,
+    configRevisionHash: "revision",
+    appliedConfigHash: null,
+  };
+  const readBeforeFailure = createDeferred<typeof valid>();
+  vi.mocked(readConfigGetResponse).mockReturnValueOnce(readBeforeFailure.promise);
+  const oldRead = getHarness();
+  const get = expectDefined(configHandlers["config.get"], "registered config.get");
+  const pendingRead = get(oldRead.options);
+  write.mockRejectedValueOnce(
+    new ConfigWritePostCommitError({
+      configPath: valid.path,
+      publication: "partial",
+      rollbackStatus: "unknown",
+      cause: new Error("injected restoration failure"),
+    }),
+  );
+  await expectDefined(configHandlers["config.set"], "registered config.set")(writeHarness.options);
+  expect(writeHarness.respond).toHaveBeenCalledWith(
+    false,
+    undefined,
+    expect.objectContaining({ code: "UNAVAILABLE" }),
+  );
+  expect(invalidateConfigGetResponseCache).toHaveBeenCalled();
+  const writeError = expect.objectContaining({
+    code: "UNAVAILABLE",
+    details: {
+      publication: "partial",
+      rollbackStatus: "unknown",
+      configPath: valid.path,
+      recoveryBackupPath: `${valid.path}.bak`,
+    },
+  });
+  readBeforeFailure.resolve(valid);
+  await pendingRead;
+  expect(oldRead.respond).toHaveBeenCalledWith(true, { ...valid, writeError }, undefined);
+
+  const invalid = {
+    ...valid,
+    valid: false,
+    issues: [{ path: "gateway.port", message: "Expected number, received string" }],
+  };
+  for (const snapshot of [{ ...valid, exists: false, raw: null }, invalid]) {
+    vi.mocked(readConfigGetResponse).mockResolvedValueOnce(snapshot);
+    const reader = getHarness();
+    await get(reader.options);
+    expect(reader.respond).toHaveBeenCalledWith(true, { ...snapshot, writeError }, undefined);
+  }
+  vi.mocked(readConfigGetResponse).mockResolvedValueOnce(valid);
+  const restored = getHarness();
+  await get(restored.options);
+  expect(restored.respond).toHaveBeenCalledWith(true, valid, undefined);
+  vi.mocked(readConfigGetResponse).mockResolvedValueOnce(invalid);
+  const laterInvalid = getHarness();
+  await get(laterInvalid.options);
+  expect(laterInvalid.respond).toHaveBeenCalledWith(true, invalid, undefined);
+});

--- a/src/gateway/server-methods/config.read-recovery.test.ts
+++ b/src/gateway/server-methods/config.read-recovery.test.ts
@@ -1,0 +1,55 @@
+import { writeFileSync } from "node:fs";
+import path from "node:path";
+import { expectDefined } from "@openclaw/normalization-core";
+import { afterEach, expect, it, vi } from "vitest";
+import { createTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { readConfigGetResponse } from "../config-get-response.js";
+import { configHandlers } from "./config.js";
+import { createConfigHandlerHarness, createConfigWriteSnapshot } from "./config.test-helpers.js";
+
+vi.mock("../config-get-response.js", () => ({
+  readConfigGetResponse: vi.fn(),
+  invalidateConfigGetResponseCache: vi.fn(),
+}));
+const dirs = createTempDirTracker();
+afterEach(dirs.cleanup);
+
+it.each([
+  { exists: false, valid: true, backup: true, recovery: true },
+  { exists: true, valid: false, backup: true, recovery: true },
+  { exists: false, valid: true, backup: false, recovery: false },
+  { exists: true, valid: false, backup: false, recovery: false },
+  { exists: true, valid: true, backup: true, recovery: false },
+])(
+  "config.get preserves recovery for every reader: %j",
+  async ({ exists, valid, backup, recovery }) => {
+    const configPath = path.join(dirs.make("config-read-recovery-"), "openclaw.json");
+    const recoveryBackupPath = `${configPath}.bak`;
+    if (backup) {
+      writeFileSync(recoveryBackupPath, '{"gateway":{"mode":"local"}}');
+    }
+    const snapshot = {
+      ...createConfigWriteSnapshot({}).snapshot,
+      path: configPath,
+      exists,
+      valid,
+      configRevisionHash: "revision",
+      appliedConfigHash: null,
+    };
+    vi.mocked(readConfigGetResponse).mockResolvedValue(snapshot);
+    const { options, respond } = createConfigHandlerHarness({ method: "config.get" });
+    await expectDefined(configHandlers["config.get"], "registered config.get")(options);
+    if (recovery) {
+      expect(respond).toHaveBeenCalledWith(
+        false,
+        undefined,
+        expect.objectContaining({
+          code: "UNAVAILABLE",
+          details: { configPath, recoveryBackupPath, rollbackStatus: "unknown" },
+        }),
+      );
+    } else {
+      expect(respond).toHaveBeenCalledWith(true, snapshot, undefined);
+    }
+  },
+);

--- a/src/gateway/server-methods/config.ts
+++ b/src/gateway/server-methods/config.ts
@@ -1,4 +1,3 @@
-import { existsSync } from "node:fs";
 // Config gateway methods: validation, redaction, secrets, reload planning.
 import { isDeepStrictEqual } from "node:util";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
@@ -98,6 +97,11 @@ let configSchemaResponseCache: {
   pluginRegistryVersion: number;
   response: ConfigSchemaResponse;
 } | null = null;
+
+const configWriteRecovery = new WeakMap<
+  GatewayConfigRevisionProjector,
+  { configPath: string; error: ReturnType<typeof errorShape> }
+>();
 
 type ConfigRedactionHints = Parameters<typeof redactConfigObject>[1];
 type ConfigWriteCommitResult = Awaited<ReturnType<typeof commitGatewayConfigWrite>>;
@@ -779,16 +783,25 @@ function loadSchemaWithPlugins(): ConfigSchemaResponse {
 }
 
 async function commitGatewayConfigWriteOrRespond(
-  params: Parameters<typeof commitGatewayConfigWrite>[0] & { respond: RespondFn },
+  params: Parameters<typeof commitGatewayConfigWrite>[0] & {
+    respond: RespondFn;
+    context: GatewayRequestContext;
+  },
 ): Promise<Awaited<ReturnType<typeof commitGatewayConfigWrite>> | null> {
+  const gateway = params.context.configRevisionProjector;
+  const recoveryAtStart = configWriteRecovery.get(gateway);
   try {
-    return await commitGatewayConfigWrite(params);
+    const result = await commitGatewayConfigWrite(params);
+    if (configWriteRecovery.get(gateway) === recoveryAtStart) {
+      configWriteRecovery.delete(gateway);
+    }
+    return result;
   } catch (error) {
     if (error instanceof ConfigWritePostCommitError) {
-      params.respond(
-        false,
-        undefined,
-        errorShape(ErrorCodes.UNAVAILABLE, redactToolDetail(formatErrorMessage(error)), {
+      const outcome = errorShape(
+        ErrorCodes.UNAVAILABLE,
+        redactToolDetail(formatErrorMessage(error)),
+        {
           details: {
             publication: error.publication,
             rollbackStatus: error.rollbackStatus,
@@ -797,8 +810,14 @@ async function commitGatewayConfigWriteOrRespond(
               ? { recoveryBackupPath: error.recoveryBackupPath }
               : {}),
           },
-        }),
+        },
       );
+      if (error.rollbackStatus !== "restored") {
+        configWriteRecovery.set(gateway, { configPath: error.configPath, error: outcome });
+        // A pre-publication cached read must not admit a fresh tab after this failure.
+        invalidateConfigGetResponseCache();
+      }
+      params.respond(false, undefined, outcome);
       return null;
     }
     if (!(error instanceof ConfigMutationConflictError)) {
@@ -865,25 +884,22 @@ export const configHandlers: GatewayRequestHandlers = {
     if (!assertValidParams(params, validateConfigGetParams, "config.get", respond)) {
       return;
     }
+    const gateway = context.configRevisionProjector;
+    const recoveryAtStart = configWriteRecovery.get(gateway);
     const snapshot = await readConfigGetResponse({
       getHotReloadStatus: context.getConfigReloaderHotReloadStatus,
       loadUiHints: () => loadSchemaWithPlugins().uiHints,
       revisionProjector: context.configRevisionProjector,
     });
-    const recoveryBackupPath = `${snapshot.path}.bak`;
-    if ((!snapshot.exists || !snapshot.valid) && existsSync(recoveryBackupPath)) {
-      respond(
-        false,
-        undefined,
-        errorShape(
-          ErrorCodes.UNAVAILABLE,
-          "Configuration recovery required; restore the settings file before retrying.",
-          {
-            details: { configPath: snapshot.path, recoveryBackupPath, rollbackStatus: "unknown" },
-          },
-        ),
-      );
-      return;
+    const recovery = configWriteRecovery.get(gateway);
+    if (recovery?.configPath === snapshot.path) {
+      // Only a read started after this failure can reconcile its recorded outcome.
+      if (recovery === recoveryAtStart && snapshot.exists && snapshot.valid) {
+        configWriteRecovery.delete(gateway);
+      } else {
+        respond(true, { ...snapshot, writeError: recovery.error }, undefined);
+        return;
+      }
     }
     respond(true, snapshot, undefined);
   },

--- a/src/gateway/server-methods/config.ts
+++ b/src/gateway/server-methods/config.ts
@@ -1,3 +1,4 @@
+import { existsSync } from "node:fs";
 // Config gateway methods: validation, redaction, secrets, reload planning.
 import { isDeepStrictEqual } from "node:util";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
@@ -864,15 +865,27 @@ export const configHandlers: GatewayRequestHandlers = {
     if (!assertValidParams(params, validateConfigGetParams, "config.get", respond)) {
       return;
     }
-    respond(
-      true,
-      await readConfigGetResponse({
-        getHotReloadStatus: context.getConfigReloaderHotReloadStatus,
-        loadUiHints: () => loadSchemaWithPlugins().uiHints,
-        revisionProjector: context.configRevisionProjector,
-      }),
-      undefined,
-    );
+    const snapshot = await readConfigGetResponse({
+      getHotReloadStatus: context.getConfigReloaderHotReloadStatus,
+      loadUiHints: () => loadSchemaWithPlugins().uiHints,
+      revisionProjector: context.configRevisionProjector,
+    });
+    const recoveryBackupPath = `${snapshot.path}.bak`;
+    if ((!snapshot.exists || !snapshot.valid) && existsSync(recoveryBackupPath)) {
+      respond(
+        false,
+        undefined,
+        errorShape(
+          ErrorCodes.UNAVAILABLE,
+          "Configuration recovery required; restore the settings file before retrying.",
+          {
+            details: { configPath: snapshot.path, recoveryBackupPath, rollbackStatus: "unknown" },
+          },
+        ),
+      );
+      return;
+    }
+    respond(true, snapshot, undefined);
   },
   "config.schema": ({ params, respond }) => {
     if (!assertValidParams(params, validateConfigSchemaParams, "config.schema", respond)) {

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -5,6 +5,7 @@ import type {
   CronListParams,
   CronRunLogEntry as ProtocolCronRunLogEntry,
   CronRunsParams,
+  ErrorShape,
   SessionsFilesListResult as ProtocolSessionsFilesListResult,
 } from "../../../packages/gateway-protocol/src/index.js";
 import type {
@@ -192,6 +193,7 @@ export type NostrStatus = {
 type ConfigSnapshotIssue = { path: string; message: string };
 
 export type ConfigSnapshot = {
+  writeError?: ErrorShape;
   path?: string | null;
   exists?: boolean | null;
   raw?: string | null;

--- a/ui/src/app/app-shell-view.ts
+++ b/ui/src/app/app-shell-view.ts
@@ -360,8 +360,10 @@ export function renderApplicationShell(host: ShellViewHost) {
           onSearchQueryChange: (nextQuery) => void host.handleSettingsSearchQueryChange(nextQuery),
           preloadTimers: host.settingsPreloadTimers,
           saveIndicator: {
-            status: runtimeConfig.configAutoSaveStatus,
-            lastError: runtimeConfig.lastError,
+            status: runtimeConfig.configRecoveryError
+              ? "recovery"
+              : runtimeConfig.configAutoSaveStatus,
+            lastError: runtimeConfig.configRecoveryError ?? runtimeConfig.lastError,
             needsApply: runtimeConfig.configNeedsApply,
             applying: runtimeConfig.configApplying,
             applyDisabled:

--- a/ui/src/components/settings-save-indicator.ts
+++ b/ui/src/components/settings-save-indicator.ts
@@ -7,7 +7,7 @@ import { icons } from "./icons.ts";
 const SAVED_VISIBLE_MS = 2_000;
 
 export type SettingsSaveIndicatorProps = {
-  status: ConfigAutoSaveStatus;
+  status: ConfigAutoSaveStatus | "recovery";
   lastError: string | null;
   needsApply: boolean;
   applying: boolean;
@@ -25,7 +25,7 @@ class SettingsSaveIndicator extends LitElement {
 
   @property({ attribute: false }) props?: SettingsSaveIndicatorProps;
   @state() private savedVisible = false;
-  private previousStatus: ConfigAutoSaveStatus | undefined;
+  private previousStatus: SettingsSaveIndicatorProps["status"] | undefined;
   private savedTimer: ReturnType<typeof globalThis.setTimeout> | undefined;
 
   override willUpdate(): void {
@@ -77,6 +77,9 @@ class SettingsSaveIndicator extends LitElement {
     } else if (props.status === "saving") {
       content = html` ${this.renderClaw("settings-save-indicator__claw--saving")}
         <span>${t("configView.autoSaveSaving")}</span>`;
+    } else if (props.status === "recovery") {
+      modifier = " settings-save-indicator--danger settings-save-indicator--recovery";
+      content = html`<span>${props.lastError}</span>`;
     } else if (props.status === "error") {
       title = props.lastError?.trim() ?? "";
       label = title ? `${t("configView.autoSaveFailed")}: ${title}` : "";

--- a/ui/src/components/settings-save-indicator.ts
+++ b/ui/src/components/settings-save-indicator.ts
@@ -79,7 +79,14 @@ class SettingsSaveIndicator extends LitElement {
         <span>${t("configView.autoSaveSaving")}</span>`;
     } else if (props.status === "recovery") {
       modifier = " settings-save-indicator--danger settings-save-indicator--recovery";
-      content = html`<span>${props.lastError}</span>`;
+      content = html`<span>${props.lastError}</span>
+        <button
+          class="btn btn--xs settings-save-indicator__action"
+          type="button"
+          @click=${props.onReload}
+        >
+          ${t("configView.recoveryReload")}
+        </button>`;
     } else if (props.status === "error") {
       title = props.lastError?.trim() ?? "";
       label = title ? `${t("configView.autoSaveFailed")}: ${title}` : "";

--- a/ui/src/e2e/settings-config-recovery.e2e.test.ts
+++ b/ui/src/e2e/settings-config-recovery.e2e.test.ts
@@ -20,116 +20,142 @@ const snapshot = {
 const configPath = "/settings/openclaw.json";
 const recoveryBackupPath = `${configPath}.bak`;
 
+const scenario = {
+  methodResponses: {
+    "config.get": snapshot,
+    "config.schema": {
+      schema: {
+        type: "object",
+        properties: {
+          messages: {
+            type: "object",
+            properties: {
+              responsePrefix: { type: "string", title: "Outbound Response Prefix" },
+            },
+          },
+        },
+      },
+      uiHints: { "messages.responsePrefix": { advanced: false } },
+      version: "test",
+    },
+  },
+};
+
 suite.define(() => {
   it.each(["unknown", "not-restored", "restored"])(
     "Settings config.set preserves the full draft after partial publication (%s)",
     async (rollbackStatus) => {
-      await suite.withPage({ viewport: { width: 1280, height: 900 } }, async ({ page }) => {
-        const gateway = await installMockGateway(page, {
-          methodResponses: {
-            "config.get": snapshot,
-            "config.schema": {
-              schema: {
-                type: "object",
-                properties: {
-                  messages: {
-                    type: "object",
-                    properties: {
-                      responsePrefix: { type: "string", title: "Outbound Response Prefix" },
-                    },
-                  },
-                },
-              },
-              uiHints: { "messages.responsePrefix": { advanced: false } },
-              version: "test",
-            },
-          },
-        });
-        await page.goto(`${suite.server.baseUrl}settings/communications`);
-        const prefix = page.getByRole("textbox", { name: "Outbound Response Prefix" });
-        await prefix.waitFor();
-        await gateway.deferNext("config.set");
-        await prefix.fill("retained draft");
-        await prefix.press("Tab");
-        await gateway.waitForRequest("config.set");
-        const message = `Config publication failed after removing ${configPath}: included config changed since last load. Restoration: ${rollbackStatus}. Inspect recovery backups at ${recoveryBackupPath}.`;
-        await gateway.rejectDeferred("config.set", {
-          code: "UNAVAILABLE",
-          message,
-          details: { publication: "partial", rollbackStatus, configPath, recoveryBackupPath },
-        });
-        const indicator = page.locator("openclaw-settings-save-indicator");
-        await expect
-          .poll(() => indicator.textContent())
-          .toContain(rollbackStatus === "restored" ? "Save failed" : "Your draft is kept");
-        expect(await indicator.getByRole("button", { name: "Reload", exact: true }).count()).toBe(
-          0,
-        );
-        if (rollbackStatus !== "restored") {
-          await gateway.setMethodResponse("config.get", {
-            ...snapshot,
-            exists: false,
-            config: {},
-            raw: null,
-            hash: "missing",
-          });
-          await prefix.fill("later draft");
+      await suite.withPage(
+        { viewport: { width: 1280, height: 900 } },
+        async ({ page, context }) => {
+          const gateway = await installMockGateway(page, scenario);
+          await page.goto(`${suite.server.baseUrl}settings/communications`);
+          const prefix = page.getByRole("textbox", { name: "Outbound Response Prefix" });
+          await prefix.waitFor();
+          await gateway.deferNext("config.set");
+          await prefix.fill("retained draft");
           await prefix.press("Tab");
-          // Exceed the registered Settings autosave debounce before checking absence.
-          await page.waitForTimeout(1200);
-          expect(await gateway.getRequests("config.set")).toHaveLength(1);
-          expect(await prefix.inputValue()).toBe("later draft");
-          expect(await indicator.textContent()).toContain(configPath);
-          expect(await indicator.textContent()).toContain(recoveryBackupPath);
-          const recover = indicator.getByRole("button", { name: "Discard draft and reload" });
-          await recover.waitFor();
-          for (const candidate of [
-            { ...snapshot, exists: false, config: {}, raw: null, hash: "missing" },
-            { ...snapshot, valid: false, raw: "{", hash: "invalid" },
-          ]) {
-            const reads = (await gateway.getRequests("config.get")).length;
-            await gateway.deferNext("config.get");
-            await recover.click();
-            await gateway.waitForRequest("config.get", { after: reads });
-            await gateway.resolveDeferred("config.get", candidate);
-            await expect.poll(() => prefix.inputValue()).toBe("later draft");
+          await gateway.waitForRequest("config.set");
+          const message = `Config publication failed after removing ${configPath}: included config changed since last load. Restoration: ${rollbackStatus}. Inspect recovery backups at ${recoveryBackupPath}.`;
+          await gateway.rejectDeferred("config.set", {
+            code: "UNAVAILABLE",
+            message,
+            details: { publication: "partial", rollbackStatus, configPath, recoveryBackupPath },
+          });
+          const indicator = page.locator("openclaw-settings-save-indicator");
+          await expect
+            .poll(() => indicator.textContent())
+            .toContain(rollbackStatus === "restored" ? "Save failed" : "Your draft is kept");
+          expect(await indicator.getByRole("button", { name: "Reload", exact: true }).count()).toBe(
+            0,
+          );
+          if (rollbackStatus !== "restored") {
+            const secondPage = await context.newPage();
+            const secondGateway = await installMockGateway(secondPage, {
+              ...scenario,
+              deferredMethods: ["config.get"],
+            });
+            await secondPage.goto(`${suite.server.baseUrl}settings/communications`);
+            await secondGateway.waitForRequest("config.get");
+            await secondGateway.rejectDeferred("config.get", {
+              code: "UNAVAILABLE",
+              message: "Configuration recovery required",
+              details: { rollbackStatus: "unknown", configPath, recoveryBackupPath },
+            });
+            await expect
+              .poll(() => secondPage.locator("openclaw-settings-save-indicator").textContent())
+              .toContain(recoveryBackupPath);
+            const secondPrefix = secondPage.getByRole("textbox", {
+              name: "Outbound Response Prefix",
+            });
+            await expect.poll(() => secondPrefix.isDisabled()).toBe(true);
+            expect(await secondGateway.getRequests("config.set")).toHaveLength(0);
+            await secondPage.close();
+            await gateway.setMethodResponse("config.get", {
+              ...snapshot,
+              exists: false,
+              config: {},
+              raw: null,
+              hash: "missing",
+            });
+            await prefix.fill("later draft");
+            await prefix.press("Tab");
+            // Exceed the registered Settings autosave debounce before checking absence.
+            await page.waitForTimeout(1200);
+            expect(await gateway.getRequests("config.set")).toHaveLength(1);
+            expect(await prefix.inputValue()).toBe("later draft");
+            expect(await indicator.textContent()).toContain(configPath);
             expect(await indicator.textContent()).toContain(recoveryBackupPath);
+            const recover = indicator.getByRole("button", { name: "Discard draft and reload" });
+            await recover.waitFor();
+            for (const candidate of [
+              { ...snapshot, exists: false, config: {}, raw: null, hash: "missing" },
+              { ...snapshot, valid: false, raw: "{", hash: "invalid" },
+            ]) {
+              const reads = (await gateway.getRequests("config.get")).length;
+              await gateway.deferNext("config.get");
+              await recover.click();
+              await gateway.waitForRequest("config.get", { after: reads });
+              await gateway.resolveDeferred("config.get", candidate);
+              await expect.poll(() => prefix.inputValue()).toBe("later draft");
+              expect(await indicator.textContent()).toContain(recoveryBackupPath);
+            }
+            // A clean draft must retain a usable recovery action after file repair.
+            await prefix.fill("initial");
+            await prefix.press("Tab");
+            await expect.poll(() => prefix.inputValue()).toBe("initial");
+            await gateway.setMethodResponse("config.get", { ...snapshot, hash: "recovered" });
+            await recover.click();
+            await expect.poll(() => indicator.textContent()).not.toContain("Your draft is kept");
+            await gateway.deferNext("config.set");
+            await prefix.fill("saved after recovery");
+            await prefix.press("Tab");
+            const saved = await gateway.waitForRequest("config.set", { after: 1 });
+            expect(saved.params).toMatchObject({ baseHash: "recovered" });
+            const { raw } = saved.params as { raw: string };
+            expect(JSON.parse(raw)).toEqual({
+              ...config,
+              messages: { responsePrefix: "saved after recovery" },
+            });
+            await gateway.resolveDeferred("config.set");
+            await expect.poll(() => indicator.textContent()).toContain("Saved");
+          } else {
+            await gateway.deferNext("config.set");
+            await indicator.getByRole("button", { name: "Retry" }).click();
+            const retried = await gateway.waitForRequest("config.set", { after: 1 });
+            expect(retried.params).toEqual(expect.objectContaining({ raw: expect.any(String) }));
+            const { raw } = retried.params as { raw: string };
+            expect(JSON.parse(raw)).toEqual({
+              ...config,
+              messages: { responsePrefix: "retained draft" },
+            });
+            await gateway.resolveDeferred("config.set");
+            await expect.poll(() => indicator.textContent()).toContain("Apply changes");
+            await page.reload();
+            await expect.poll(() => prefix.inputValue()).toBe("retained draft");
           }
-          // A clean draft must retain a usable recovery action after file repair.
-          await prefix.fill("initial");
-          await prefix.press("Tab");
-          await expect.poll(() => prefix.inputValue()).toBe("initial");
-          await gateway.setMethodResponse("config.get", { ...snapshot, hash: "recovered" });
-          await recover.click();
-          await expect.poll(() => indicator.textContent()).not.toContain("Your draft is kept");
-          await gateway.deferNext("config.set");
-          await prefix.fill("saved after recovery");
-          await prefix.press("Tab");
-          const saved = await gateway.waitForRequest("config.set", { after: 1 });
-          expect(saved.params).toMatchObject({ baseHash: "recovered" });
-          const { raw } = saved.params as { raw: string };
-          expect(JSON.parse(raw)).toEqual({
-            ...config,
-            messages: { responsePrefix: "saved after recovery" },
-          });
-          await gateway.resolveDeferred("config.set");
-          await expect.poll(() => indicator.textContent()).toContain("Saved");
-        } else {
-          await gateway.deferNext("config.set");
-          await indicator.getByRole("button", { name: "Retry" }).click();
-          const retried = await gateway.waitForRequest("config.set", { after: 1 });
-          expect(retried.params).toEqual(expect.objectContaining({ raw: expect.any(String) }));
-          const { raw } = retried.params as { raw: string };
-          expect(JSON.parse(raw)).toEqual({
-            ...config,
-            messages: { responsePrefix: "retained draft" },
-          });
-          await gateway.resolveDeferred("config.set");
-          await expect.poll(() => indicator.textContent()).toContain("Apply changes");
-          await page.reload();
-          await expect.poll(() => prefix.inputValue()).toBe("retained draft");
-        }
-      });
+        },
+      );
     },
   );
 });

--- a/ui/src/e2e/settings-config-recovery.e2e.test.ts
+++ b/ui/src/e2e/settings-config-recovery.e2e.test.ts
@@ -1,0 +1,101 @@
+import { expect, it } from "vitest";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+
+const suite = createControlUiE2eSuite({ name: "Settings config publication recovery" });
+const config = {
+  gateway: { mode: "local", auth: { mode: "token", token: "__OPENCLAW_REDACTED__" } },
+  agents: { defaults: { workspace: "/workspace" } },
+  plugins: { enabled: false },
+  logging: { level: "info" },
+  messages: { responsePrefix: "initial" },
+};
+const snapshot = {
+  exists: true,
+  valid: true,
+  config,
+  raw: JSON.stringify(config),
+  hash: "initial",
+};
+const configPath = "/settings/openclaw.json";
+const recoveryBackupPath = `${configPath}.bak`;
+
+suite.define(() => {
+  it.each(["unknown", "not-restored", "restored"])(
+    "Settings config.set preserves the full draft after partial publication (%s)",
+    async (rollbackStatus) => {
+      await suite.withPage({ viewport: { width: 1280, height: 900 } }, async ({ page }) => {
+        const gateway = await installMockGateway(page, {
+          methodResponses: {
+            "config.get": snapshot,
+            "config.schema": {
+              schema: {
+                type: "object",
+                properties: {
+                  messages: {
+                    type: "object",
+                    properties: {
+                      responsePrefix: { type: "string", title: "Outbound Response Prefix" },
+                    },
+                  },
+                },
+              },
+              uiHints: { "messages.responsePrefix": { advanced: false } },
+              version: "test",
+            },
+          },
+        });
+        await page.goto(`${suite.server.baseUrl}settings/communications`);
+        const prefix = page.getByRole("textbox", { name: "Outbound Response Prefix" });
+        await prefix.waitFor();
+        await gateway.deferNext("config.set");
+        await prefix.fill("retained draft");
+        await prefix.press("Tab");
+        await gateway.waitForRequest("config.set");
+        const message = `Config publication failed after removing ${configPath}: included config changed since last load. Restoration: ${rollbackStatus}. Inspect recovery backups at ${recoveryBackupPath}.`;
+        await gateway.rejectDeferred("config.set", {
+          code: "UNAVAILABLE",
+          message,
+          details: { publication: "partial", rollbackStatus, configPath, recoveryBackupPath },
+        });
+        const indicator = page.locator("openclaw-settings-save-indicator");
+        await expect
+          .poll(() => indicator.textContent())
+          .toContain(rollbackStatus === "restored" ? "Save failed" : "Your draft is kept");
+        expect(await indicator.getByRole("button", { name: "Reload" }).count()).toBe(0);
+        if (rollbackStatus !== "restored") {
+          await gateway.setMethodResponse("config.get", {
+            ...snapshot,
+            exists: false,
+            config: {},
+            raw: null,
+            hash: "missing",
+          });
+          await prefix.fill("later draft");
+          await prefix.press("Tab");
+          // Exceed the registered Settings autosave debounce before checking absence.
+          await page.waitForTimeout(1200);
+          expect(await gateway.getRequests("config.set")).toHaveLength(1);
+          expect(await prefix.inputValue()).toBe("later draft");
+          expect(await indicator.textContent()).toContain(configPath);
+          expect(await indicator.textContent()).toContain(recoveryBackupPath);
+          expect(await indicator.getByRole("button").count()).toBe(0);
+        } else {
+          await gateway.deferNext("config.set");
+          await indicator.getByRole("button", { name: "Retry" }).click();
+          const retried = await gateway.waitForRequest("config.set", { after: 1 });
+          expect(retried.params).toEqual(expect.objectContaining({ raw: expect.any(String) }));
+          const { raw } = retried.params as { raw: string };
+          expect(JSON.parse(raw)).toEqual({
+            ...config,
+            messages: { responsePrefix: "retained draft" },
+          });
+          await gateway.resolveDeferred("config.set");
+          await expect.poll(() => indicator.textContent()).toContain("Apply changes");
+          await page.reload();
+          await expect.poll(() => prefix.inputValue()).toBe("retained draft");
+        }
+      });
+    },
+  );
+});

--- a/ui/src/e2e/settings-config-recovery.e2e.test.ts
+++ b/ui/src/e2e/settings-config-recovery.e2e.test.ts
@@ -62,7 +62,9 @@ suite.define(() => {
         await expect
           .poll(() => indicator.textContent())
           .toContain(rollbackStatus === "restored" ? "Save failed" : "Your draft is kept");
-        expect(await indicator.getByRole("button", { name: "Reload" }).count()).toBe(0);
+        expect(await indicator.getByRole("button", { name: "Reload", exact: true }).count()).toBe(
+          0,
+        );
         if (rollbackStatus !== "restored") {
           await gateway.setMethodResponse("config.get", {
             ...snapshot,
@@ -79,7 +81,39 @@ suite.define(() => {
           expect(await prefix.inputValue()).toBe("later draft");
           expect(await indicator.textContent()).toContain(configPath);
           expect(await indicator.textContent()).toContain(recoveryBackupPath);
-          expect(await indicator.getByRole("button").count()).toBe(0);
+          const recover = indicator.getByRole("button", { name: "Discard draft and reload" });
+          await recover.waitFor();
+          for (const candidate of [
+            { ...snapshot, exists: false, config: {}, raw: null, hash: "missing" },
+            { ...snapshot, valid: false, raw: "{", hash: "invalid" },
+          ]) {
+            const reads = (await gateway.getRequests("config.get")).length;
+            await gateway.deferNext("config.get");
+            await recover.click();
+            await gateway.waitForRequest("config.get", { after: reads });
+            await gateway.resolveDeferred("config.get", candidate);
+            await expect.poll(() => prefix.inputValue()).toBe("later draft");
+            expect(await indicator.textContent()).toContain(recoveryBackupPath);
+          }
+          // A clean draft must retain a usable recovery action after file repair.
+          await prefix.fill("initial");
+          await prefix.press("Tab");
+          await expect.poll(() => prefix.inputValue()).toBe("initial");
+          await gateway.setMethodResponse("config.get", { ...snapshot, hash: "recovered" });
+          await recover.click();
+          await expect.poll(() => indicator.textContent()).not.toContain("Your draft is kept");
+          await gateway.deferNext("config.set");
+          await prefix.fill("saved after recovery");
+          await prefix.press("Tab");
+          const saved = await gateway.waitForRequest("config.set", { after: 1 });
+          expect(saved.params).toMatchObject({ baseHash: "recovered" });
+          const { raw } = saved.params as { raw: string };
+          expect(JSON.parse(raw)).toEqual({
+            ...config,
+            messages: { responsePrefix: "saved after recovery" },
+          });
+          await gateway.resolveDeferred("config.set");
+          await expect.poll(() => indicator.textContent()).toContain("Saved");
         } else {
           await gateway.deferNext("config.set");
           await indicator.getByRole("button", { name: "Retry" }).click();

--- a/ui/src/e2e/settings-config-recovery.e2e.test.ts
+++ b/ui/src/e2e/settings-config-recovery.e2e.test.ts
@@ -77,10 +77,16 @@ suite.define(() => {
             });
             await secondPage.goto(`${suite.server.baseUrl}settings/communications`);
             await secondGateway.waitForRequest("config.get");
-            await secondGateway.rejectDeferred("config.get", {
-              code: "UNAVAILABLE",
-              message: "Configuration recovery required",
-              details: { rollbackStatus: "unknown", configPath, recoveryBackupPath },
+            await secondGateway.resolveDeferred("config.get", {
+              ...snapshot,
+              exists: false,
+              raw: null,
+              config: {},
+              writeError: {
+                code: "UNAVAILABLE",
+                message,
+                details: { publication: "partial", rollbackStatus, configPath, recoveryBackupPath },
+              },
             });
             await expect
               .poll(() => secondPage.locator("openclaw-settings-save-indicator").textContent())
@@ -158,4 +164,25 @@ suite.define(() => {
       );
     },
   );
+
+  it("Settings config.get shows ordinary validation issues without claiming restoration failed", async () => {
+    await suite.withPage({ viewport: { width: 1280, height: 900 } }, async ({ page }) => {
+      const issues = [{ path: "gateway.port", message: "Expected number, received string" }];
+      await installMockGateway(page, {
+        methodResponses: {
+          ...scenario.methodResponses,
+          "config.get": { ...snapshot, raw: null, config: {}, valid: false, issues },
+        },
+      });
+      await page.goto(`${suite.server.baseUrl}settings/advanced`);
+      const diagnostics = page.locator(".config-content-callout");
+      await expect.poll(() => diagnostics.textContent()).toContain("gateway.port");
+      expect(await diagnostics.textContent()).toContain("Expected number, received string");
+      const indicator = page.locator("openclaw-settings-save-indicator");
+      expect(await indicator.textContent()).not.toContain("restoration");
+      expect(
+        await indicator.getByRole("button", { name: "Discard draft and reload" }).count(),
+      ).toBe(0);
+    });
+  });
 });

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -1886,6 +1886,11 @@ export const en: TranslationMap & {
     autoSavePaused: "Autosave paused after reconnect",
     saveNow: "Save",
     autoSaveFailed: "Save failed",
+    recoveryNotRestored:
+      "Settings could not be restored. Your draft is kept. Check {path} before saving again.",
+    recoveryUnknown:
+      "Settings restoration could not be confirmed. Your draft is kept. Check {path} before saving again.",
+    recoveryBackup: "Inspect the recovery backup at {path}.",
     autoSaveConflict: "Settings changed elsewhere",
     retry: "Retry",
     applyChanges: "Apply changes",

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -1891,6 +1891,7 @@ export const en: TranslationMap & {
     recoveryUnknown:
       "Settings restoration could not be confirmed. Your draft is kept. Check {path} before saving again.",
     recoveryBackup: "Inspect the recovery backup at {path}.",
+    recoveryReload: "Discard draft and reload",
     autoSaveConflict: "Settings changed elsewhere",
     retry: "Retry",
     applyChanges: "Apply changes",

--- a/ui/src/lib/config/config-draft-model.ts
+++ b/ui/src/lib/config/config-draft-model.ts
@@ -148,9 +148,6 @@ export function applyConfigSnapshot(
   if (!rawAvailable && state.configFormMode === "raw") {
     state.configFormMode = "form";
   }
-  state.configValid = typeof snapshot.valid === "boolean" ? snapshot.valid : null;
-  state.configIssues = Array.isArray(snapshot.issues) ? snapshot.issues : [];
-
   if (!preservePendingChanges) {
     resetConfigPendingChanges(state);
   } else {

--- a/ui/src/lib/config/config-draft-model.ts
+++ b/ui/src/lib/config/config-draft-model.ts
@@ -36,6 +36,24 @@ export function clearConfigDraftTracking(state: RuntimeConfigState): void {
 }
 
 export function formatConfigMutationError(error: unknown, submittedRaw: string | null): string {
+  if (
+    error instanceof GatewayRequestError &&
+    isRecord(error.details) &&
+    (error.details.publication === "partial" || error.details.publication === "complete") &&
+    error.details.rollbackStatus !== "restored" &&
+    typeof error.details.configPath === "string"
+  ) {
+    const message = t(
+      error.details.rollbackStatus === "not-restored"
+        ? "configView.recoveryNotRestored"
+        : "configView.recoveryUnknown",
+      { path: error.details.configPath },
+    );
+    // Recovery paths are user instructions, unlike incidental paths in exception text.
+    return typeof error.details.recoveryBackupPath === "string"
+      ? message + "\n" + t("configView.recoveryBackup", { path: error.details.recoveryBackupPath })
+      : message;
+  }
   const formatted = formatUiError(error);
   let message = error instanceof GatewayRequestError ? `${error.name}: ${formatted}` : formatted;
   if (!submittedRaw || !(error instanceof GatewayRequestError) || !isRecord(error.details)) {
@@ -126,12 +144,15 @@ export function applyConfigSnapshot(
   snapshot: ConfigSnapshot,
   options: LoadConfigOptions = {},
 ) {
-  const preservePendingChanges = state.configFormDirty && options.discardPendingChanges !== true;
+  const preservePendingChanges =
+    (state.configFormDirty || state.configRecoveryError !== null) &&
+    options.discardPendingChanges !== true;
   if (options.discardPendingChanges === true) {
     // Discard resets pending edits and stale save status, but NOT the restart
     // banner: a saved-but-unapplied config still needs an apply even after
     // the local draft is thrown away.
     state.configAutoSaveStatus = "idle";
+    state.configRecoveryError = null;
   }
   const currentRevisionHash = snapshot.configRevisionHash ?? snapshot.hash ?? null;
   if (snapshot.appliedConfigHash !== undefined) {
@@ -515,10 +536,8 @@ function syncConfigDraft(state: RuntimeConfigState, nextForm: Record<string, unk
 /**
  * Any mutation invalidates a lingering "Saved"/"Save failed" indicator: a
  * dirty edit is about to reschedule, and a clean revert makes the old
- * failure moot (its error is cleared too). Three states persist regardless:
- * "saving" reports the in-flight request, "conflict" marks the snapshot
- * itself stale, and "paused" marks the reconnect latch — only an explicit
- * Save/Apply or discard clears it, no local edit can.
+ * failure moot (its error is cleared too). In-flight writes, stale snapshots,
+ * reconnect pauses and publication recovery survive local edits.
  */
 function resetStaleAutoSaveStatus(state: RuntimeConfigState) {
   if (

--- a/ui/src/lib/config/config-draft-model.ts
+++ b/ui/src/lib/config/config-draft-model.ts
@@ -36,24 +36,6 @@ export function clearConfigDraftTracking(state: RuntimeConfigState): void {
 }
 
 export function formatConfigMutationError(error: unknown, submittedRaw: string | null): string {
-  if (
-    error instanceof GatewayRequestError &&
-    isRecord(error.details) &&
-    (error.details.publication === "partial" || error.details.publication === "complete") &&
-    error.details.rollbackStatus !== "restored" &&
-    typeof error.details.configPath === "string"
-  ) {
-    const message = t(
-      error.details.rollbackStatus === "not-restored"
-        ? "configView.recoveryNotRestored"
-        : "configView.recoveryUnknown",
-      { path: error.details.configPath },
-    );
-    // Recovery paths are user instructions, unlike incidental paths in exception text.
-    return typeof error.details.recoveryBackupPath === "string"
-      ? message + "\n" + t("configView.recoveryBackup", { path: error.details.recoveryBackupPath })
-      : message;
-  }
   const formatted = formatUiError(error);
   let message = error instanceof GatewayRequestError ? `${error.name}: ${formatted}` : formatted;
   if (!submittedRaw || !(error instanceof GatewayRequestError) || !isRecord(error.details)) {

--- a/ui/src/lib/config/config-gateway-operations.ts
+++ b/ui/src/lib/config/config-gateway-operations.ts
@@ -1,4 +1,5 @@
 import { ErrorCodes } from "@openclaw/gateway-client/browser";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { err as failure, ok, type Result } from "@openclaw/normalization-core/result";
 import { GatewayRequestError, type GatewayBrowserClient } from "../../api/gateway.ts";
 import type { ConfigSchemaResponse, ConfigSnapshot } from "../../api/types.ts";
@@ -67,16 +68,32 @@ export async function refreshDraft(
   reconcileAppliedRefresh();
 }
 
-/**
- * Gateway contract: requireConfigBaseHash in
- * src/gateway/server-methods/config.ts rejects writes whose baseHash no
- * longer matches the file with exactly this message. A conflict means another
- * writer changed openclaw.json; retrying the whole-form draft would clobber
- * their edit, so callers surface a reload affordance instead.
- */
-function isConfigBaseHashConflictError(err: unknown): boolean {
-  const message = formatUiError(err);
-  return message.includes("config changed since last load");
+// Publication outcomes outrank nested pre-write conflict messages.
+function classifyConfigMutationError(err: unknown): "conflict" | "error" | "recovery" {
+  if (
+    err instanceof GatewayRequestError &&
+    isRecord(err.details) &&
+    (err.details.publication === "partial" || err.details.publication === "complete")
+  ) {
+    return err.details.rollbackStatus === "restored" ? "error" : "recovery";
+  }
+  return formatUiError(err).includes("config changed since last load") ? "conflict" : "error";
+}
+
+function configMutationFailure(
+  state: RuntimeConfigState,
+  error: unknown,
+  submittedRaw?: string | null,
+) {
+  const status = classifyConfigMutationError(error);
+  const message =
+    status === "recovery" || submittedRaw !== undefined
+      ? formatConfigMutationError(error, submittedRaw ?? null)
+      : formatUiError(error);
+  if (status === "recovery") {
+    state.configRecoveryError = message;
+  }
+  return { status: status === "recovery" ? ("error" as const) : status, message };
 }
 
 function isDefinitiveConfigMutationRejection(err: unknown): boolean {
@@ -198,14 +215,16 @@ export async function executeConfigExternalMutation<T>(
         error: "Connection changed before the configuration update completed.",
       };
     }
+    const outcome = configMutationFailure(state, error);
     return {
       ok: false,
-      reason: isConfigBaseHashConflictError(error)
-        ? "conflict"
-        : isDefinitiveConfigMutationRejection(error)
-          ? "rejected"
-          : "error",
-      error: formatUiError(error),
+      reason:
+        outcome.status === "conflict"
+          ? "conflict"
+          : isDefinitiveConfigMutationRejection(error)
+            ? "rejected"
+            : "error",
+      error: outcome.message,
     };
   }
   const refreshFailure = (error: string): RuntimeConfigExternalMutationResult<T> => ({
@@ -333,6 +352,9 @@ async function readConfig(
     if (!isCurrent()) {
       return failure("The configuration refresh was superseded.");
     }
+    if (state.configRecoveryError !== null && (!res.exists || !res.valid)) {
+      return failure(state.configRecoveryError);
+    }
     // Recovery captures the latest intent before a clean draft is replaced.
     options.beforeApplySnapshot?.();
     if (!isCurrent()) {
@@ -407,7 +429,7 @@ export async function submitConfigDraft(
   const client = state.client;
   const canSubmitDraft = () =>
     mode !== "auto" || (state.configFormDirty && state.configFormMode === "form");
-  if (!client || !state.connected || !canSubmitDraft()) {
+  if (!client || !state.connected || !canSubmitDraft() || state.configRecoveryError !== null) {
     return false;
   }
   const connectionEpoch = currentConfigConnectionEpoch(state);
@@ -475,11 +497,10 @@ export async function submitConfigDraft(
     return true;
   } catch (err) {
     if (isCurrent()) {
-      state.lastError = formatConfigMutationError(err, submittedFormRaw);
-      if (isConfigBaseHashConflictError(err)) {
-        state.configAutoSaveStatus = "conflict";
-      } else if (mode !== "apply") {
-        state.configAutoSaveStatus = "error";
+      const outcome = configMutationFailure(state, err, submittedFormRaw);
+      state.lastError = outcome.message;
+      if (outcome.status === "conflict" || mode !== "apply") {
+        state.configAutoSaveStatus = outcome.status;
       }
     }
     return false;
@@ -509,8 +530,9 @@ export function teardownFlushConfigDraft(
   try {
     assertConfigDraftCurrent(state);
   } catch (error) {
-    state.lastError = formatUiError(error);
-    state.configAutoSaveStatus = isConfigBaseHashConflictError(error) ? "conflict" : "error";
+    const outcome = configMutationFailure(state, error);
+    state.lastError = outcome.message;
+    state.configAutoSaveStatus = outcome.status;
     return;
   }
   const draft = {
@@ -588,8 +610,9 @@ export async function patchConfig(
     return true;
   } catch (err) {
     if (isCurrentConfigConnection(state, client, connectionEpoch)) {
-      state.lastError = formatUiError(err);
-      state.configAutoSaveStatus = isConfigBaseHashConflictError(err) ? "conflict" : "error";
+      const outcome = configMutationFailure(state, err);
+      state.lastError = outcome.message;
+      state.configAutoSaveStatus = outcome.status;
     }
     return false;
   }

--- a/ui/src/lib/config/config-gateway-operations.ts
+++ b/ui/src/lib/config/config-gateway-operations.ts
@@ -68,32 +68,46 @@ export async function refreshDraft(
   reconcileAppliedRefresh();
 }
 
-// Publication outcomes outrank nested pre-write conflict messages.
-function classifyConfigMutationError(err: unknown): "conflict" | "error" | "recovery" {
-  if (
-    err instanceof GatewayRequestError &&
-    isRecord(err.details) &&
-    (err.details.publication === "partial" || err.details.publication === "complete")
-  ) {
-    return err.details.rollbackStatus === "restored" ? "error" : "recovery";
-  }
-  return formatUiError(err).includes("config changed since last load") ? "conflict" : "error";
-}
-
+// Publication and read-recovery outcomes outrank nested pre-write conflict text.
 function configMutationFailure(
   state: RuntimeConfigState,
   error: unknown,
   submittedRaw?: string | null,
 ) {
-  const status = classifyConfigMutationError(error);
-  const message =
-    status === "recovery" || submittedRaw !== undefined
-      ? formatConfigMutationError(error, submittedRaw ?? null)
+  let message =
+    submittedRaw !== undefined
+      ? formatConfigMutationError(error, submittedRaw)
       : formatUiError(error);
-  if (status === "recovery") {
-    state.configRecoveryError = message;
+  const details =
+    error instanceof GatewayRequestError && isRecord(error.details) ? error.details : null;
+  const hasRecoveryOutcome =
+    details &&
+    (details.publication === "partial" ||
+      details.publication === "complete" ||
+      typeof details.recoveryBackupPath === "string");
+  if (hasRecoveryOutcome) {
+    if (details.rollbackStatus !== "restored") {
+      if (typeof details.configPath === "string") {
+        message = t(
+          details.rollbackStatus === "not-restored"
+            ? "configView.recoveryNotRestored"
+            : "configView.recoveryUnknown",
+          { path: details.configPath },
+        );
+        if (typeof details.recoveryBackupPath === "string") {
+          message += "\n" + t("configView.recoveryBackup", { path: details.recoveryBackupPath });
+        }
+      }
+      state.configRecoveryError = message;
+    }
+    return { status: "error" as const, message };
   }
-  return { status: status === "recovery" ? ("error" as const) : status, message };
+  return {
+    status: message.includes("config changed since last load")
+      ? ("conflict" as const)
+      : ("error" as const),
+    message,
+  };
 }
 
 function isDefinitiveConfigMutationRejection(err: unknown): boolean {
@@ -371,11 +385,12 @@ async function readConfig(
     }
     return ok(undefined);
   } catch (error) {
-    const message = formatUiError(error);
-    if (isCurrent()) {
-      state.lastError = message;
+    if (!isCurrent()) {
+      return failure("The configuration refresh was superseded.");
     }
-    return failure(message);
+    const outcome = configMutationFailure(state, error);
+    state.lastError = outcome.message;
+    return failure(outcome.message);
   } finally {
     if (isCurrentRequest(state, "config", version, client, connectionEpoch)) {
       state.configLoading = false;

--- a/ui/src/lib/config/config-gateway-operations.ts
+++ b/ui/src/lib/config/config-gateway-operations.ts
@@ -81,10 +81,7 @@ function configMutationFailure(
   const details =
     error instanceof GatewayRequestError && isRecord(error.details) ? error.details : null;
   const hasRecoveryOutcome =
-    details &&
-    (details.publication === "partial" ||
-      details.publication === "complete" ||
-      typeof details.recoveryBackupPath === "string");
+    details && (details.publication === "partial" || details.publication === "complete");
   if (hasRecoveryOutcome) {
     if (details.rollbackStatus !== "restored") {
       if (typeof details.configPath === "string") {
@@ -365,6 +362,13 @@ async function readConfig(
     const res = await client.request<ConfigSnapshot>("config.get", {});
     if (!isCurrent()) {
       return failure("The configuration refresh was superseded.");
+    }
+    state.configValid = typeof res.valid === "boolean" ? res.valid : null;
+    state.configIssues = Array.isArray(res.issues) ? res.issues : [];
+    if (res.writeError) {
+      const outcome = configMutationFailure(state, new GatewayRequestError(res.writeError));
+      state.lastError = outcome.message;
+      return failure(outcome.message);
     }
     if (state.configRecoveryError !== null && (!res.exists || !res.valid)) {
       return failure(state.configRecoveryError);

--- a/ui/src/lib/config/config-publication-recovery.test.ts
+++ b/ui/src/lib/config/config-publication-recovery.test.ts
@@ -1,0 +1,103 @@
+// @vitest-environment node
+import { expect, it, vi } from "vitest";
+import { GatewayRequestError, type GatewayBrowserClient } from "../../api/gateway.ts";
+import {
+  CONFIG_FORM_AUTO_SAVE_DEBOUNCE_MS,
+  createConfigCapabilityHarness,
+  createConfigServerMock,
+  deferred,
+} from "./config-test-harness.ts";
+
+it.each(["Settings", "external"])(
+  "%s config.set retains publication recovery through queued writes, Raw errors and reads",
+  async (origin) => {
+    vi.useFakeTimers();
+    const firstWrite = deferred<unknown>();
+    const server = createConfigServerMock();
+    let readState = "valid";
+    let recovered = false;
+    const request = vi.fn(async (method: string, params?: unknown) => {
+      if (method === "config.set" && !recovered) {
+        return firstWrite.promise;
+      }
+      if (method === "config.get") {
+        if (readState === "failed") {
+          throw new Error("read unavailable");
+        }
+        return readState === "missing"
+          ? { exists: false, valid: true, config: {}, raw: null, hash: "missing" }
+          : { ...(await server.request(method, params)), exists: true };
+      }
+      if (method === "config.schema") {
+        throw new Error("schema unavailable");
+      }
+      return server.request(method, params);
+    });
+    const { runtimeConfig, publish } = createConfigCapabilityHarness(
+      request as GatewayBrowserClient["request"],
+    );
+    await runtimeConfig.ensureLoaded();
+    const original = runtimeConfig.state.configRaw;
+    if (origin === "Settings") {
+      runtimeConfig.patchForm(["count"], 2);
+    }
+    const externalWrite = () =>
+      runtimeConfig.runExternalMutation((client) =>
+        client.request("config.set", { raw: '{"count":3}', baseHash: "hash-1" }),
+      );
+    const failedWrite = origin === "Settings" ? runtimeConfig.save() : externalWrite();
+    const queuedWrite = externalWrite();
+    firstWrite.reject(
+      new GatewayRequestError({
+        code: "UNAVAILABLE",
+        message: "included config changed since last load",
+        details: {
+          publication: "partial",
+          rollbackStatus: "unknown",
+          configPath: "/settings/openclaw.json",
+          recoveryBackupPath: "/settings/openclaw.json.bak",
+        },
+      }),
+    );
+    await failedWrite;
+    await queuedWrite;
+    const recovery = runtimeConfig.state.configRecoveryError;
+    expect(recovery).toContain("/settings/openclaw.json.bak");
+
+    runtimeConfig.setRaw("{");
+    runtimeConfig.patchForm(["count"], 4);
+    runtimeConfig.setRaw(original);
+    await runtimeConfig.refresh();
+    readState = "failed";
+    publish(false);
+    publish(true);
+    await vi.advanceTimersByTimeAsync(0);
+    await runtimeConfig.refreshSchema();
+    await runtimeConfig.openFile();
+    readState = "missing";
+    await runtimeConfig.discardDraft();
+    expect(runtimeConfig.state.configRecoveryError).toBe(recovery);
+    expect(runtimeConfig.state.configRaw).toBe(original);
+
+    runtimeConfig.patchForm(["count"], 4);
+    await runtimeConfig.save();
+    await runtimeConfig.apply();
+    await runtimeConfig.patch({ raw: { count: 4 }, note: "test" });
+    await externalWrite();
+    await vi.advanceTimersByTimeAsync(CONFIG_FORM_AUTO_SAVE_DEBOUNCE_MS);
+    expect(request.mock.calls.filter(([method]) => method === "config.set")).toHaveLength(1);
+    expect(
+      request.mock.calls.some(([method]) => method === "config.patch" || method === "config.apply"),
+    ).toBe(false);
+
+    readState = "valid";
+    recovered = true;
+    await runtimeConfig.discardDraft();
+    expect(runtimeConfig.state.configRecoveryError).toBeNull();
+    runtimeConfig.patchForm(["count"], 5);
+    await expect(runtimeConfig.save()).resolves.toBe(true);
+    expect(server.submissions).toHaveLength(1);
+    expect(server.submissions.map(({ raw }) => JSON.parse(raw))).toEqual([{ count: 5 }]);
+    runtimeConfig.dispose();
+  },
+);

--- a/ui/src/lib/config/config-publication-recovery.test.ts
+++ b/ui/src/lib/config/config-publication-recovery.test.ts
@@ -1,11 +1,11 @@
 // @vitest-environment node
 import { expect, it, vi } from "vitest";
+import { createDeferred as deferred } from "../../../../test/helpers/promise.js";
 import { GatewayRequestError, type GatewayBrowserClient } from "../../api/gateway.ts";
 import {
   CONFIG_FORM_AUTO_SAVE_DEBOUNCE_MS,
   createConfigCapabilityHarness,
   createConfigServerMock,
-  deferred,
 } from "./config-test-harness.ts";
 
 it.each(["Settings", "external"])(

--- a/ui/src/lib/config/config-state-model.ts
+++ b/ui/src/lib/config/config-state-model.ts
@@ -24,6 +24,7 @@ export type RuntimeConfigState = {
   configSaving: boolean;
   configApplying: boolean;
   configAutoSaveStatus: ConfigAutoSaveStatus;
+  configRecoveryError: string | null;
   /** True when the config file revision differs from the active Gateway runtime. */
   configNeedsApply: boolean;
   configSnapshot: ConfigSnapshot | null;
@@ -126,6 +127,7 @@ export function createInitialConfigState(
     configSaving: false,
     configApplying: false,
     configAutoSaveStatus: "idle",
+    configRecoveryError: null,
     configNeedsApply: false,
     configSnapshot: null,
     configDraftBaseHash: null,

--- a/ui/src/lib/config/config-write-coordinator.ts
+++ b/ui/src/lib/config/config-write-coordinator.ts
@@ -163,6 +163,7 @@ export function createConfigWriteCoordinator({
   // Stale bases and previous connections require explicit recovery, including teardown.
   const canAutoSaveDraft = () =>
     state.configAutoSaveStatus !== "conflict" &&
+    state.configRecoveryError === null &&
     !autoSaveRequiresExplicitSubmit &&
     autoSaveDraftConnection !== null &&
     autoSaveDraftConnection.client === state.client &&
@@ -377,7 +378,7 @@ export function createConfigWriteCoordinator({
         }
         // The updater may have started while we drained; suspension must be a
         // real barrier or an apply could restart the gateway mid-update.
-        if (writesSuspended || isDisposed()) {
+        if (writesSuspended || isDisposed() || state.configRecoveryError !== null) {
           return unavailable;
         }
         if (!client || !isCurrentConfigConnection(state, client, connectionEpoch)) {

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -735,6 +735,11 @@ openclaw-settings-save-indicator:empty {
   min-width: 0;
 }
 
+.settings-save-indicator--recovery {
+  white-space: pre-line;
+  overflow-wrap: anywhere;
+}
+
 .settings-save-indicator--danger {
   color: var(--danger);
 }

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -736,6 +736,8 @@ openclaw-settings-save-indicator:empty {
 }
 
 .settings-save-indicator--recovery {
+  flex-direction: column;
+  align-items: flex-start;
   white-space: pre-line;
   overflow-wrap: anywhere;
 }


### PR DESCRIPTION
## What Problem This Solves

After a partially saved settings file cannot be restored, Settings can misread the error as a stale conflict. Reloading the missing file and editing again can overwrite the complete configuration and prevent Gateway startup.

## User Impact

Settings keeps the draft, shows recovery instructions, and blocks further writes in existing and fresh tabs. “Discard draft and reload” accepts only an existing, valid file. Ordinary conflicts keep Reload. Ordinary invalid files keep their validation issues, even when a routine backup exists.

## Why This Change Was Made

The decision `how a config save error is classified` is made by exactly one mechanism at `ui/src/lib/config/config-gateway-operations.ts:72`. The decision `whether this running Gateway has an unresolved publication outcome to expose` is made by exactly one mechanism at `src/gateway/server-methods/config.ts:785`.

The added state retains actual write failures for fresh readers without inferring recovery from a backup file. Related: #146291. AI-assisted.

## Consumers

- Settings save indicators retain drafts and expose guarded recovery reload.
- Workshop, cloud-worker, Labs and MCP configuration edits receive recovery failures through shared write admission.
- Provider login, logout and API-key edits, model setup, agent identity and shared GitHub operations wait for recovery.
- Config-backed preference sync keeps pending edits when writes are refused.
- Skill and plugin changes share admission; wrappers retain an originating request error and use the owner message for pre-dispatch refusal.

## Invalidation

The Gateway records actual unresolved publication failures. A matching fresh valid read or successful write can clear its captured record; older operations cannot clear a newer failure. Settings retains its draft until explicit valid reload. Failure recording has one writer at the publication outcome boundary.

## Evidence

A real Gateway and browser reproduced Reload → reduced settings → cold startup exit 78 before the fix. Afterward, failed restoration retained the original draft and blocked a fresh tab; restoration enabled a complete save. A normal backup plus an unrelated invalid port preserved the concrete validation issue without claiming failed restoration.

## Compatibility

Existing diagnostic snapshots and revision fields remain intact. Optional `writeError` carries the actual publication error. No configuration keys, storage schemas, migrations or protocol versions change.

## Contention

The existing queue is unchanged. A held pre-failure read cannot retire a newer recovery record; no lock or awaited publication step is added.

## Tests

Targeted integration tests passed: 7 Gateway, 87 UI owner and 4 Settings browser cases. Existing ordinary-conflict coverage remains. Sanitized browser captures show retained drafts, blocked fresh-tab fields and preserved validation issues.
