### PR TITLE
test(ui): preserve nested failure summaries in CI logs

### DIFF
--- a/ui/src/e2e/chat-file-links.e2e.test.ts
+++ b/ui/src/e2e/chat-file-links.e2e.test.ts
@@ -306,7 +306,7 @@ describeControlUiE2e("Control UI chat file links", () => {
         await page.screenshot({
           path: path.join(artifactDir, `root-identity-file-${index + 1}.png`),
         });
-        await page.getByRole("button", { name: "Close Review", exact: true }).click();
+        await page.getByRole("button", { name: "Close tab: file.ts", exact: true }).click();
         await fileView.waitFor({ state: "detached" });
       }
       const requests = await gateway.getRequests("sessions.files.get");

--- a/ui/src/test-helpers/control-ui-e2e.test.ts
+++ b/ui/src/test-helpers/control-ui-e2e.test.ts
@@ -1,6 +1,7 @@
 // Control UI tests cover control ui e2e behavior.
 import { readFileSync, readdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
+import { format } from "node:util";
 import type { Page } from "playwright";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.ts";
@@ -153,6 +154,11 @@ describe("shared proof capture", () => {
           return Buffer.from("failure-proof");
         },
       } as unknown as Page;
+      const frameEvent = {
+        at: "2026-09-01T00:00:00.000Z",
+        source: "framenavigated" as const,
+        details: { url: "https://private-frame.invalid/?token=private-token" },
+      };
       for (let attempt = 0; attempt < 2; attempt += 1) {
         const original = new Error("private-original-error");
         const failedAction = async () => {
@@ -163,6 +169,7 @@ describe("shared proof capture", () => {
               error: original,
               label: "chat.send",
               modelResponses,
+              pageEvents: [frameEvent],
             });
             throw error;
           }
@@ -172,11 +179,14 @@ describe("shared proof capture", () => {
       const directories = readdirSync(parent, { withFileTypes: true }).filter((entry) =>
         entry.isDirectory(),
       );
-      const summaries = logs.mock.calls
+      const renderedSummaries = logs.mock.calls
         .filter(([message]) => message === "[control-ui-e2e] failure state")
-        .map(([, summary]) => summary);
-      expect(summaries).toHaveLength(2);
-      for (const summary of summaries) {
+        .map((args) => format(...args));
+      expect(renderedSummaries).toHaveLength(2);
+      for (const rendered of renderedSummaries) {
+        expect(rendered).not.toContain("[Object]");
+        expect(rendered).not.toContain("private-");
+        const summary = JSON.parse(rendered.slice("[control-ui-e2e] failure state ".length));
         expect(summary).toMatchObject({
           browser: {
             gatewayPhase: failure === "storage" ? "unknown" : "connected",
@@ -244,6 +254,7 @@ describe("shared proof capture", () => {
         const report = JSON.parse(readFileSync(path.join(root, reportFile!), "utf8"));
         expect(report).toMatchObject({
           label: "chat.send",
+          pageEvents: [frameEvent],
           captureErrors:
             failure === "screenshot" ? [expect.stringContaining("private-screenshot-error")] : [],
           ci: {

--- a/ui/src/test-helpers/control-ui-e2e.ts
+++ b/ui/src/test-helpers/control-ui-e2e.ts
@@ -3767,10 +3767,9 @@ async function captureControlUiE2eFailureDiagnosticsUnsafe(
   }
   // Normal PR CI may not upload this artifact owner. Emit safe facts before any
   // capture I/O so a broken screenshot or output directory cannot hide the state.
-  console.error("[control-ui-e2e] failure state", {
-    browser: summary,
-    models: modelResponses ? summarizeRecordedModelResponses(modelResponses) : null,
-  });
+  // JSON preserves nested facts that Node's default object rendering collapses.
+  const models = modelResponses ? summarizeRecordedModelResponses(modelResponses) : null;
+  console.error("[control-ui-e2e] failure state", JSON.stringify({ browser: summary, models }));
   const configuredDir = process.env.OPENCLAW_UI_E2E_DIAGNOSTIC_DIR?.trim();
   const artifactDir = createControlUiE2eArtifactDir(
     "failure",


### PR DESCRIPTION
## What Problem This Solves

Node renders nested safe Control UI failure details as `[Object]`, hiding facts such as the send-button label and state during the intermittent approval-flow failure. The shared capture owner already has those sanitized facts; console formatting loses them.

## User Impact

Failure logs retain the complete existing sanitized summary as JSON. Product behavior, test scheduling and deadlines are unchanged. This improves diagnosis without claiming to fix or explain the intermittent approval-flow failure.

## Why This Change Was Made

Serialize the existing closed `{ browser, models }` summary before artifact I/O. Raw browser state, frame data, credentials, model identifiers and draft text stay outside console output. Capture failures preserve the original test error. Existing tests now exercise Node's real formatter instead of only inspecting the spy's in-memory argument.

This head also retains the reviewed one-line file-tab fixture correction from c1f1ea3eab48f8edb6ea607a432830b56b35eb71. The identical correction subsequently landed on main in #146810 (ff9c1b0b), so it adds no further behavior when this PR merges. The remaining net change is the two diagnostic files.

## Evidence

Four existing diagnostic cases failed against the original `[Object]` rendering; all nine pass with JSON serialization. Nested facts, private-data exclusion, repeated captures, screenshot/storage failures and original-error preservation remain asserted. Both changed-file gates and independent P2 reviews passed, including a combined review of the retained three-file head; final files match their tested hashes.

The corrected file-link case passed with all six siblings in original order, taking 1.37s locally. Its content, distinct roots, path, target-line, keyboard and detachment assertions are retained. The hosted old-selector failure and local pass are not a controlled timing comparison.

Exact-head [CI 34748471920](https://github.com/openclaw/openclaw/actions/runs/34748471920) passed at 7fc7a1a8d7782ddea60518e082eb6cc4d5377ffe. CI checkout logs verify that head in the tested merge. All 56 real-Gateway cases in 28 files passed in 405.70s; no speedup from this diagnostic change is claimed.

Production LOC: 0; net new test support: -1; tests: +11. No new cases, fields, waits, timeouts, shards or caching. Changelog remains release-owned.
