### PR TITLE
fix: avoid Gateway reinstalls when macOS service inspection is inconclusive

### DIFF
--- a/apps/macos/Sources/OpenClaw/GatewayLaunchAgentManager.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayLaunchAgentManager.swift
@@ -130,14 +130,25 @@ enum GatewayLaunchAgentManager {
     }
 
     static func reusableLoadedGatewayPID(port: Int, allowUnconfigured: Bool = false) async -> Int32? {
-        await self.loadedGatewayState(port: port, allowUnconfigured: allowUnconfigured).reusablePID
+        try? await self.loadedGatewayState(port: port, allowUnconfigured: allowUnconfigured)?.reusablePID
     }
 
-    static func loadedGatewayState(port: Int, allowUnconfigured: Bool = false) async -> LoadedGatewayState {
-        guard let service = await self.readDaemonService() else {
-            return LoadedGatewayState(runningPID: nil, reusablePID: nil)
-        }
+    static func loadedGatewayState(port: Int, allowUnconfigured: Bool = false) async throws -> LoadedGatewayState? {
+        guard let service = try await self.readDaemonService() else { return nil }
         let runningPID = self.runningGatewayPID(from: service)
+        let runtime = service["runtime"] as? [String: Any]
+        guard let loaded = service["loaded"] as? Bool,
+              !loaded || runtime?["status"] as? String == "stopped" || runningPID != nil
+        else {
+            for state in [service["loadState"] as? [String: Any], runtime] {
+                if let detail = state?["detail"] as? String,
+                   !detail.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                {
+                    throw ServiceInspectionError(message: detail)
+                }
+            }
+            return nil
+        }
         let configAudit = service["configAudit"] as? [String: Any]
         let command = service["command"] as? [String: Any]
         let arguments = command?["programArguments"] as? [String] ?? []
@@ -163,7 +174,7 @@ enum GatewayLaunchAgentManager {
     }
 
     static func runningGatewayPID() async -> Int32? {
-        guard let service = await self.readDaemonService() else { return nil }
+        guard let service = try? await self.readDaemonService() else { return nil }
         return self.runningGatewayPID(from: service)
     }
 
@@ -252,12 +263,22 @@ enum GatewayLaunchAgentManager {
 }
 
 extension GatewayLaunchAgentManager {
-    private static func readDaemonService() async -> [String: Any]? {
+    private struct ServiceInspectionError: LocalizedError, Sendable {
+        let message: String
+        var errorDescription: String? {
+            self.message
+        }
+    }
+
+    private static func readDaemonService() async throws -> [String: Any]? {
         let result = await self.runDaemonCommandResult(
             ["status", "--json", "--no-probe"],
             timeout: 15,
             quiet: true)
-        guard result.success, let payload = result.payload else { return nil }
+        guard result.success else {
+            throw ServiceInspectionError(message: result.message ?? "Gateway service inspection failed")
+        }
+        guard let payload = result.payload else { return nil }
         guard
             let json = try? JSONSerialization.jsonObject(with: payload) as? [String: Any],
             let service = json["service"] as? [String: Any]
@@ -370,11 +391,11 @@ extension GatewayLaunchAgentManager {
             return CommandResult(success: true, payload: payload, message: nil)
         }
 
+        let detail = message ?? self.summarize(response.stderr) ?? self.summarize(response.stdout)
         if quiet {
-            return CommandResult(success: false, payload: payload, message: message)
+            return CommandResult(success: false, payload: payload, message: detail)
         }
 
-        let detail = message ?? self.summarize(response.stderr) ?? self.summarize(response.stdout)
         let exit = response.exitCode.map { "exit \($0)" } ?? (response.errorMessage ?? "failed")
         let fullMessage = detail.map { "Gateway daemon command failed (\(exit)): \($0)" }
             ?? "Gateway daemon command failed (\(exit))"

--- a/apps/macos/Sources/OpenClaw/GatewayProcessManager.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayProcessManager.swift
@@ -40,18 +40,30 @@ final class GatewayProcessManager {
         let generation: UInt64
     }
 
-    private struct LaunchAgentEnableResult: Sendable {
-        let error: String?
-        let installed: Bool
+    private enum LaunchAgentEnableResult: Sendable {
+        case skipped
+        case installedService
+        case failed(String)
+        case deferred(String)
 
-        static let skipped = LaunchAgentEnableResult(error: nil, installed: false)
-
-        static func failed(_ error: String) -> LaunchAgentEnableResult {
-            LaunchAgentEnableResult(error: error, installed: false)
+        var error: String? {
+            if case let .failed(message) = self {
+                message
+            } else { nil }
         }
 
-        static func installed() -> LaunchAgentEnableResult {
-            LaunchAgentEnableResult(error: nil, installed: true)
+        var installed: Bool {
+            if case .installedService = self {
+                true
+            } else {
+                false
+            }
+        }
+
+        var inspectionFailure: String? {
+            if case let .deferred(message) = self {
+                message
+            } else { nil }
         }
     }
 
@@ -65,6 +77,7 @@ final class GatewayProcessManager {
         let readinessFailure: LaunchAgentReadinessFailure?
         let endpointPIDBeforeProbe: Int32?
         let launchAgentInstalled: Bool
+        let inspectionFailure: String?
     }
 
     private enum GatewayReadinessPurpose {
@@ -87,12 +100,13 @@ final class GatewayProcessManager {
     private enum GatewayReadinessFailure {
         case attachProbe(String)
         case responsiveProbe(String)
+        case serviceInspection(String)
         case timeoutWithRepairEvidence(LaunchAgentReadinessFailure)
         case deadlineWithoutRepairEvidence
 
         var reason: String {
             switch self {
-            case let .attachProbe(reason), let .responsiveProbe(reason): reason
+            case let .attachProbe(reason), let .responsiveProbe(reason), let .serviceInspection(reason): reason
             case .timeoutWithRepairEvidence: "Gateway did not start in time"
             case .deadlineWithoutRepairEvidence: "Gateway did not become ready in time"
             }
@@ -359,9 +373,20 @@ final class GatewayProcessManager {
     private func performLaunchAgentEnable(_ request: LaunchAgentEnableRequest) async -> LaunchAgentEnableResult {
         // App startup and onboarding can request persistence together. One drain owns all installs;
         // a second forced install would kill the first Gateway during startup migrations.
-        let launchAgent = await GatewayLaunchAgentManager.loadedGatewayState(
-            port: request.port,
-            allowUnconfigured: request.allowUnconfigured)
+        let launchAgent: GatewayLaunchAgentManager.LoadedGatewayState?
+        do {
+            launchAgent = try await GatewayLaunchAgentManager.loadedGatewayState(
+                port: request.port,
+                allowUnconfigured: request.allowUnconfigured)
+        } catch {
+            let reason = error.localizedDescription
+            self.appendLog("[gateway] launchd inspection failed: \(reason); waiting for readiness\n")
+            return .deferred(reason)
+        }
+        guard let launchAgent else {
+            self.appendLog("[gateway] launchd status unavailable; deferring installation\n")
+            return .skipped
+        }
         // Pair one launchd snapshot with a current listener read. A PID that starts after the
         // status read cannot look reusable, so the ownership guard preserves it instead of forcing
         // an install; a reusable PID from this same snapshot receives its readiness cycle below.
@@ -412,7 +437,7 @@ final class GatewayProcessManager {
         // and persistence calls coalesce, so the later caller may not receive `installed` itself.
         self.launchAgentInstallGeneration = request.generation
         self.launchAgentFreshInstallGeneration = isReadinessRepair ? nil : request.generation
-        return .installed()
+        return .installedService
     }
 
     private func resolveLaunchAgentReadinessFailure(
@@ -766,7 +791,8 @@ extension GatewayProcessManager {
         port: Int,
         generation: UInt64,
         readinessPID: Int32? = nil,
-        launchAgentInstalled: Bool = false) -> GatewayReadinessContext
+        launchAgentInstalled: Bool = false,
+        inspectionFailure: String? = nil) -> GatewayReadinessContext
     {
         GatewayReadinessContext(
             purpose: purpose,
@@ -777,7 +803,8 @@ extension GatewayProcessManager {
             readinessCandidate: self.launchAgentReadinessCandidate,
             readinessFailure: self.launchAgentReadinessFailure,
             endpointPIDBeforeProbe: self.lastObservedGatewayPID,
-            launchAgentInstalled: launchAgentInstalled)
+            launchAgentInstalled: launchAgentInstalled,
+            inspectionFailure: inspectionFailure)
     }
 
     private func prepareLaunchdGatewayStart(startGeneration: UInt64) async -> GatewayReadinessContext? {
@@ -816,7 +843,8 @@ extension GatewayProcessManager {
             port: port,
             generation: startGeneration,
             readinessPID: readinessPID,
-            launchAgentInstalled: enableResult.installed)
+            launchAgentInstalled: enableResult.installed,
+            inspectionFailure: enableResult.inspectionFailure)
     }
 
     private func enableLaunchdGateway(startGeneration: UInt64) async {
@@ -917,6 +945,7 @@ extension GatewayProcessManager {
             policy: deadlinePolicy,
             latestDisposition: latestRetryDisposition,
             latestError: latestProbeError,
+            responsiveStartupProgressObserved: responsiveStartupProgressObserved,
             readinessPID: readinessPID)
     }
 
@@ -925,6 +954,7 @@ extension GatewayProcessManager {
         policy: GatewayReadinessDeadlinePolicy,
         latestDisposition: GatewayProbeFailureDisposition?,
         latestError: Error?,
+        responsiveStartupProgressObserved: Bool,
         readinessPID: Int32?) async -> GatewayReadinessTerminal
     {
         guard self.isCurrentGatewayReadiness(context) else { return .superseded }
@@ -936,8 +966,14 @@ extension GatewayProcessManager {
         } else {
             false
         }
+        let fallbackFailure = if responsiveStartupProgressObserved {
+            GatewayReadinessFailure.deadlineWithoutRepairEvidence
+        } else {
+            context.inspectionFailure.map(GatewayReadinessFailure.serviceInspection)
+                ?? .deadlineWithoutRepairEvidence
+        }
         guard latestDisposition == .retryWithRepair else {
-            return migration ? .failed(.deadlineWithoutRepairEvidence) : .superseded
+            return migration ? .failed(fallbackFailure) : .superseded
         }
         let failure: LaunchAgentReadinessFailure? = if migration || context.readinessCandidate != nil {
             await self.resolveLaunchAgentReadinessFailure(
@@ -948,7 +984,7 @@ extension GatewayProcessManager {
         }
         guard self.isCurrentGatewayReadiness(context) else { return .superseded }
         guard let failure else {
-            return migration ? .failed(.deadlineWithoutRepairEvidence) : .superseded
+            return migration ? .failed(fallbackFailure) : .superseded
         }
         return .failed(.timeoutWithRepairEvidence(failure))
     }
@@ -1163,7 +1199,7 @@ extension GatewayProcessManager {
             }
             let retainedFailure: LaunchAgentReadinessFailure? = switch terminalFailure {
             case let .timeoutWithRepairEvidence(failure): failure
-            case .attachProbe, .responsiveProbe, .deadlineWithoutRepairEvidence: nil
+            case .attachProbe, .responsiveProbe, .serviceInspection, .deadlineWithoutRepairEvidence: nil
             }
             self.setLaunchAgentReadinessState(candidate: nil, failure: retainedFailure)
             self.status = .failed(terminalFailure.reason)
@@ -1174,6 +1210,9 @@ extension GatewayProcessManager {
             case .responsiveProbe:
                 self.lastFailureReason = terminalFailure.reason
                 self.appendLog("[gateway] responsive health probe failed: \(terminalFailure.reason)\n")
+            case .serviceInspection:
+                self.lastFailureReason = terminalFailure.reason
+                self.appendLog("[gateway] service inspection failed: \(terminalFailure.reason)\n")
             case .timeoutWithRepairEvidence:
                 self.lastFailureReason = if case .launchd = context.purpose {
                     "launchd start timeout"

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayLaunchAgentManagerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayLaunchAgentManagerTests.swift
@@ -264,6 +264,49 @@ struct GatewayLaunchAgentManagerTests {
         }
     }
 
+    @Test(arguments: ["load-state", "runtime"])
+    func `unknown service inspection preserves structured diagnostics`(_ scenario: String) async {
+        await TestIsolation.withIsolatedState {
+            defer {
+                GatewayLaunchAgentManager.setTestingInterceptDaemonCommands(false)
+                GatewayLaunchAgentManager.setTestingDaemonStatusPayload(nil)
+                GatewayLaunchAgentManager.clearTestingDaemonCommandCalls()
+            }
+
+            let expected = switch scenario {
+            case "load-state": "launchctl inspection failed; run openclaw gateway status --deep"
+            default: "launchd runtime inspection failed; retry from a GUI login"
+            }
+            let payload = switch scenario {
+            case "load-state":
+                """
+                {"ok":true,"service":{"loaded":null,
+                "loadState":{"status":"unknown","detail":"\(expected)"},
+                "runtime":{"status":"unknown","detail":"Runtime status is unavailable."}}}
+                """
+            default:
+                """
+                {"ok":true,"service":{"loaded":true,
+                "loadState":{"status":"loaded"},
+                "runtime":{"status":"unknown","detail":"\(expected)"}}}
+                """
+            }
+            GatewayLaunchAgentManager.setTestingInterceptDaemonCommands(true)
+            GatewayLaunchAgentManager.setTestingDaemonStatusPayload(payload)
+            GatewayLaunchAgentManager.clearTestingDaemonCommandCalls()
+
+            do {
+                _ = try await GatewayLaunchAgentManager.loadedGatewayState(port: 18789)
+                Issue.record("Expected the service inspection diagnostic")
+            } catch {
+                #expect(error.localizedDescription == expected)
+            }
+            #expect(GatewayLaunchAgentManager.testingDaemonCommandCallsSnapshot() == [
+                ["status", "--json", "--no-probe"],
+            ])
+        }
+    }
+
     @Test func `launch agent plist snapshot parses args and env`() throws {
         let url = FileManager().temporaryDirectory
             .appendingPathComponent("openclaw-launchd-\(UUID().uuidString).plist")

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayProcessManagerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayProcessManagerTests.swift
@@ -103,7 +103,7 @@ struct GatewayProcessManagerTests {
         mode: String = "local",
         port: Int? = nil,
         homeDirectory: URL? = nil,
-        statusPayload: String? = nil,
+        statusPayload: String? = #"{"ok":true,"service":{"loaded":false}}"#,
         statusPayloads: [String]? = nil,
         commandDelayNanoseconds: UInt64 = 0,
         commandHook: (@Sendable ([String]) async -> Void)? = nil,
@@ -592,6 +592,85 @@ struct GatewayProcessManagerTests {
             #expect(GatewayLaunchAgentManager.testingDaemonCommandCallsSnapshot() == expectedCalls)
             #expect(installed == shouldInstall)
         }
+    }
+
+    @Test(arguments: ["unresolved", "healthy", "responsive-error"])
+    func `startup readiness preserves the most specific failure`(_ outcome: String) async throws {
+        let port = try self.availableGatewayPort()
+        let url = try #require(URL(string: "ws://example.invalid"))
+        let inspectedService = Mutex(false)
+        let inspectionError = "launchctl inspection failed"
+        let guidance = "openclaw gateway status --deep"
+        let healthError = "fixture health rejected"
+        let statusPayload = """
+        {"ok":false,"error":"\(inspectionError)","hints":["\(guidance)"]}
+        """
+
+        try await self.withLaunchAgentEnvironment(
+            port: port,
+            statusPayload: statusPayload,
+            commandHook: { arguments in
+                if arguments.first == "status" {
+                    inspectedService.withLock { $0 = true }
+                }
+            }) {
+                try #require(GatewayEnvironment.gatewayPort() == port)
+                let session = GatewayTestWebSocketSession {
+                    GatewayTestWebSocketTask(sendHook: { task, message, sendIndex in
+                        guard sendIndex > 0,
+                              let id = GatewayWebSocketTestSupport.requestID(from: message)
+                        else { return }
+                        if outcome == "responsive-error",
+                           GatewayWebSocketTestSupport.requestMethod(from: message) == "health"
+                        {
+                            task.emitReceiveSuccess(.data(Data("""
+                            {"type":"res","id":"\(id)","ok":false,
+                            "error":{"code":"INVALID_REQUEST","message":"\(healthError)"}}
+                            """.utf8)))
+                        } else {
+                            task.emitReceiveSuccess(.data(GatewayWebSocketTestSupport.okResponseData(id: id)))
+                        }
+                    })
+                }
+                let connection = GatewayConnection(
+                    configProvider: {
+                        // Keep the initial attach unavailable until startup inspects the service.
+                        guard inspectedService.withLock({ $0 }), outcome != "unresolved" else {
+                            throw URLError(.cannotConnectToHost)
+                        }
+                        return (url: url, token: nil, password: nil)
+                    },
+                    sessionBox: WebSocketSessionBox(session: session))
+                let manager = GatewayProcessManager()
+                manager.setTestingConnection(connection)
+                manager.setTestingSkipControlChannelRefresh(true)
+                manager.setTestingDesiredActive(true)
+                defer { manager.setTestingDesiredActive(false) }
+
+                manager.startIfNeeded()
+                await manager.waitForStartupAttempt()
+                await connection.shutdown()
+
+                let calls = GatewayLaunchAgentManager.testingDaemonCommandCallsSnapshot()
+                #expect(!calls.isEmpty)
+                #expect(calls.allSatisfy { $0 == ["status", "--json", "--no-probe"] })
+                if outcome == "healthy" {
+                    guard case .running = manager.status else {
+                        Issue.record("expected healthy startup after the deferred service inspection")
+                        return
+                    }
+                    #expect(manager.lastFailureReason == nil)
+                } else {
+                    guard case let .failed(reason) = manager.status else {
+                        Issue.record("expected terminal startup failure")
+                        return
+                    }
+                    let expected = outcome == "unresolved" ? inspectionError : healthError
+                    #expect(reason.contains(expected))
+                    #expect(manager.lastFailureReason == reason)
+                    #expect(reason.contains(guidance) == (outcome == "unresolved"))
+                }
+            }
     }
 
     @Test func `newer inactive lifecycle retains the pending disable`() async throws {

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayProcessManagerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayProcessManagerTests.swift
@@ -550,6 +550,50 @@ struct GatewayProcessManagerTests {
         }
     }
 
+    @Test(arguments: [
+        (
+            """
+            {"service":{"loaded":null,"loadState":{"status":"unknown"},
+            "runtime":{"status":"unknown"}}}
+            """,
+            false),
+        (
+            """
+            {"service":{"loaded":true,"loadState":{"status":"loaded"},
+            "runtime":{"status":"unknown","inspectionFailure":{
+              "code":"service-runtime-inspection-failed","detail":"launchctl print failed"}}}}
+            """,
+            false),
+        (#"{"ok":false,"error":"Gateway service inspection failed."}"#, false),
+        (
+            """
+            {"service":{"loaded":false,"loadState":{"status":"not-loaded"},
+            "runtime":{"status":"unknown","missingUnit":true}}}
+            """,
+            true),
+    ])
+    func `persistence ensure distinguishes unknown inspection from a missing service`(
+        statusPayload: String,
+        shouldInstall: Bool) async throws
+    {
+        let port = try self.availableGatewayPort()
+        // Queue status alone so an erroneous install still receives the fixture's success response.
+        try await self.withLaunchAgentEnvironment(port: port, statusPayloads: [statusPayload]) {
+            try #require(GatewayEnvironment.gatewayPort() == port)
+            let manager = self.manager
+            manager.setTestingDesiredActive(true)
+
+            let installed = await manager.ensureLaunchAgentEnabledIfNeeded()
+
+            var expectedCalls = [["status", "--json", "--no-probe"]]
+            if shouldInstall {
+                expectedCalls.append(["install", "--force", "--port", String(port), "--runtime", "node"])
+            }
+            #expect(GatewayLaunchAgentManager.testingDaemonCommandCallsSnapshot() == expectedCalls)
+            #expect(installed == shouldInstall)
+        }
+    }
+
     @Test func `newer inactive lifecycle retains the pending disable`() async throws {
         try await self.withLaunchAgentEnvironment(commandDelayNanoseconds: 100_000_000) {
             let manager = self.manager

--- a/docs/platforms/mac/bundled-gateway.md
+++ b/docs/platforms/mac/bundled-gateway.md
@@ -96,6 +96,8 @@ Behavior:
 - Quitting the app does **not** stop the Gateway (launchd keeps it alive).
 - If a Gateway is already running on the configured port, the app attaches to
   it instead of starting a new one.
+- If service inspection is inconclusive, the app defers installation and uses
+  its existing readiness checks. A service confirmed absent can still be installed.
 
 Use the CLI for lifecycle checks and recovery:
 


### PR DESCRIPTION
## What Problem This Solves

The macOS app can request a forced Gateway installation when service inspection fails or cannot establish the service's runtime state.

## User Impact

An inconclusive inspection now defers installation while startup continues through the existing readiness checks. Confirmed absence, stopped-service recovery, and configuration-mismatch repair retain their existing behavior.

## Why This Change Was Made

Unknown inspection previously produced the same empty PID result as a missing service, allowing `install --force`. The service adapter now distinguishes those outcomes and carries actionable command errors and structured status details into the existing readiness attempt. Load-state detail takes precedence over runtime detail.

The inspection diagnostic is shown if readiness ends without stronger evidence. Healthy recovery clears it, and a more specific responsive health or authentication error takes precedence. This uses the existing readiness owner and deadlines.

## Evidence

- [Native baseline](https://github.com/openclaw/openclaw/actions/runs/34747909548/job/103699199198): all three inconclusive-status cases incorrectly requested installation and returned an installed result, producing six assertion issues. The confirmed-absent control passed.
- [Current-head native CI](https://github.com/openclaw/openclaw/actions/runs/34757399770/job/103724108451) passed at `45668887559c94f400f1632ab18e4c3f29f27f8f`, including four install-decision cases, three startup diagnostic-precedence cases, and two structured-detail cases. Printed Swift Testing summaries separately report 2,245 default Mac tests, 4 named-profile tests, and 1,719 shared-kit tests passing. These fixtures intercept CLI commands and use in-memory Gateway transport; they do not demonstrate actual launchd mutation.
- Three independent P2 review passes found no actionable issues. The reviewed five-file patch is unchanged after integrating main. Current-head [macOS Periphery](https://github.com/openclaw/openclaw/actions/runs/34757399778), [shared-kit Periphery](https://github.com/openclaw/openclaw/actions/runs/34757399783), and [ClawSweeper revision 4](https://github.com/openclaw/openclaw/pull/146880#issuecomment-5652271482) are clear.

The completed CI watcher reported active rollup GREEN after excluding seven superseded contexts; the raw GitHub rollup retained FAILURE. The native maintainer workflow still owns preparation and merge admission.

<details>
<summary>Earlier fixed-head validation</summary>

[Native CI](https://github.com/openclaw/openclaw/actions/runs/34752409480/job/103711133878) also passed the same regression cases at `f955b9e7f520e179e2922941f987e94c135713e2`. That historical proof remains separate from the current-head run above.

</details>
