### PR TITLE
fix(discord): settle voice preprocessing before releasing audio input

### DIFF
--- a/extensions/discord/src/voice-message.metadata.test.ts
+++ b/extensions/discord/src/voice-message.metadata.test.ts
@@ -1,0 +1,151 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { setImmediate } from "node:timers/promises";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import { useAutoCleanupTempDirTracker } from "openclaw/plugin-sdk/test-env";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const media = vi.hoisted(() => ({
+  root: "",
+  probe: vi.fn<(args: string[]) => Promise<string>>(),
+  waveform: vi.fn<(args: string[]) => Promise<string>>(),
+  onCleanup: () => {},
+}));
+
+vi.mock("openclaw/plugin-sdk/temp-path", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("openclaw/plugin-sdk/temp-path")>()),
+  resolvePreferredOpenClawTmpDir: () => media.root,
+}));
+
+vi.mock("openclaw/plugin-sdk/media-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/media-runtime")>();
+  return {
+    ...actual,
+    runFfprobe: media.probe,
+    runFfmpeg: media.waveform,
+    unlinkIfExists: (filePath: string | null | undefined) => {
+      const cleanup = actual.unlinkIfExists(filePath);
+      void cleanup.then(() => media.onCleanup());
+      return cleanup;
+    },
+  };
+});
+
+import { getVoiceMessageMetadata } from "./voice-message.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+beforeEach(() => {
+  media.root = tempDirs.make("discord-voice-metadata-");
+  media.probe.mockReset();
+  media.waveform.mockReset();
+  media.onCleanup = () => {};
+});
+
+async function arrangeMetadata(waveformFails = false) {
+  const inputPath = path.join(media.root, "original.ogg");
+  const original = Buffer.from("caller-owned audio input");
+  await fs.writeFile(inputPath, original);
+  const probe = createDeferred<string>();
+  const started = createDeferred<void>();
+  const release = createDeferred<void>();
+  const cleaned = createDeferred<void>();
+  media.onCleanup = () => cleaned.resolve();
+  media.probe.mockReturnValue(probe.promise);
+  media.waveform.mockImplementation(async (args) => {
+    const outputPath = args.at(-1);
+    if (!outputPath) {
+      throw new Error("Missing waveform output path");
+    }
+    started.resolve();
+    await release.promise;
+    if (waveformFails) {
+      throw new Error("waveform conversion failed");
+    }
+    const pcm = Buffer.alloc(512);
+    for (let offset = 0; offset < pcm.length; offset += 2) {
+      pcm.writeInt16LE(1_000, offset);
+    }
+    await fs.writeFile(outputPath, pcm);
+    return "";
+  });
+  let settled = false;
+  const outcome = getVoiceMessageMetadata(inputPath).then(
+    (value) => {
+      settled = true;
+      return { value, error: undefined };
+    },
+    (error: unknown) => {
+      settled = true;
+      return { value: undefined, error };
+    },
+  );
+  return {
+    inputPath,
+    original,
+    probe,
+    started: started.promise,
+    release,
+    cleaned: cleaned.promise,
+    outcome,
+    isSettled: () => settled,
+  };
+}
+
+describe("voice metadata settlement owns waveform cleanup", () => {
+  it.each(["failure", "cancellation"] as const)(
+    "joins waveform cleanup before reporting duration %s",
+    async (failure) => {
+      const fixture = await arrangeMetadata();
+      const probeError = Object.assign(new Error(`duration ${failure}`), {
+        signal: failure === "cancellation" ? "SIGTERM" : undefined,
+      });
+      let settledBeforeWaveformRelease = false;
+      try {
+        await vi.waitFor(() => expect(media.waveform).toHaveBeenCalledOnce());
+        await fixture.started;
+        fixture.probe.reject(probeError);
+        await setImmediate();
+        settledBeforeWaveformRelease = fixture.isSettled();
+      } finally {
+        fixture.probe.resolve("1.25\n");
+        fixture.release.resolve();
+        await fixture.cleaned;
+        await fixture.outcome;
+      }
+
+      const result = await fixture.outcome;
+      expect(result.error).toMatchObject({
+        message: `Failed to get audio duration: duration ${failure}`,
+        cause: probeError,
+      });
+      expect(await fs.readFile(fixture.inputPath)).toEqual(fixture.original);
+      expect(await fs.readdir(media.root)).toEqual(["original.ogg"]);
+      expect(settledBeforeWaveformRelease).toBe(false);
+    },
+  );
+
+  it.each([false, true])(
+    "returns usable metadata after waveform failure=%s and cleanup",
+    async (waveformFails) => {
+      const fixture = await arrangeMetadata(waveformFails);
+      try {
+        await vi.waitFor(() => expect(media.waveform).toHaveBeenCalledOnce());
+        await fixture.started;
+        fixture.probe.resolve("1.25\n");
+      } finally {
+        fixture.probe.resolve("1.25\n");
+        fixture.release.resolve();
+        await fixture.cleaned;
+        await fixture.outcome;
+      }
+
+      const result = await fixture.outcome;
+      expect(result.error).toBeUndefined();
+      expect(result.value?.durationSecs).toBe(1.25);
+      expect(Buffer.from(result.value?.waveform ?? "", "base64")).toHaveLength(256);
+      expect(await fs.readFile(fixture.inputPath)).toEqual(fixture.original);
+      expect(await fs.readdir(media.root)).toEqual(["original.ogg"]);
+    },
+  );
+});

--- a/extensions/discord/src/voice-message.ts
+++ b/extensions/discord/src/voice-message.ts
@@ -272,15 +272,15 @@ export async function ensureOggOpus(filePath: string): Promise<{ path: string; c
 }
 
 /**
- * Get voice message metadata (duration and waveform)
+ * Wait for waveform cleanup before callers can release the audio input.
  */
 export async function getVoiceMessageMetadata(filePath: string): Promise<VoiceMessageMetadata> {
-  const [durationSecs, waveform] = await Promise.all([
-    getAudioDuration(filePath),
-    generateWaveform(filePath),
-  ]);
-
-  return { durationSecs, waveform };
+  const waveform = generateWaveform(filePath);
+  try {
+    return { durationSecs: await getAudioDuration(filePath), waveform: await waveform };
+  } finally {
+    await waveform;
+  }
 }
 
 type UploadUrlResponse = {


### PR DESCRIPTION
## What Problem This Solves

Fixes Discord voice-send cleanup releasing its temporary audio input while waveform processing is still active when duration probing fails.

## User Impact

When duration probing fails, the send now waits for waveform processing and cleanup attempts before returning the original error; successful metadata remains unchanged.

## Why This Change Was Made

The metadata owner starts duration and waveform work concurrently, but its fail-fast `Promise.all` could reject while the waveform task still owned the input. A `try/finally` now joins that waveform task before metadata completes, keeping cleanup with the existing media and workspace owners. Production changes are +7/−7 (net zero); the four regression cases add 151 test lines.

## Evidence

The final implementation passed 40 focused tests covering metadata, voice sends, voice-message helpers, and media execution. The normal changed gate passed all 25 selected checks against the explicit `c23e1b27…` base.

A fresh [Linux Testbox execution](https://github.com/openclaw/openclaw/actions/runs/34744365540) compared the exact final candidate with its unpatched baseline using the same synthetic audio and native tools. The baseline failed exactly two unit and two native premature-settlement assertions; the candidate passed all four unit and five native tests. Probe exit and SIGTERM cases showed baseline metadata settling while waveform work remained alive, while the candidate stayed pending until that work completed. Success and fallback metadata matched across phases. All ten native cases preserved input bytes and left no owned children or media residue; runtime-error reports were empty.

This proves native media preprocessing through the real media helpers, Execa, filesystem staging, and ffmpeg/ffprobe controls. It does not claim a live Discord send. Strict source inventories were unchanged within each phase, only the metadata owner differed between phases, and all 108,638 dependency entries remained unchanged.

The payload and archive packaging exited **0**. The outer wrapper exited **7** because artifact collection exited **9**; a subsequent single-file native download exited **0**. The recovered archive and all 139 manifested files were independently hash-verified, and the retained Testbox was explicitly stopped and confirmed completed. Earlier failed attempts remain excluded from this proof.

<details>
<summary>Exact candidate and recovered artifact identity</summary>

- Commit: [`fcfaf728f86e99075bca498b8daae8a10f3c1636`](https://github.com/openclaw/openclaw/commit/fcfaf728f86e99075bca498b8daae8a10f3c1636), containing the final `try/finally` implementation.
- Production SHA-256: `4b987fb038cf6250b046aeac6366a740cf1ca04367ccc7a6cbcec34eb158c273`.
- Regression-test SHA-256: `490d62b70bc0810dee06692b4bad3b6eff081263c1ab3239336f83eb95dfe563`.
- Recovered `result.tar.gz`: 18,292,810 bytes; SHA-256 `d6cf378ef747132dd64b4cdedb5a10aea5684aa40352207778db7a6d54f91bf6`.
- Recovered `final.json` SHA-256: `1d574f767ef9f4079e7e07e0d4e3292ac4c096b7418f7c3b33ca8cc967913257`.

The supplied main snapshot `ce6718fd82a492b7c1f2b068e1c68477fd9a8b7f` has no drift from the proof base in the inspected metadata owner, caller, media/process helpers, or related voice/audio lifecycle paths.

</details>
