### PR TITLE
refactor(qa): share harness drift result construction

### DIFF
--- a/extensions/qa-lab/src/harness-parity.test.ts
+++ b/extensions/qa-lab/src/harness-parity.test.ts
@@ -267,6 +267,112 @@ describe("harness parity", () => {
     ).toBe("tool-description");
   });
 
+  it.each([
+    {
+      drift: "failure-mode",
+      right: { transportErrorClass: "transport", runtimeErrorClass: "runtime" },
+      details: "at least one harness variant hit a transport failure",
+    },
+    {
+      drift: "system-prompt",
+      right: {
+        systemPromptReport: {
+          ...BASE_PROMPT_REPORT,
+          systemPrompt: { ...BASE_PROMPT_REPORT.systemPrompt, chars: 101 },
+        },
+      },
+      details: "system prompt report differs",
+      promptDelta: { systemPromptChars: 1 },
+    },
+    {
+      drift: "tool-description",
+      right: {
+        systemPromptReport: {
+          ...BASE_PROMPT_REPORT,
+          tools: {
+            ...BASE_PROMPT_REPORT.tools,
+            entries: [{ ...BASE_PROMPT_REPORT.tools.entries[0], summaryChars: 10 }],
+          },
+        },
+      },
+      details: "tool description summary shape differs",
+      promptDelta: { toolSummaryChars: 2 },
+    },
+    {
+      drift: "tool-schema",
+      right: {
+        systemPromptReport: {
+          ...BASE_PROMPT_REPORT,
+          tools: { ...BASE_PROMPT_REPORT.tools, schemaChars: 22 },
+        },
+      },
+      details: "tool schema shape differs",
+      promptDelta: { toolSchemaChars: 2 },
+    },
+    {
+      drift: "tool-call-shape",
+      right: { toolCalls: [{ tool: "read", argsHash: "b", resultHash: "r" }] },
+      details: "tool call 1 differs (read/a vs read/b)",
+    },
+    {
+      drift: "tool-result-shape",
+      right: { toolCalls: [{ tool: "read", argsHash: "a", resultHash: "changed" }] },
+      details: "tool result 1 differs (read)",
+    },
+    {
+      drift: "structural",
+      right: {
+        transcriptBytes: '{"role":"assistant"}\n{"role":"tool"}\n',
+      },
+      details: "transcript/final-text structure differs (1 message records vs 2 message records)",
+    },
+    {
+      drift: "text-only",
+      right: { finalText: "different" },
+      details: "final text differs after whitespace normalization",
+    },
+    { drift: "none", right: {} },
+  ])("keeps complete result metadata for $drift", ({ drift, right, details, promptDelta }) => {
+    const source = makeCell("openclaw", {
+      toolCalls: [{ tool: "read", argsHash: "a", resultHash: "r" }],
+    });
+    const leftCell = buildHarnessParityCell({
+      variant: LEFT,
+      cell: source,
+      tokenUsageSource: "live-usage",
+    });
+    const rightCell = buildHarnessParityCell({
+      variant: RIGHT,
+      cell: {
+        ...source,
+        transcriptBytes: '{"type":"metadata"}\n' + source.transcriptBytes,
+        usage: { inputTokens: 20, outputTokens: 10, totalTokens: 30 },
+        ...right,
+      },
+      tokenUsageSource: "live-usage",
+    });
+
+    expect(
+      buildHarnessParityResult({ scenarioId: "metadata", left: leftCell, right: rightCell }),
+    ).toStrictEqual({
+      scenarioId: "metadata",
+      left: leftCell,
+      right: rightCell,
+      drift,
+      ...(drift === "none" ? {} : { driftDetails: details, firstDriftTurn: 1 }),
+      promptDelta: {
+        systemPromptChars: 0,
+        projectContextChars: 0,
+        skillPromptChars: 0,
+        toolSummaryChars: 0,
+        toolSchemaChars: 0,
+        toolCount: 0,
+        ...promptDelta,
+      },
+      tokenDeltaPercent: 100,
+    });
+  });
+
   it("labels mock token estimates separately from live usage", () => {
     const sourceCell = makeCell("openclaw", {
       usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },

--- a/extensions/qa-lab/src/harness-parity.ts
+++ b/extensions/qa-lab/src/harness-parity.ts
@@ -273,6 +273,19 @@ export function buildHarnessParityResult(params: {
       : ((params.right.tokenUsage.totalTokens - params.left.tokenUsage.totalTokens) /
           params.left.tokenUsage.totalTokens) *
         100;
+  const driftResult = (
+    drift: Exclude<HarnessParityDrift, "none">,
+    driftDetails: string,
+  ): HarnessParityResult => ({
+    scenarioId: params.scenarioId,
+    left: params.left,
+    right: params.right,
+    drift,
+    driftDetails,
+    promptDelta,
+    tokenDeltaPercent,
+    firstDriftTurn: firstDriftTurn(params.left.transcriptBytes, params.right.transcriptBytes),
+  });
   const failDetails =
     params.left.transportErrorClass || params.right.transportErrorClass
       ? "at least one harness variant hit a transport failure"
@@ -280,52 +293,16 @@ export function buildHarnessParityResult(params: {
         ? "at least one harness variant hit a runtime failure"
         : undefined;
   if (failDetails) {
-    return {
-      scenarioId: params.scenarioId,
-      left: params.left,
-      right: params.right,
-      drift: "failure-mode",
-      driftDetails: failDetails,
-      promptDelta,
-      tokenDeltaPercent,
-      firstDriftTurn: firstDriftTurn(params.left.transcriptBytes, params.right.transcriptBytes),
-    };
+    return driftResult("failure-mode", failDetails);
   }
   if (params.left.systemPromptHash !== params.right.systemPromptHash) {
-    return {
-      scenarioId: params.scenarioId,
-      left: params.left,
-      right: params.right,
-      drift: "system-prompt",
-      driftDetails: "system prompt report differs",
-      promptDelta,
-      tokenDeltaPercent,
-      firstDriftTurn: firstDriftTurn(params.left.transcriptBytes, params.right.transcriptBytes),
-    };
+    return driftResult("system-prompt", "system prompt report differs");
   }
   if (params.left.toolDescriptionHash !== params.right.toolDescriptionHash) {
-    return {
-      scenarioId: params.scenarioId,
-      left: params.left,
-      right: params.right,
-      drift: "tool-description",
-      driftDetails: "tool description summary shape differs",
-      promptDelta,
-      tokenDeltaPercent,
-      firstDriftTurn: firstDriftTurn(params.left.transcriptBytes, params.right.transcriptBytes),
-    };
+    return driftResult("tool-description", "tool description summary shape differs");
   }
   if (params.left.toolSchemaHash !== params.right.toolSchemaHash) {
-    return {
-      scenarioId: params.scenarioId,
-      left: params.left,
-      right: params.right,
-      drift: "tool-schema",
-      driftDetails: "tool schema shape differs",
-      promptDelta,
-      tokenDeltaPercent,
-      firstDriftTurn: firstDriftTurn(params.left.transcriptBytes, params.right.transcriptBytes),
-    };
+    return driftResult("tool-schema", "tool schema shape differs");
   }
   const compareToolShapes =
     params.comparisonMode !== "codex-native-workspace" && params.comparisonMode !== "outcome-only";
@@ -335,29 +312,11 @@ export function buildHarnessParityResult(params: {
   if (compareToolShapes) {
     const toolCallDrift = compareToolCallShape(params.left.toolCalls, params.right.toolCalls);
     if (toolCallDrift) {
-      return {
-        scenarioId: params.scenarioId,
-        left: params.left,
-        right: params.right,
-        drift: "tool-call-shape",
-        driftDetails: toolCallDrift,
-        promptDelta,
-        tokenDeltaPercent,
-        firstDriftTurn: firstDriftTurn(params.left.transcriptBytes, params.right.transcriptBytes),
-      };
+      return driftResult("tool-call-shape", toolCallDrift);
     }
     const toolResultDrift = compareToolResultShape(params.left.toolCalls, params.right.toolCalls);
     if (toolResultDrift) {
-      return {
-        scenarioId: params.scenarioId,
-        left: params.left,
-        right: params.right,
-        drift: "tool-result-shape",
-        driftDetails: toolResultDrift,
-        promptDelta,
-        tokenDeltaPercent,
-        firstDriftTurn: firstDriftTurn(params.left.transcriptBytes, params.right.transcriptBytes),
-      };
+      return driftResult("tool-result-shape", toolResultDrift);
     }
   }
   const leftTranscriptRecords = countComparableTranscriptRecords(params.left.transcriptBytes);
@@ -368,30 +327,15 @@ export function buildHarnessParityResult(params: {
       (!params.left.finalText && Boolean(params.right.finalText)) ||
       (Boolean(params.left.finalText) && !params.right.finalText))
   ) {
-    return {
-      scenarioId: params.scenarioId,
-      left: params.left,
-      right: params.right,
-      drift: "structural",
-      driftDetails: `transcript/final-text structure differs (${leftTranscriptRecords} message records vs ${rightTranscriptRecords} message records)`,
-      promptDelta,
-      tokenDeltaPercent,
-      firstDriftTurn: firstDriftTurn(params.left.transcriptBytes, params.right.transcriptBytes),
-    };
+    return driftResult(
+      "structural",
+      `transcript/final-text structure differs (${leftTranscriptRecords} message records vs ${rightTranscriptRecords} message records)`,
+    );
   }
   if (
     normalizeTextForParity(params.left.finalText) !== normalizeTextForParity(params.right.finalText)
   ) {
-    return {
-      scenarioId: params.scenarioId,
-      left: params.left,
-      right: params.right,
-      drift: "text-only",
-      driftDetails: "final text differs after whitespace normalization",
-      promptDelta,
-      tokenDeltaPercent,
-      firstDriftTurn: firstDriftTurn(params.left.transcriptBytes, params.right.transcriptBytes),
-    };
+    return driftResult("text-only", "final text differs after whitespace normalization");
   }
   return {
     scenarioId: params.scenarioId,


### PR DESCRIPTION
## What Problem This Solves

QA harness comparisons repeat the same result metadata in eight drift branches, making those reports harder to maintain consistently.

## User Impact

No user-visible behavior changes. Comparison priority, diagnostics, token deltas, and transcript drift positions are preserved.

## Why This Change Was Made

One typed local constructor now owns drift results. The no-drift result still omits drift details and the first drift turn. Production changes: −56 lines; tests: +106 lines.

## Evidence

- [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34752307224) attempt 1 passed, including the required `openclaw/ci-gate`.
- Job 103710855310 passed all 14 harness-parity tests, including nine complete-result cases; 83 files and 825 tests passed. Actual module parity also matched 672 before/after cases.
- Primary and independent source reviews, fresh P2 autoreview, and the exact-head ClawSweeper review are clean. Native main comparison confirms both original files remain unchanged on main.
- A separate Labeler job failed with an installation-token permission error. Current branch rules require only `openclaw/ci-gate`; no permission changes or retries were made.
- No live provider or Codex runtime behavior is changed or claimed.
