### PR TITLE
refactor(feishu): remove unreachable requester topic selection

### DIFF
--- a/extensions/feishu/src/subagent-hooks.test.ts
+++ b/extensions/feishu/src/subagent-hooks.test.ts
@@ -158,6 +158,53 @@ describe("feishu subagent hook handlers", () => {
     });
   });
 
+  it("keeps ambiguous requester topics unresolved unless the child has one route", async () => {
+    const { deliveryHandler, manager } = managedHookFixture();
+    const requesterSessionKey = "agent:main:requester";
+    const childSessionKey = "agent:main:subagent:child";
+    for (const sender of ["ou_a", "ou_b"]) {
+      manager.bindConversation({
+        conversationId: `oc_group:topic:om_topic:sender:${sender}`,
+        parentConversationId: "oc_group",
+        targetKind: "session",
+        targetSessionKey: requesterSessionKey,
+      });
+    }
+    for (const [chat, topic] of [
+      ["oc_group", "om_topic"],
+      ["oc_other", "om_other"],
+    ] as const) {
+      manager.bindConversation({
+        conversationId: `${chat}:topic:${topic}`,
+        parentConversationId: chat,
+        targetKind: "subagent",
+        targetSessionKey: childSessionKey,
+      });
+    }
+    const event = deliveryEvent({
+      childSessionKey,
+      requesterSessionKey,
+      requesterOrigin: {
+        channel: "feishu",
+        accountId: "work",
+        to: "chat:oc_group",
+        threadId: "om_topic",
+      },
+    });
+
+    await expect(deliveryHandler(event, {})).resolves.toBeUndefined();
+
+    manager.unbindConversation("oc_other:topic:om_other");
+    await expect(deliveryHandler(event, {})).resolves.toEqual({
+      origin: {
+        channel: "feishu",
+        accountId: "work",
+        to: "chat:oc_group",
+        threadId: "om_topic",
+      },
+    });
+  });
+
   it("removes bound routes on subagent_ended", async () => {
     const { deliveryHandler, endedHandler, manager } = managedHookFixture();
     manager.bindConversation({

--- a/extensions/feishu/src/subagent-hooks.ts
+++ b/extensions/feishu/src/subagent-hooks.ts
@@ -95,27 +95,6 @@ function resolveFeishuRequesterConversation(params: {
             parentConversationId: existing.parentConversationId,
           };
         }
-        const senderScopedTopicBindings = matchingTopicBindings.filter((entry) => {
-          const parsed = parseFeishuConversationId({
-            conversationId: entry.conversationId,
-            parentConversationId: entry.parentConversationId,
-          });
-          return parsed?.scope === "group_topic_sender";
-        });
-        if (
-          senderScopedTopicBindings.length === 1 &&
-          matchingTopicBindings.length === senderScopedTopicBindings.length
-        ) {
-          const existing = senderScopedTopicBindings.at(0);
-          if (existing === undefined) {
-            return null;
-          }
-          return {
-            accountId: existing.accountId,
-            conversationId: existing.conversationId,
-            parentConversationId: existing.parentConversationId,
-          };
-        }
         return null;
       }
     }


### PR DESCRIPTION
## What Problem This Solves

Feishu requester-topic selection contains an unreachable duplicate route-selection branch.

## User Impact

No user-visible behavior changes. Ambiguous requester topics remain unresolved, and a child with only one bound route retains its existing fallback.

## Why This Change Was Made

The earlier branch already returns whenever exactly one topic matches. The removed branch required that same count, so it could never select a route. Production changes: −21 lines; tests: +47 lines.

## Evidence

- The registered-hook fixture uses real binding-manager APIs and distinct requester/child routes. It checks ambiguity rejection, then removes one child route and checks the remaining-route fallback.
- Actual before/after resolver and delivery functions matched across 10,206 cases using legal binding assignments and an in-memory manager adapter. This did not run Vitest or the Feishu API.
- Independent review and fresh P2 autoreview are clean. Targeted formatting and the normal commit hook passed with installed oxfmt 0.65.0.
- [Exact-head hosted CI](https://github.com/openclaw/openclaw/actions/runs/34752309091) passed. Job 103710876538 executed all 6 subagent hook cases, including the new ambiguity/fallback fixture; its descriptor passed 2059 tests across 103 files. Type/lint and pinned formatting checks passed. No live Feishu API or gateway execution is claimed.
