### PR TITLE
fix(ui): avoid extra chat rail work while replies stream

### DIFF
--- a/ui/src/pages/chat/components/chat-position-rail.test.ts
+++ b/ui/src/pages/chat/components/chat-position-rail.test.ts
@@ -1,7 +1,7 @@
 /* @vitest-environment jsdom */
 
 import { html, nothing, render } from "lit";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, assert, beforeEach, describe, expect, it, vi } from "vitest";
 import { createTestTranscript } from "../chat-view.test-helpers.ts";
 import { getTranscriptState } from "./chat-thread-interactions.ts";
 import { renderChatThread } from "./chat-thread.ts";
@@ -29,6 +29,111 @@ function message(id: string, role: string, content: unknown, seq: number, runId?
 describe("conversation position rail", () => {
   beforeEach(installTranscriptDomMocks);
   afterEach(resetTranscriptTestDom);
+
+  it("keeps stream edits off target scans while reconciling bubble mounts and identities", async () => {
+    const observed = new Set<Element>();
+    vi.stubGlobal(
+      "IntersectionObserver",
+      class {
+        observe = (element: Element) => observed.add(element);
+        unobserve = (element: Element) => observed.delete(element);
+        disconnect = () => observed.clear();
+      },
+    );
+    const props = {
+      ...threadProps("rail-mutations", "agent:main:rail-mutations", [
+        message("question", "user", "Earlier question", 1),
+        message("answer", "assistant", "Earlier answer", 2),
+      ]),
+      runActive: true,
+      stream: "Live **start**",
+      streamStartedAt: 3_000,
+    };
+    const transcript = createTestTranscript();
+    const container = document.body.appendChild(document.createElement("div"));
+    const rerender = () => {
+      render(renderChatThread(props, transcript), container);
+      transcript.hostUpdated();
+    };
+    const settleFrames = () =>
+      new Promise<void>((resolve) => {
+        requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+      });
+    props.onRequestUpdate = rerender;
+    try {
+      rerender();
+      transcript.hostConnected();
+      const root = container.querySelector<HTMLElement>(".chat-thread");
+      const marks = container.querySelector<HTMLElement>(".chat-position-rail__marks");
+      const original = container.querySelector<HTMLElement>(
+        '.chat-bubble[data-entry-id="question"]',
+      );
+      assert(root && marks && original);
+      Object.defineProperty(marks, "clientHeight", { configurable: true, value: 600 });
+      await settleFrames();
+      expect(observed.has(original)).toBe(true);
+      const query = vi.spyOn(root, "querySelectorAll");
+      const targetScans = () =>
+        query.mock.calls.filter(([selector]) => selector === ".chat-bubble[data-entry-id]").length;
+
+      for (const word of ["one", "two", "three"]) {
+        props.stream = `Live **${word}**`;
+        rerender();
+        await settleFrames();
+        expect(container.querySelector(".chat-bubble strong")?.textContent).toBe(word);
+        expect(container.querySelector('.chat-bubble[data-entry-id="question"]')).toBe(original);
+      }
+      expect(targetScans()).toBe(0);
+
+      original.remove();
+      await settleFrames();
+      expect(targetScans()).toBeGreaterThan(0);
+      expect(observed.has(original)).toBe(false);
+      query.mockClear();
+
+      const replacement = original.cloneNode(true) as HTMLElement;
+      root.append(replacement);
+      await settleFrames();
+      expect(targetScans()).toBeGreaterThan(0);
+      expect(observed.has(replacement)).toBe(true);
+      query.mockClear();
+      replacement.remove();
+      await settleFrames();
+      expect(targetScans()).toBeGreaterThan(0);
+      expect(observed.has(replacement)).toBe(false);
+      query.mockClear();
+
+      const wrapper = document.createElement("section");
+      wrapper.append(replacement);
+      root.append(wrapper);
+      await settleFrames();
+      expect(targetScans()).toBeGreaterThan(0);
+      expect(observed.has(replacement)).toBe(true);
+      query.mockClear();
+      wrapper.remove();
+      await settleFrames();
+      expect(targetScans()).toBeGreaterThan(0);
+      expect(observed.has(replacement)).toBe(false);
+      query.mockClear();
+
+      replacement.removeAttribute("data-entry-id");
+      root.append(replacement);
+      await settleFrames();
+      expect(targetScans()).toBe(0);
+      replacement.dataset.entryId = "question";
+      await settleFrames();
+      expect(targetScans()).toBeGreaterThan(0);
+      expect(observed.has(replacement)).toBe(true);
+      query.mockClear();
+      replacement.removeAttribute("data-entry-id");
+      await settleFrames();
+      expect(targetScans()).toBeGreaterThan(0);
+      expect(observed.has(replacement)).toBe(false);
+    } finally {
+      render(nothing, container);
+      transcript.hostDisconnected();
+    }
+  });
 
   it("publishes consecutive reader offsets even when the virtual row range is unchanged", async () => {
     transcriptDomState.measuredRowHeight = 120;

--- a/ui/src/pages/chat/components/chat-position-rail.ts
+++ b/ui/src/pages/chat/components/chat-position-rail.ts
@@ -15,6 +15,7 @@ import { resolveMessageDisplayMarkdown } from "./chat-message-text.ts";
 import type { ChatTranscriptSession } from "./chat-transcript-session.ts";
 
 const PREVIEW_LENGTH = 140;
+const MESSAGE_SELECTOR = ".chat-bubble[data-entry-id]";
 
 type RailInteraction = {
   hoveredId: string | null;
@@ -125,15 +126,25 @@ class ChatPositionRailDirective extends AsyncDirective {
         { root, rootMargin: `0px 0px -${underlap}px 0px`, threshold: [0, Number.EPSILON, 1] },
       );
       // Virtualization replaces message nodes without replacing the rail.
+      // Streaming descendants keep the same observed bubble targets.
       this.mutationObserver = new MutationObserver((records, observer) => {
         if (observer !== this.mutationObserver) {
           return;
         }
         if (
-          records.some(
-            (record) =>
-              !(record.target instanceof Element) || !record.target.closest(".chat-position-rail"),
-          )
+          records.some((record) => {
+            if (record.target instanceof Element && record.target.closest(".chat-position-rail")) {
+              return false;
+            }
+            return (
+              record.type === "attributes" ||
+              [...record.addedNodes, ...record.removedNodes].some(
+                (node) =>
+                  node instanceof Element &&
+                  (node.matches(MESSAGE_SELECTOR) || node.querySelector(MESSAGE_SELECTOR)),
+              )
+            );
+          })
         ) {
           this.targetsChanged = true;
           this.scheduleLayout();
@@ -151,7 +162,7 @@ class ChatPositionRailDirective extends AsyncDirective {
       return;
     }
     this.targetsChanged = false;
-    const targets = new Set(root.querySelectorAll(".chat-bubble[data-entry-id]"));
+    const targets = new Set(root.querySelectorAll(MESSAGE_SELECTOR));
     for (const [element, message] of this.observedMessages) {
       if (
         !targets.has(element) ||


### PR DESCRIPTION
## What Problem This Solves

Fixes: the conversation position rail repeatedly rescans unchanged saved messages while an assistant reply streams.

## User Impact

Streaming replies avoid redundant browser work while the rail continues tracking messages that enter or leave the mounted transcript. No configuration or migration is required.

## Why This Change Was Made

The existing observer now distinguishes changes to observed message targets from edits inside those messages. Direct and nested message mounts, removals, and identity changes still reconcile the target set. The change adds no cache and preserves the existing observer lifecycle.

Production changes: +16/-5 (net +11), needed to express which mutations change target membership. Tests: +106/-1.

Related grouping work: https://github.com/openclaw/openclaw/pull/143296. This fix preserves the current grouping and message-selector contract.

## Evidence

- Independent owner/dependency review is clear.
- The new regression uses the real transcript renderer and native MutationObserver. It checks zero full target scans across three streamed updates, then verifies direct/nested mounts, removals, and identity adoption/removal.
- Required autoreview completed with no actionable P0–P2 findings. Remote baseline/candidate tests and existing browser navigation coverage are pending.
- This is a reduction in redundant browser work; no end-to-end latency improvement has been measured.
