### PR TITLE
fix: restore browser proof for file links after tab migration

### DIFF
--- a/ui/src/e2e/chat-file-links.e2e.test.ts
+++ b/ui/src/e2e/chat-file-links.e2e.test.ts
@@ -306,7 +306,7 @@ describeControlUiE2e("Control UI chat file links", () => {
         await page.screenshot({
           path: path.join(artifactDir, `root-identity-file-${index + 1}.png`),
         });
-        await page.getByRole("button", { name: "Close Review", exact: true }).click();
+        await page.getByRole("button", { name: "Close tab: file.ts", exact: true }).click();
         await fileView.waitFor({ state: "detached" });
       }
       const requests = await gateway.getRequests("sessions.files.get");


### PR DESCRIPTION
Related: #146572, #146672

## What Problem This Solves

Fixes the file-label browser regression test stopping after its first preview because it still looks for the former “Close Review” button.

## User Impact

No product behavior changes. The regression again verifies both absolute and relative file targets through click and keyboard activation on the current tabbed file preview.

## Why This Change Was Made

The tab migration changed the accessible close control to “Close tab: file.ts.” This updates the one stale lookup while preserving the complete test, including distinct labels, exact Gateway request paths, file contents, line highlights, and preview teardown. Production changes: 0 lines; tests: +1/−1.

## Evidence

On main `ce6718fd82a492b7c1f2b068e1c68477fd9a8b7f`, the original browser case failed at the stale button lookup. With this correction, all seven cases in `chat-file-links.e2e.test.ts` passed against the normally built Control UI in Chromium. The candidate reached both file targets and retained the expected line-7 highlights. The explicit-base changed gate, formatting, and whitespace checks passed.

The retained synthetic screenshots and request evidence were inspected. This is a follow-up to the existing root-label repair, not an additional product fix.
