### PR TITLE
refactor(cli): reuse command-group names

### DIFF
--- a/src/cli/program/command-group-descriptors.ts
+++ b/src/cli/program/command-group-descriptors.ts
@@ -1,6 +1,7 @@
 // Descriptor-to-lazy-command-group adapters used by core and sub-CLI registration.
 import type { Command } from "commander";
 import type { MachineOutputResolver } from "../machine-output-argv.js";
+import type { CommandGroupEntry } from "./register-command-groups.js";
 
 /** Descriptor for one root command placeholder. */
 export type NamedCommandDescriptor = {
@@ -18,19 +19,15 @@ export type CommandGroupDescriptorSpec<TArgs extends unknown[] = []> = readonly 
   register: (program: Command, ...args: TArgs) => Promise<void> | void,
 ];
 
-type CommandGroupEntryLike = {
-  placeholders: NamedCommandDescriptor[];
-  register: (program: Command) => Promise<void> | void;
-};
-
 /** Bind descriptors and registration arguments without importing the command modules. */
 export function buildCommandGroupEntries<TArgs extends unknown[]>(
   descriptors: readonly NamedCommandDescriptor[],
   specs: readonly CommandGroupDescriptorSpec<TArgs>[],
   ...args: TArgs
-): CommandGroupEntryLike[] {
+): CommandGroupEntry[] {
   const descriptorsByName = new Map(descriptors.map((descriptor) => [descriptor.name, descriptor]));
   return specs.map(([commandNames, register]) => ({
+    names: commandNames,
     placeholders: commandNames.map((name) => {
       const descriptor = descriptorsByName.get(name);
       if (!descriptor) {


### PR DESCRIPTION
## What Problem This Solves

CLI command-group construction discards names it already owns, causing registration and completion lookups to reconstruct them from placeholders.

## User Impact

No user-visible behavior change is intended. Command names, aliases, registration order and completion behavior remain unchanged; no migration or operator action is required.

## Why This Change Was Made

Keep existing names on internally built groups and remove the duplicate return-type shape. The builder infers its result with an explicitly typed callback; callers enforce the canonical command-group contract. This removes four production lines and redundant name-array allocation while preserving the public optional-name fallback, lazy callbacks, update behavior and plugin-loading policy.

## Evidence

[Repair CI run 34754248689](https://github.com/openclaw/openclaw/actions/runs/34754248689) passed at `2a370b80e2a4626dcda4bc1203fc72708b907ede`: 114 successful jobs, 17 skipped, including the required CI gate, architecture, core production types, all 18 canonical core-test graphs through the five-stripe union and tail, and all five core type-aware lint stripes. This is not a claim that the literal full lint command ran.

The repaired source also passed Madge with zero cycles and all 37 tests in the same three existing registry, sub-CLI and plugin-group files, with no skips. Formatting and diff checks passed. Fresh Codex P2 review found only the old cyclic index version; staging the exact reviewed working-tree repair resolved it, with no additional working-tree findings.

The original CI run caught a genuine static cycle introduced by the type import even though the runtime-only cycle guard passed. The repair removes that back-edge without a new module or suppression. Both earlier local 6 GiB type/lint resource failures remain recorded; their limits were not raised and the checks were not retried locally. The separate Labeler HTTP 422 permission failure was auxiliary, not required.

Earlier functional proof exercised the real `registerProgramCommands` facade with plain Commander, completion-group visits and lazy replacement/reparse with omitted and explicit names: all 12 paired observations matched. The original author also passed 26 selected small guards. These retain their original source labels; the repair only changes erased type imports/annotations and preserves the runtime implementation. This is boundary proof, not full CLI startup, generated shell-script proof or a measured speedup.

ClawSweeper's completed exact-head review verified the repair and admin exemption and reported no code/security finding. Maintainer assessment treats its contradictory generic external-contributor proof checkbox as inapplicable to this internal cleanup, given the actual proof above. The reviewer did not execute these tests; its comment and markers remain unchanged. All enforced review and required-check gates still apply.
