### PR TITLE
improve: speed up session lists with large agent rosters

### DIFF
--- a/src/gateway/session-utils-list.ts
+++ b/src/gateway/session-utils-list.ts
@@ -6,7 +6,7 @@ import {
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
 import type { SessionsListParams } from "../../packages/gateway-protocol/src/index.js";
-import { listAgentIds } from "../agents/agent-scope-config.js";
+import { listAgentIds, withAgentRosterFactsBatch } from "../agents/agent-scope-config.js";
 import type { ModelCatalogEntry } from "../agents/model-catalog.js";
 import { tryResolveLegacyCompatibilityAgentId } from "../config/legacy.default-agent-owner.js";
 import type { SessionEntry } from "../config/sessions.js";
@@ -641,13 +641,13 @@ export async function listSessionsFromStoreAsync(
         ++checkedItems % 16 === 0 &&
         performance.now() - workStartedAt >= SESSIONS_LIST_YIELD_INTERVAL_MS;
       const preparation = prepareSessionList(params, shouldYieldPreparation);
-      let step = preparation.next();
+      let step = withAgentRosterFactsBatch(cfg, () => preparation.next());
       while (!step.done) {
         const pause = yieldIfNeeded();
         if (pause) {
           await pause;
         }
-        step = preparation.next();
+        step = withAgentRosterFactsBatch(cfg, () => preparation.next());
       }
       const list = step.value;
       const sessions: GatewaySessionRow[] = [];


### PR DESCRIPTION
## What Problem This Solves

Large session lists repeatedly scan the configured agent roster while preparing owner and participant details.

## User Impact

Session lists use less CPU and finish sooner on Gateways with many agent-owned sessions. Returned rows, owner filters, pagination and cooperative yielding retain their behavior; no configuration or migration is required.

## Why This Change Was Made

Reuse the existing agent-roster batch around each synchronous preparation chunk. Its lazy index is discarded before every await, so later chunks and requests observe current config. The supported internal selection callbacks are read-only; their contracts remain unchanged.

## Evidence

Four fresh Windows/Node 26.8.2 processes in baseline/candidate/candidate/baseline order, with 12 warm calls per scenario through the actual asynchronous list projection:

| 10,000 sessions | Before | After |
| --- | ---: | ---: |
| 128 configured agents | 111.39 ms | 71.99 ms |
| 128 agents with participant projection | 211.29 ms | 87.30 ms |
| 128 agents with the production visibility filter | 119.20 ms | 84.13 ms |

Values are means of the two process means; baseline and candidate process ranges are disjoint for these cases. Tiny, 1,000-session and no-owner controls overlap. Imports, fixture setup and assertions are outside warm timing. These are synthetic-store projection measurements, not an overall Gateway or memory claim.

Full responses match across all variants, including rows, owner facets, filters, normalized duplicate/missing IDs and keyed-roster precedence. Functional controls verify config replacement between calls and between cooperative chunks, including first-owner facet retention.

All 30 existing focused tests, targeted typed lint, installed formatting and fresh independent P2 review passed. Fresh build of this exact commit passed. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34748254932) is pending. Attempt 1 passed all executed jobs but one job never acquired a runner. Attempt 2 has another unacquired job and a 10-second child-process timeout in the unchanged settings-storage concurrency test, which passed on this same commit in attempt 1. That test does not call the modified session-list path; its failure remains recorded while CI recovery proceeds.
The built candidate completed an isolated synthetic Gateway load with eight concurrent turns, 1,000 stored sessions, 2,050 history reads, 100 updates and 138 probe samples, with zero request/probe failures. Turn duration was 49.54 s; the unchanged baseline measured 17.64 s initially and 46.89 s on a fresh repeat. This adaptive shared-host load establishes functional coverage, not an overall speedup. Candidate event-loop maximum was 899.2 ms and peak RSS 1,062.3 MiB. Gateway teardown exited 1 after the successful workload, also observed on both baselines; this is not clean-shutdown proof. All owned load processes joined and are absent.