### PR TITLE
fix: keep queued deliveries in their original state directory

### DIFF
--- a/docs/reference/database-schemas/storage-changes.md
+++ b/docs/reference/database-schemas/storage-changes.md
@@ -97,6 +97,13 @@ session leaves the message for ordinary inbound dispatch. The durable reply is
 recorded before its optional side audit artifact and before completing the waiter;
 an audit failure does not discard an already recorded reply.
 
+Outbound queue work captures its state root and external-supervisor mode before
+asynchronous preparation. Enqueue, media custody, claims, completion and cleanup
+retain that context; SDK reconnect requests capture it before waiting for Gateway
+admission or loading the delivery runtime. A recovery root applies to an existing
+queue entry, while fresh sends use their selected default root. This context stays
+internal and is not added to durable payloads or plugin callback inputs.
+
 Board operations, board inventory reads, and widget document reads expose asynchronous
 contracts. Gateway callers await persistence before publishing board changes or replies.
 Writes carry the caller's current-authority assertion into the synchronous SQLite

--- a/scripts/check-plugin-sdk-exports.mts
+++ b/scripts/check-plugin-sdk-exports.mts
@@ -52,10 +52,15 @@ const requiredSubpathExports: Record<string, string[]> = {
   ],
 };
 
-// This private runtime facade has declarations only in the private-QA profile.
-// Do not require its types from ordinary public-package builds.
-const privateSessionManagerConsumer = isPrivateQaPluginSdkBuild(process.env)
+// These private runtime facades have declarations only in the private-QA profile.
+// Do not require their types from ordinary public-package builds.
+const privateRuntimeConsumers = isPrivateQaPluginSdkBuild(process.env)
   ? `import { SessionManager, type SessionEntry } from "openclaw/plugin-sdk/agent-sessions";
+import type { drainPendingDeliveries } from "openclaw/plugin-sdk/delivery-queue-runtime";
+
+type RecoveryDeliver = NonNullable<Parameters<typeof drainPendingDeliveries>[0]["deliver"]>;
+type RecoveryParams = Parameters<RecoveryDeliver>[0];
+type RecoveryContextIsPrivate = RequireNever<Extract<keyof RecoveryParams, PrivateQueueContextKeys>>;
 
 // Private facade declarations must preserve callable access to persist.
 declare const sessionManager: SessionManager;
@@ -77,6 +82,7 @@ let missing = 0;
       join(consumerRoot, "index.ts"),
       `import { buildChannelConfigSchema, DmPolicySchema } from "openclaw/plugin-sdk/channel-config-schema";
 import { defineChannelPluginEntry } from "openclaw/plugin-sdk/core";
+import type { sendDurableMessageBatch } from "openclaw/plugin-sdk/channel-outbound";
 import type {
   EmbeddingBatchChunk,
   EmbeddingBatchOptions,
@@ -98,7 +104,33 @@ import { createPluginRuntimeStore, type PluginRuntime } from "openclaw/plugin-sd
 import type { buildModelsProviderData, buildPreparedModelsProviderData, ModelsProviderData } from "openclaw/plugin-sdk/models-provider-runtime";
 import type { buildModelsProviderData as buildCommandAuthModelsProviderData } from "openclaw/plugin-sdk/command-auth";
 import { z } from "zod";
-${privateSessionManagerConsumer}
+${privateRuntimeConsumers}
+
+type RequireNever<T extends never> = T;
+type RequireTrue<T extends true> = T;
+type Equal<A, B> = (<T>() => T extends A ? 1 : 2) extends
+  (<T>() => T extends B ? 1 : 2) ? true : false;
+type PrivateQueueContextKeys = "deliveryQueueStateContext" | "supervisorMode" | "env";
+type SendParams = Parameters<typeof sendDurableMessageBatch>[0];
+type KeysOfUnion<T> = T extends unknown ? keyof T : never;
+// Database context stays private even when public aliases derive from core types.
+type SendContextIsPrivate = RequireNever<Extract<keyof SendParams, PrivateQueueContextKeys>>;
+type CompletionContextIsPrivate = RequireNever<
+  Extract<KeysOfUnion<NonNullable<SendParams["deliveryCompletion"]>>, PrivateQueueContextKeys>
+>;
+type QueueOwner = NonNullable<SendParams["deliveryQueueOwner"]>;
+type FailureRecorder = Parameters<QueueOwner["fail"]>[0];
+type FailureRecorderArgsUnchanged = RequireTrue<Equal<Parameters<FailureRecorder>, [
+  id: string,
+  error: string,
+  stateDir?: string,
+  expectedPlatformSendAttemptId?: string | null,
+]>>;
+type AckOptionsUnchanged = RequireTrue<Equal<NonNullable<Parameters<QueueOwner["ack"]>[0]>, {
+  retainSpoolArtifacts?: boolean;
+  suppressCompletionReceipt?: boolean;
+  expectedPlatformSendAttemptId?: string | null;
+}>>;
 
 // Stable v2026.7.1-2 consumers construct these results and supply typed adapters.
 const legacyModelsData = {

--- a/src/gateway/conversation-route-ownership.ts
+++ b/src/gateway/conversation-route-ownership.ts
@@ -326,14 +326,17 @@ export function assertConversationDeliveryAttemptAuthorized(params: {
   );
 }
 
-export function assertQueuedConversationDeliveryAttemptAuthorized(params: {
-  config: OpenClawConfig;
-  agentId: string;
-  operationId: string;
-  storePath?: string;
-  routeFingerprint: string;
-}): void {
-  const scope = {
+export function assertQueuedConversationDeliveryAttemptAuthorized(
+  params: {
+    config: OpenClawConfig;
+    agentId: string;
+    operationId: string;
+    storePath?: string;
+    routeFingerprint: string;
+  },
+  capturedScope?: ConversationRegistryScope,
+): void {
+  const scope = capturedScope ?? {
     agentId: params.agentId,
     ...(params.storePath ? { storePath: params.storePath } : {}),
   };

--- a/src/gateway/server-restart-sentinel-notice.ts
+++ b/src/gateway/server-restart-sentinel-notice.ts
@@ -15,6 +15,7 @@ import { createQueuedDeliveryOwner } from "../infra/outbound/deliver-queue-state
 import type { OutboundDeliveryResult } from "../infra/outbound/deliver-types.js";
 import { deliverOutboundPayloadsInternal } from "../infra/outbound/deliver.js";
 import { runOutboundDeliveryCommitHooks } from "../infra/outbound/delivery-commit-hooks.js";
+import { failPendingDelivery } from "../infra/outbound/delivery-queue-ack.js";
 import {
   withStableDeliveryPreparation,
   type StableDeliveryPreparationOwner,
@@ -27,7 +28,6 @@ import {
   failDelivery,
   failDeliveryAfterPlatformSend,
   failDeliveryBeforePlatformSend,
-  failPendingDelivery,
   findDeliveryIntentOwner,
   loadPendingDelivery,
   reserveDeliveryAttempt,

--- a/src/gateway/server-restart-sentinel.test.ts
+++ b/src/gateway/server-restart-sentinel.test.ts
@@ -415,11 +415,14 @@ vi.mock("../infra/outbound/delivery-queue-storage.js", () => ({
   failDelivery: mocks.failDelivery,
   failDeliveryAfterPlatformSend: mocks.failDeliveryAfterPlatformSend,
   failDeliveryBeforePlatformSend: mocks.failDeliveryBeforePlatformSend,
-  failPendingDelivery: mocks.failPendingDelivery,
   findDeliveryIntentOwner: mocks.findDeliveryIntentOwner,
   loadPendingDelivery: async () =>
     mocks.takeInitialOutboundDelivery() ?? (await mocks.loadPendingDelivery()),
   reserveDeliveryAttempt: mocks.reserveDeliveryAttempt,
+}));
+vi.mock("../infra/outbound/delivery-queue-ack.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../infra/outbound/delivery-queue-ack.js")>()),
+  failPendingDelivery: mocks.failPendingDelivery,
 }));
 vi.mock("../infra/outbound/delivery-queue-recovery.js", () => ({
   drainPendingDeliveriesCore: mocks.drainPendingDeliveries,

--- a/src/gateway/server-runtime-services.test.ts
+++ b/src/gateway/server-runtime-services.test.ts
@@ -273,12 +273,15 @@ describe("server-runtime-services", () => {
     if (!deliveryLog || !sessionDeliveryLog) {
       throw new Error("Expected delivery recovery log children");
     }
-    expect(hoisted.recoverPendingDeliveries).toHaveBeenCalledWith({
-      deliver: expect.any(Function),
-      cfg: {},
-      log: deliveryLog,
-      shouldContinue: expect.any(Function),
-    });
+    expect(hoisted.recoverPendingDeliveries).toHaveBeenCalledWith(
+      {
+        deliver: expect.any(Function),
+        cfg: {},
+        log: deliveryLog,
+        shouldContinue: expect.any(Function),
+      },
+      expect.any(Function),
+    );
     expect(hoisted.recoverPendingRestartContinuationDeliveries).toHaveBeenCalledWith({
       deps: {},
       maxEnqueuedAt: 123,
@@ -765,6 +768,7 @@ describe("server-runtime-services", () => {
         storePath: "/tmp/agent.sqlite",
         routeFingerprint: "route-recovery",
       }),
+      expect.objectContaining({ agentId: "main", storePath: "/tmp/agent.sqlite" }),
     );
     services.heartbeatRunner.stop();
   });
@@ -786,6 +790,7 @@ describe("server-runtime-services", () => {
 
       expect(hoisted.drainPendingDeliveries).toHaveBeenCalledWith(
         expect.objectContaining({ cfg: reloadedConfig }),
+        expect.any(Function),
       );
       expect(runtimeConfig).toHaveBeenCalledOnce();
     } finally {

--- a/src/gateway/server-runtime-services.ts
+++ b/src/gateway/server-runtime-services.ts
@@ -2,6 +2,10 @@
 // Starts delayed maintenance, cron, heartbeat, recovery, and pricing refresh work.
 import { getRuntimeConfig } from "../config/config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import {
+  resolveDeliveryQueueStateEnv,
+  type DeliveryQueueStateContext,
+} from "../infra/delivery-queue-sqlite.js";
 import { computeBackoffMs } from "../infra/delivery-recovery.shared.js";
 import {
   resolveHeartbeatAgents,
@@ -183,6 +187,7 @@ function startPendingOutboundDeliveryRecovery(params: {
       }
       const deliverWithCurrentConversationAuthority = async (
         deliveryParams: DeliverOutboundPayloadsParams,
+        stateContext?: DeliveryQueueStateContext,
       ) => {
         const completion = deliveryParams.deliveryCompletion;
         const attemptAuthority =
@@ -190,24 +195,37 @@ function startPendingOutboundDeliveryRecovery(params: {
             ? completion
             : deliveryParams.conversationDeliveryAttemptAuthority;
         if (!attemptAuthority) {
-          return await deliverOutboundPayloadsInternal(deliveryParams);
+          return await deliverOutboundPayloadsInternal(deliveryParams, stateContext);
         }
-        return await deliverOutboundPayloadsInternal({
-          ...deliveryParams,
-          onDeliveryAttempt: async () => {
-            await deliveryParams.onDeliveryAttempt?.();
-            if (!attemptAuthority.routeFingerprint) {
-              return;
-            }
-            assertQueuedConversationDeliveryAttemptAuthorized({
-              config: getRuntimeConfig(),
-              agentId: attemptAuthority.agentId,
-              operationId: attemptAuthority.operationId,
-              ...(attemptAuthority.storePath ? { storePath: attemptAuthority.storePath } : {}),
-              routeFingerprint: attemptAuthority.routeFingerprint,
-            });
+        return await deliverOutboundPayloadsInternal(
+          {
+            ...deliveryParams,
+            onDeliveryAttempt: async () => {
+              await deliveryParams.onDeliveryAttempt?.();
+              if (!attemptAuthority.routeFingerprint) {
+                return;
+              }
+              assertQueuedConversationDeliveryAttemptAuthorized(
+                {
+                  config: getRuntimeConfig(),
+                  agentId: attemptAuthority.agentId,
+                  operationId: attemptAuthority.operationId,
+                  ...(attemptAuthority.storePath ? { storePath: attemptAuthority.storePath } : {}),
+                  routeFingerprint: attemptAuthority.routeFingerprint,
+                },
+                {
+                  agentId: attemptAuthority.agentId,
+                  ...(attemptAuthority.storePath ? { storePath: attemptAuthority.storePath } : {}),
+                  env: resolveDeliveryQueueStateEnv(
+                    deliveryParams.deliveryQueueStateDir,
+                    stateContext,
+                  ),
+                },
+              );
+            },
           },
-        });
+          stateContext,
+        );
       };
       logRecovery ??= params.log.child("delivery-recovery");
       if (migrationPending) {
@@ -222,25 +240,31 @@ function startPendingOutboundDeliveryRecovery(params: {
         // A new scheduled-service lifecycle starts unchecked. Latch only after
         // one pass neither skipped ownership nor left retired rows behind.
         migrationPending = migration.skipped > 0 || migration.remaining > 0;
-        await recoverPendingDeliveries({
-          deliver: deliverWithCurrentConversationAuthority,
-          log: logRecovery,
-          cfg,
-          shouldContinue: () => !stopped,
-        });
+        await recoverPendingDeliveries(
+          {
+            deliver: deliverWithCurrentConversationAuthority,
+            log: logRecovery,
+            cfg,
+            shouldContinue: () => !stopped,
+          },
+          deliverWithCurrentConversationAuthority,
+        );
         return;
       }
       // Normal retries use fresh config so revoked accounts cannot inherit the
       // authority captured at gateway startup.
-      await drainPendingDeliveriesCore({
-        drainKey: "gateway:outbound",
-        logLabel: "Outbound delivery retry",
-        cfg: getRuntimeConfig(),
-        log: logRecovery,
-        deliver: deliverWithCurrentConversationAuthority,
-        selectEntry: () => ({ match: true, bypassBackoff: false }),
-        shouldContinue: () => !stopped,
-      });
+      await drainPendingDeliveriesCore(
+        {
+          drainKey: "gateway:outbound",
+          logLabel: "Outbound delivery retry",
+          cfg: getRuntimeConfig(),
+          log: logRecovery,
+          deliver: deliverWithCurrentConversationAuthority,
+          selectEntry: () => ({ match: true, bypassBackoff: false }),
+          shouldContinue: () => !stopped,
+        },
+        deliverWithCurrentConversationAuthority,
+      );
     }, "runtime:delivery-recovery").catch((err: unknown) =>
       params.log.error(`Delivery recovery failed: ${String(err)}`),
     );

--- a/src/infra/delivery-queue-sqlite-claim.ts
+++ b/src/infra/delivery-queue-sqlite-claim.ts
@@ -5,6 +5,8 @@ import {
 import { loadDeliveryQueueEntryInDatabase } from "./delivery-queue-sqlite-bound.js";
 import {
   upsertDeliveryQueueEntryInDatabase,
+  resolveDeliveryQueueStateEnv,
+  type DeliveryQueueStateContext,
   type DeliveryQueueEntryState,
 } from "./delivery-queue-sqlite.js";
 import { hasLiveDeliveryQueueClaim } from "./delivery-queue-sqlite.types.js";
@@ -44,6 +46,7 @@ export function transitionOwnedDeliveryQueueEntry(
   },
   // Unlike void, undefined rejects async callbacks before they can escape the transaction.
   transition: (entry: DeliveryQueueEntryState, database: OpenClawStateDatabase) => undefined,
+  context?: DeliveryQueueStateContext,
 ): boolean {
   return runOpenClawStateWriteTransaction(
     (database) => {
@@ -69,7 +72,7 @@ export function transitionOwnedDeliveryQueueEntry(
     },
     {
       database: params.database,
-      env: params.stateDir ? { ...process.env, OPENCLAW_STATE_DIR: params.stateDir } : process.env,
+      env: resolveDeliveryQueueStateEnv(params.stateDir, context),
     },
     {
       operationLabel: `mutate owned ${params.queueName} delivery platform send`,
@@ -81,6 +84,7 @@ function transitionDeliveryQueueEntryPlatformSend(
   params: PlatformClaimParams,
   operation: "claim" | "promote" | "dispatch",
   transition: (entry: DeliveryQueueEntryState, now: number) => DeliveryQueueEntryState | undefined,
+  context?: DeliveryQueueStateContext,
 ): boolean {
   return runOpenClawStateWriteTransaction(
     (database) => {
@@ -116,7 +120,7 @@ function transitionDeliveryQueueEntryPlatformSend(
         : false;
     },
     {
-      env: params.stateDir ? { ...process.env, OPENCLAW_STATE_DIR: params.stateDir } : process.env,
+      env: resolveDeliveryQueueStateEnv(params.stateDir, context),
     },
     {
       operationLabel: `${operation} ${params.queueName} delivery platform send`,
@@ -127,34 +131,40 @@ function transitionDeliveryQueueEntryPlatformSend(
 /** Claim a recoverable producer lease before any provider invocation. */
 export function claimDeliveryQueueEntryPlatformSend(
   params: PlatformClaimParams,
+  context?: DeliveryQueueStateContext,
 ): string | undefined {
   const claimId = generateSecureUuid();
-  return transitionDeliveryQueueEntryPlatformSend(params, "claim", (entry, now) => {
-    const reconciledNotSent =
-      entry.recoveryState === "send_attempt_started" &&
-      typeof params.reconciledPlatformSendStartedAt === "number" &&
-      entry.platformSendStartedAt === params.reconciledPlatformSendStartedAt &&
-      typeof params.reconciledPlatformSendAttemptId === "string" &&
-      entry.platformSendAttemptId === params.reconciledPlatformSendAttemptId;
-    if (
-      entry.recoveryState &&
-      !reconciledNotSent &&
-      (entry.recoveryState !== "producer_claimed" ||
-        typeof entry.availableAt !== "number" ||
-        entry.availableAt > now)
-    ) {
-      return undefined;
-    }
-    return {
-      ...entry,
-      ...(params.requiresProducerClaim === true ? { requiresProducerClaim: true } : {}),
-      availableAt: now + PLATFORM_SEND_OWNER_LEASE_MS,
-      producerClaimId: claimId,
-      platformSendAttemptId: undefined,
-      platformSendStartedAt: undefined,
-      recoveryState: "producer_claimed",
-    };
-  })
+  return transitionDeliveryQueueEntryPlatformSend(
+    params,
+    "claim",
+    (entry, now) => {
+      const reconciledNotSent =
+        entry.recoveryState === "send_attempt_started" &&
+        typeof params.reconciledPlatformSendStartedAt === "number" &&
+        entry.platformSendStartedAt === params.reconciledPlatformSendStartedAt &&
+        typeof params.reconciledPlatformSendAttemptId === "string" &&
+        entry.platformSendAttemptId === params.reconciledPlatformSendAttemptId;
+      if (
+        entry.recoveryState &&
+        !reconciledNotSent &&
+        (entry.recoveryState !== "producer_claimed" ||
+          typeof entry.availableAt !== "number" ||
+          entry.availableAt > now)
+      ) {
+        return undefined;
+      }
+      return {
+        ...entry,
+        ...(params.requiresProducerClaim === true ? { requiresProducerClaim: true } : {}),
+        availableAt: now + PLATFORM_SEND_OWNER_LEASE_MS,
+        producerClaimId: claimId,
+        platformSendAttemptId: undefined,
+        platformSendStartedAt: undefined,
+        recoveryState: "producer_claimed",
+      };
+    },
+    context,
+  )
     ? claimId
     : undefined;
 }
@@ -164,6 +174,7 @@ export function renewDeliveryQueueEntryPlatformSendLease(
   params: Pick<PlatformClaimParams, "queueName" | "id" | "stateDir"> & {
     claimId: string;
   },
+  context?: DeliveryQueueStateContext,
 ): number | undefined {
   return runOpenClawStateWriteTransaction(
     (database) => {
@@ -194,7 +205,7 @@ export function renewDeliveryQueueEntryPlatformSendLease(
         : undefined;
     },
     {
-      env: params.stateDir ? { ...process.env, OPENCLAW_STATE_DIR: params.stateDir } : process.env,
+      env: resolveDeliveryQueueStateEnv(params.stateDir, context),
     },
     {
       operationLabel: `renew ${params.queueName} delivery platform send`,
@@ -208,25 +219,30 @@ export function promoteDeliveryQueueEntryPlatformSend(
     claimId: string;
     route?: { replyToId?: string | null };
   },
+  context?: DeliveryQueueStateContext,
 ): boolean {
-  return transitionDeliveryQueueEntryPlatformSend(params, "promote", (entry, now) =>
-    entry.recoveryState === "producer_claimed" &&
-    hasLiveDeliveryQueueClaim(entry, params.claimId, now)
-      ? {
-          ...entry,
-          // Only an explicitly leased owner keeps its cross-process fence;
-          // legacy recovery must remain immediately eligible after a crash.
-          availableAt:
-            entry.requiresProducerClaim === true ? now + PLATFORM_SEND_OWNER_LEASE_MS : undefined,
-          producerClaimId: undefined,
-          platformSendAttemptId: params.claimId,
-          platformSendStartedAt: now,
-          ...(params.route && "replyToId" in params.route
-            ? { effectiveReplyToId: params.route.replyToId ?? null }
-            : {}),
-          recoveryState: "send_attempt_started",
-        }
-      : undefined,
+  return transitionDeliveryQueueEntryPlatformSend(
+    params,
+    "promote",
+    (entry, now) =>
+      entry.recoveryState === "producer_claimed" &&
+      hasLiveDeliveryQueueClaim(entry, params.claimId, now)
+        ? {
+            ...entry,
+            // Only an explicitly leased owner keeps its cross-process fence;
+            // legacy recovery must remain immediately eligible after a crash.
+            availableAt:
+              entry.requiresProducerClaim === true ? now + PLATFORM_SEND_OWNER_LEASE_MS : undefined,
+            producerClaimId: undefined,
+            platformSendAttemptId: params.claimId,
+            platformSendStartedAt: now,
+            ...(params.route && "replyToId" in params.route
+              ? { effectiveReplyToId: params.route.replyToId ?? null }
+              : {}),
+            recoveryState: "send_attempt_started",
+          }
+        : undefined,
+    context,
   );
 }
 
@@ -236,31 +252,37 @@ export function dispatchDeliveryQueueEntryPlatformSend(
     claimId: string;
     route?: { replyToId?: string | null };
   },
+  context?: DeliveryQueueStateContext,
 ): boolean {
-  return transitionDeliveryQueueEntryPlatformSend(params, "dispatch", (entry, now) => {
-    if (!hasLiveDeliveryQueueClaim(entry, params.claimId, now)) {
-      return undefined;
-    }
-    return {
-      ...entry,
-      // Exact reconciliation can skip pre-send promotion, so publish attempt identity
-      // atomically; later batch dispatches retain stronger unknown-after-send evidence.
-      availableAt:
-        entry.requiresProducerClaim === true
-          ? entry.recoveryState === "producer_claimed"
-            ? now + PLATFORM_SEND_OWNER_LEASE_MS
-            : entry.availableAt
-          : undefined,
-      producerClaimId: undefined,
-      platformSendAttemptId: params.claimId,
-      platformSendStartedAt: now,
-      ...(params.route && "replyToId" in params.route
-        ? { effectiveReplyToId: params.route.replyToId ?? null }
-        : {}),
-      recoveryState:
-        entry.recoveryState === "unknown_after_send"
-          ? "unknown_after_send"
-          : "send_attempt_started",
-    };
-  });
+  return transitionDeliveryQueueEntryPlatformSend(
+    params,
+    "dispatch",
+    (entry, now) => {
+      if (!hasLiveDeliveryQueueClaim(entry, params.claimId, now)) {
+        return undefined;
+      }
+      return {
+        ...entry,
+        // Exact reconciliation can skip pre-send promotion, so publish attempt identity
+        // atomically; later batch dispatches retain stronger unknown-after-send evidence.
+        availableAt:
+          entry.requiresProducerClaim === true
+            ? entry.recoveryState === "producer_claimed"
+              ? now + PLATFORM_SEND_OWNER_LEASE_MS
+              : entry.availableAt
+            : undefined,
+        producerClaimId: undefined,
+        platformSendAttemptId: params.claimId,
+        platformSendStartedAt: now,
+        ...(params.route && "replyToId" in params.route
+          ? { effectiveReplyToId: params.route.replyToId ?? null }
+          : {}),
+        recoveryState:
+          entry.recoveryState === "unknown_after_send"
+            ? "unknown_after_send"
+            : "send_attempt_started",
+      };
+    },
+    context,
+  );
 }

--- a/src/infra/delivery-queue-sqlite-namespace.ts
+++ b/src/infra/delivery-queue-sqlite-namespace.ts
@@ -3,6 +3,8 @@ import { runOpenClawStateWriteTransaction } from "../state/openclaw-state-db.js"
 import type { DeliveryQueueDatabase } from "./delivery-queue-sqlite-bound.js";
 import {
   completeDeliveryQueueEntryInDatabase,
+  resolveDeliveryQueueStateEnv,
+  type DeliveryQueueStateContext,
   deleteDeliveryQueueEntryInDatabase,
   getDeliveryQueueEntryOwnersInDatabase,
   upsertDeliveryQueueEntryInDatabase,
@@ -15,14 +17,17 @@ import {
 } from "./kysely-sync.js";
 
 /** Atomically publishes one staged owner only when retired namespaces do not own its id. */
-export function commitStagedDeliveryQueueEntryOnceAcrossNamespaces(params: {
-  queueName: string;
-  conflictQueueNames: readonly string[];
-  entry: DeliveryQueueEntryState;
-  stagingId: string;
-  stagingQueueName: string;
-  stateDir?: string;
-}): "created" | "existing" | "missing" {
+export function commitStagedDeliveryQueueEntryOnceAcrossNamespaces(
+  params: {
+    queueName: string;
+    conflictQueueNames: readonly string[];
+    entry: DeliveryQueueEntryState;
+    stagingId: string;
+    stagingQueueName: string;
+    stateDir?: string;
+  },
+  context?: DeliveryQueueStateContext,
+): "created" | "existing" | "missing" {
   return runOpenClawStateWriteTransaction(
     (database) => {
       const queueDb = getNodeSqliteKysely<DeliveryQueueDatabase>(database.db);
@@ -73,7 +78,7 @@ export function commitStagedDeliveryQueueEntryOnceAcrossNamespaces(params: {
       return "created";
     },
     {
-      env: params.stateDir ? { ...process.env, OPENCLAW_STATE_DIR: params.stateDir } : process.env,
+      env: resolveDeliveryQueueStateEnv(params.stateDir, context),
     },
     {
       operationLabel: "commit staged stable delivery queue owner",
@@ -82,12 +87,15 @@ export function commitStagedDeliveryQueueEntryOnceAcrossNamespaces(params: {
 }
 
 /** Inserts one stable owner only when no current or retired namespace owns its id. */
-export function upsertDeliveryQueueEntryOnceAcrossNamespaces(params: {
-  queueName: string;
-  conflictQueueNames: readonly string[];
-  entry: DeliveryQueueEntryState;
-  stateDir?: string;
-}): boolean {
+export function upsertDeliveryQueueEntryOnceAcrossNamespaces(
+  params: {
+    queueName: string;
+    conflictQueueNames: readonly string[];
+    entry: DeliveryQueueEntryState;
+    stateDir?: string;
+  },
+  context?: DeliveryQueueStateContext,
+): boolean {
   return runOpenClawStateWriteTransaction(
     (database) => {
       const owner = getDeliveryQueueEntryOwnersInDatabase(
@@ -108,7 +116,7 @@ export function upsertDeliveryQueueEntryOnceAcrossNamespaces(params: {
       );
     },
     {
-      env: params.stateDir ? { ...process.env, OPENCLAW_STATE_DIR: params.stateDir } : process.env,
+      env: resolveDeliveryQueueStateEnv(params.stateDir, context),
     },
     {
       operationLabel: "insert stable delivery queue owner",
@@ -129,12 +137,15 @@ type MovePendingDeliveryQueueEntryNamespaceParams = {
 };
 
 /** Replaces a pending entry only while its authoritative serialized value is unchanged. */
-export function replacePendingDeliveryQueueEntry(params: {
-  queueName: string;
-  expectedEntry: DeliveryQueueEntryState;
-  replacementEntry: DeliveryQueueEntryState;
-  stateDir?: string;
-}): boolean {
+export function replacePendingDeliveryQueueEntry(
+  params: {
+    queueName: string;
+    expectedEntry: DeliveryQueueEntryState;
+    replacementEntry: DeliveryQueueEntryState;
+    stateDir?: string;
+  },
+  context?: DeliveryQueueStateContext,
+): boolean {
   if (params.expectedEntry.id !== params.replacementEntry.id) {
     throw new Error(
       `Delivery queue replacement id mismatch: ${params.expectedEntry.id} != ${params.replacementEntry.id}`,
@@ -168,7 +179,7 @@ export function replacePendingDeliveryQueueEntry(params: {
       );
     },
     {
-      env: params.stateDir ? { ...process.env, OPENCLAW_STATE_DIR: params.stateDir } : process.env,
+      env: resolveDeliveryQueueStateEnv(params.stateDir, context),
     },
     {
       operationLabel: "replace pending delivery queue entry",
@@ -177,11 +188,14 @@ export function replacePendingDeliveryQueueEntry(params: {
 }
 
 /** Completes a pending entry only while its authoritative serialized value is unchanged. */
-export function completePendingDeliveryQueueEntry(params: {
-  queueName: string;
-  expectedEntry: DeliveryQueueEntryState;
-  stateDir?: string;
-}): boolean {
+export function completePendingDeliveryQueueEntry(
+  params: {
+    queueName: string;
+    expectedEntry: DeliveryQueueEntryState;
+    stateDir?: string;
+  },
+  context?: DeliveryQueueStateContext,
+): boolean {
   return runOpenClawStateWriteTransaction(
     (database) => {
       const queueDb = getNodeSqliteKysely<DeliveryQueueDatabase>(database.db);
@@ -204,7 +218,7 @@ export function completePendingDeliveryQueueEntry(params: {
       return true;
     },
     {
-      env: params.stateDir ? { ...process.env, OPENCLAW_STATE_DIR: params.stateDir } : process.env,
+      env: resolveDeliveryQueueStateEnv(params.stateDir, context),
     },
     {
       operationLabel: "complete pending delivery queue entry",
@@ -218,6 +232,7 @@ export function completePendingDeliveryQueueEntry(params: {
  */
 export function movePendingDeliveryQueueEntryNamespace(
   params: MovePendingDeliveryQueueEntryNamespaceParams,
+  context?: DeliveryQueueStateContext,
 ): "moved" | "source-changed" | "destination-exists" | "staging-missing" {
   return runOpenClawStateWriteTransaction(
     (database) => {
@@ -291,7 +306,7 @@ export function movePendingDeliveryQueueEntryNamespace(
       return "moved";
     },
     {
-      env: params.stateDir ? { ...process.env, OPENCLAW_STATE_DIR: params.stateDir } : process.env,
+      env: resolveDeliveryQueueStateEnv(params.stateDir, context),
     },
     {
       operationLabel: "migrate delivery queue namespace",

--- a/src/infra/delivery-queue-sqlite.ts
+++ b/src/infra/delivery-queue-sqlite.ts
@@ -1,5 +1,6 @@
 // Stores durable delivery queue entries in SQLite.
 import { safeParseJsonRecord } from "@openclaw/normalization-core";
+import { resolveStateDir } from "../config/state-dir.js";
 import {
   openOpenClawStateDatabase,
   runOpenClawStateWriteTransaction,
@@ -25,6 +26,7 @@ import {
   parseDeliveryQueueCompletionRetention,
   projectDeliveryQueueTerminalEntry,
 } from "./delivery-queue-sqlite.types.js";
+import { isGatewayExternallySupervised } from "./gateway-supervision.js";
 import { executeSqliteQuerySync, getNodeSqliteKysely } from "./kysely-sync.js";
 import { runSqliteImmediateTransactionSync } from "./sqlite-transaction.js";
 
@@ -41,9 +43,37 @@ type TerminalizePendingDeliveryQueueEntryResult =
   | { status: "terminalized"; retained: boolean }
   | { status: "not_pending" };
 
-function openStateDatabase(stateDir?: string) {
+export type DeliveryQueueStateContext = {
+  stateDir: string;
+  supervisorMode?: "external";
+};
+
+export function captureDeliveryQueueStateContext(stateDir?: string): DeliveryQueueStateContext {
+  return {
+    stateDir: resolveStateDir(resolveDeliveryQueueStateEnv(stateDir)),
+    ...(isGatewayExternallySupervised(process.env) ? { supervisorMode: "external" as const } : {}),
+  };
+}
+
+export function resolveDeliveryQueueStateEnv(
+  stateDir?: string,
+  context?: DeliveryQueueStateContext,
+): NodeJS.ProcessEnv {
+  return context
+    ? {
+        ...process.env,
+        OPENCLAW_STATE_DIR: context.stateDir,
+        // Captured absence must not inherit a later ambient supervisor mode.
+        OPENCLAW_SUPERVISOR_MODE: context.supervisorMode,
+      }
+    : stateDir
+      ? { ...process.env, OPENCLAW_STATE_DIR: stateDir }
+      : process.env;
+}
+
+function openStateDatabase(stateDir?: string, context?: DeliveryQueueStateContext) {
   return openOpenClawStateDatabase({
-    env: stateDir ? { ...process.env, OPENCLAW_STATE_DIR: stateDir } : process.env,
+    env: resolveDeliveryQueueStateEnv(stateDir, context),
   });
 }
 
@@ -63,8 +93,11 @@ export function upsertDeliveryQueueEntryInDatabase(
 }
 
 /** Insert or replace a delivery queue entry under a queue namespace. */
-export function upsertDeliveryQueueEntry(params: UpsertDeliveryQueueEntryParams): boolean {
-  return upsertDeliveryQueueEntryInDatabase(params, openStateDatabase(params.stateDir));
+export function upsertDeliveryQueueEntry(
+  params: UpsertDeliveryQueueEntryParams,
+  context?: DeliveryQueueStateContext,
+): boolean {
+  return upsertDeliveryQueueEntryInDatabase(params, openStateDatabase(params.stateDir, context));
 }
 
 /**
@@ -72,16 +105,19 @@ export function upsertDeliveryQueueEntry(params: UpsertDeliveryQueueEntryParams)
  * one write snapshot. A concurrent commit either lands before this snapshot or
  * loses its staging row and must fail closed.
  */
-export function expireStagingAndLoadDeliveryQueueEntries(params: {
-  expireBeforeMs: number;
-  queueNames: readonly string[];
-  stagingQueueName: string;
-  stateDir?: string;
-}): {
+export function expireStagingAndLoadDeliveryQueueEntries(
+  params: {
+    expireBeforeMs: number;
+    queueNames: readonly string[];
+    stagingQueueName: string;
+    stateDir?: string;
+  },
+  context?: DeliveryQueueStateContext,
+): {
   entries: DeliveryQueueEntryState[];
   stagingEntries: DeliveryQueueEntryState[];
 } {
-  const database = openStateDatabase(params.stateDir);
+  const database = openStateDatabase(params.stateDir, context);
   const snapshot = runSqliteImmediateTransactionSync(
     database.db,
     () => {
@@ -126,8 +162,14 @@ export function loadDeliveryQueueEntry(
   id: string,
   stateDir?: string,
   mode: DeliveryQueueReadMode = "pending",
+  context?: DeliveryQueueStateContext,
 ): DeliveryQueueEntryState | null {
-  return loadDeliveryQueueEntryInDatabase(openStateDatabase(stateDir), queueName, id, mode);
+  return loadDeliveryQueueEntryInDatabase(
+    openStateDatabase(stateDir, context),
+    queueName,
+    id,
+    mode,
+  );
 }
 
 /** Read row status without hiding dead-lettered entries. */
@@ -144,11 +186,16 @@ export function getDeliveryQueueEntryOwners(
   queueNames: readonly string[],
   id: string,
   stateDir?: string,
+  context?: DeliveryQueueStateContext,
 ): Map<string, { status: QueueStatus; settlementPending?: true }> {
   if (queueNames.length === 0) {
     return new Map();
   }
-  return getDeliveryQueueEntryOwnersInDatabase(openStateDatabase(stateDir), queueNames, id);
+  return getDeliveryQueueEntryOwnersInDatabase(
+    openStateDatabase(stateDir, context),
+    queueNames,
+    id,
+  );
 }
 
 /** Keeps namespace reads and receipt pruning on the caller's exact transaction handle. */
@@ -232,8 +279,9 @@ export function loadDeliveryQueueEntries(
   queueName: string,
   stateDir?: string,
   mode: DeliveryQueueReadMode = "pending",
+  context?: DeliveryQueueStateContext,
 ): DeliveryQueueEntryState[] {
-  const database = openStateDatabase(stateDir);
+  const database = openStateDatabase(stateDir, context);
   const rows = executeSqliteQuerySync(
     database.db,
     deliveryQueueEntriesQuery(database, [queueName], mode)
@@ -246,8 +294,13 @@ export function loadDeliveryQueueEntries(
 }
 
 /** Delete a pending delivery queue entry after successful delivery. */
-export function deleteDeliveryQueueEntry(queueName: string, id: string, stateDir?: string): void {
-  deleteDeliveryQueueEntryInDatabase(openStateDatabase(stateDir), queueName, id);
+export function deleteDeliveryQueueEntry(
+  queueName: string,
+  id: string,
+  stateDir?: string,
+  context?: DeliveryQueueStateContext,
+): void {
+  deleteDeliveryQueueEntryInDatabase(openStateDatabase(stateDir, context), queueName, id);
 }
 
 export function deleteDeliveryQueueEntryInDatabase(
@@ -319,8 +372,9 @@ export function updateDeliveryQueueEntry(
   id: string,
   stateDir: string | undefined,
   update: (entry: DeliveryQueueEntryState) => DeliveryQueueEntryState,
+  context?: DeliveryQueueStateContext,
 ): void {
-  const database = openStateDatabase(stateDir);
+  const database = openStateDatabase(stateDir, context);
   const current = loadDeliveryQueueEntryInDatabase(database, queueName, id, "pending");
   if (!current) {
     throw enoent(queueName, id);
@@ -333,13 +387,16 @@ type ReserveDeliveryQueueAttemptResult =
   | { status: "exhausted"; attemptCount: number };
 
 /** Atomically reserve one provider-delivery call before executing it. */
-export function reserveDeliveryQueueEntryAttempt(params: {
-  queueName: string;
-  id: string;
-  maxAttempts: number;
-  stateDir?: string;
-  expectedPlatformSendAttemptId?: string;
-}): ReserveDeliveryQueueAttemptResult {
+export function reserveDeliveryQueueEntryAttempt(
+  params: {
+    queueName: string;
+    id: string;
+    maxAttempts: number;
+    stateDir?: string;
+    expectedPlatformSendAttemptId?: string;
+  },
+  context?: DeliveryQueueStateContext,
+): ReserveDeliveryQueueAttemptResult {
   if (!Number.isInteger(params.maxAttempts) || params.maxAttempts <= 0) {
     throw new Error(`Invalid delivery attempt budget: ${params.maxAttempts}`);
   }
@@ -385,7 +442,7 @@ export function reserveDeliveryQueueEntryAttempt(params: {
       return { status: "reserved", attemptCount: reservedAttemptCount };
     },
     {
-      env: params.stateDir ? { ...process.env, OPENCLAW_STATE_DIR: params.stateDir } : process.env,
+      env: resolveDeliveryQueueStateEnv(params.stateDir, context),
     },
     {
       operationLabel: `reserve ${params.queueName} delivery attempt`,
@@ -505,10 +562,11 @@ export function prepareDeliveryQueueTerminalEntry(
 /** Atomically delete or tombstone a pending row only while its value is unchanged. */
 export function terminalizePendingDeliveryQueueEntry(
   params: TerminalizePendingDeliveryQueueEntryParams & { stateDir?: string },
+  context?: DeliveryQueueStateContext,
 ): TerminalizePendingDeliveryQueueEntryResult {
   const prepared = prepareDeliveryQueueTerminalEntry(params);
   return terminalizePendingDeliveryQueueEntryInDatabase(
-    openStateDatabase(params.stateDir),
+    openStateDatabase(params.stateDir, context),
     prepared,
   );
 }

--- a/src/infra/outbound/deliver-contracts.ts
+++ b/src/infra/outbound/deliver-contracts.ts
@@ -11,7 +11,10 @@ import type { ReplyToMode } from "../../config/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { MessagePresentation, ReplyPayloadDeliveryPin } from "../../interactive/payload.js";
 import type { OutboundMediaAccess } from "../../media/load-options.js";
-import type { DeliveryQueueCompletionRetention } from "../delivery-queue-sqlite.js";
+import type {
+  DeliveryQueueCompletionRetention,
+  DeliveryQueueStateContext,
+} from "../delivery-queue-sqlite.js";
 import type { QueuedDeliveryOwner } from "./deliver-queue-state.js";
 import type {
   OutboundDeliveryQueuePolicy,
@@ -264,4 +267,9 @@ export type DeliverOutboundPayloadsParams = DeliverOutboundPayloadsCoreParams & 
   queuePolicy?: OutboundDeliveryQueuePolicy;
   renderedBatchPlan?: QueuedRenderedMessageBatchPlan;
   onDeliveryIntent?: (intent: OutboundDeliveryIntent) => void;
+};
+
+/** Private owner facts excluded from SDK delivery parameters and stored payloads. */
+export type InternalDeliverOutboundPayloadsParams = DeliverOutboundPayloadsParams & {
+  deliveryQueueStateContext?: DeliveryQueueStateContext;
 };

--- a/src/infra/outbound/deliver-queue-admission.test.ts
+++ b/src/infra/outbound/deliver-queue-admission.test.ts
@@ -86,12 +86,9 @@ describe("stageAndEnqueueOutboundDelivery", () => {
 
     await expect(pending).resolves.toEqual({ id: "stable-1", created: true });
     expect(getStablePreparation).toHaveBeenCalledOnce();
-    expect(mocks.enqueuePreparedDeliveryOnce).toHaveBeenCalledWith(
-      expect.any(Object),
-      "stable-1",
-      current,
-      undefined,
-      undefined,
-    );
+    expect(mocks.enqueuePreparedDeliveryOnce).toHaveBeenCalledOnce();
+    const queued = mocks.enqueuePreparedDeliveryOnce.mock.calls[0];
+    expect(queued?.[1]).toBe("stable-1");
+    expect(queued?.[2]).toBe(current);
   });
 });

--- a/src/infra/outbound/deliver-queue-admission.ts
+++ b/src/infra/outbound/deliver-queue-admission.ts
@@ -2,7 +2,7 @@
 import { createRenderedMessageBatchPlan } from "../../channels/message/rendered-batch.js";
 import { resolveOutboundMediaMaxBytes } from "../../media/configured-max-bytes.js";
 import { createInitialDeliveryProducerClaim } from "../delivery-queue-sqlite-claim.js";
-import type { DeliverOutboundPayloadsParams } from "./deliver-contracts.js";
+import type { InternalDeliverOutboundPayloadsParams } from "./deliver-contracts.js";
 import {
   collectPayloadMediaSources,
   resolveOutboundMediaAccessForSend,
@@ -26,9 +26,9 @@ import {
 import { normalizeOutboundReplyFacts } from "./reply-policy.js";
 
 export function restoreQueuedDeliveryCustody(
-  params: DeliverOutboundPayloadsParams,
+  params: InternalDeliverOutboundPayloadsParams,
   entry: QueuedDelivery,
-): DeliverOutboundPayloadsParams {
+): InternalDeliverOutboundPayloadsParams {
   // A regenerated caller owns current runtime authority, never the durable
   // effect. Recipient, staged payload, and completion stay with the first row.
   const {
@@ -58,7 +58,7 @@ export function restoreQueuedDeliveryCustody(
 
 /** Stages producer-owned media and atomically admits one durable outbound intent. */
 export async function stageAndEnqueueOutboundDelivery(
-  params: DeliverOutboundPayloadsParams,
+  params: InternalDeliverOutboundPayloadsParams,
   preparedBatch: PreparedOutboundBatch,
   options?: {
     getStablePreparation?: () => StableDeliveryPreparation;
@@ -66,6 +66,7 @@ export async function stageAndEnqueueOutboundDelivery(
   },
 ): Promise<{ id: string; created: boolean; producerClaimId?: string } | null> {
   const { channel, to } = params;
+  const stateDir = params.deliveryQueueStateDir;
   const queuePolicy = params.queuePolicy ?? "best_effort";
   const acceptedPayloads = acceptedPreparedOutboundEntries(preparedBatch).map((entry) =>
     stripInternalRuntimeScaffoldingFromPayload(entry.payload),
@@ -74,7 +75,11 @@ export async function stageAndEnqueueOutboundDelivery(
     params.renderedBatchPlan ?? createRenderedMessageBatchPlan(acceptedPayloads);
 
   if (params.deliveryIntentId && params.reusePendingDeliveryIntent) {
-    const existing = await loadPendingDelivery(params.deliveryIntentId);
+    const existing = await loadPendingDelivery(
+      params.deliveryIntentId,
+      stateDir,
+      params.deliveryQueueStateContext,
+    );
     if (existing) {
       // Durable custody owns its already-staged media. A regenerated TTS or
       // producer file may have vanished, so claim the row before staging it.
@@ -85,22 +90,26 @@ export async function stageAndEnqueueOutboundDelivery(
   // (TTS temps above all) are deleted when this process exits, so the queue
   // takes its own copy first and the row references that; the live send below
   // keeps the original path and stays copy-free.
-  const staged = await stageQueuePayloadMedia({
-    payloads: acceptedPayloads,
-    // Resolved exactly as the live send resolves it: staging must neither
-    // reject media the send would deliver (agent workspace sources are only
-    // reachable through the agent-scoped roots) nor read more than the send may.
-    mediaAccess: resolveOutboundMediaAccessForSend(
-      params,
-      channel,
-      collectPayloadMediaSources(acceptedPayloads),
-    ),
-    maxBytes: resolveOutboundMediaMaxBytes({
-      cfg: params.cfg,
-      channel,
-      accountId: params.accountId,
-    }),
-  });
+  const staged = await stageQueuePayloadMedia(
+    {
+      stateDir,
+      payloads: acceptedPayloads,
+      // Resolved exactly as the live send resolves it: staging must neither
+      // reject media the send would deliver (agent workspace sources are only
+      // reachable through the agent-scoped roots) nor read more than the send may.
+      mediaAccess: resolveOutboundMediaAccessForSend(
+        params,
+        channel,
+        collectPayloadMediaSources(acceptedPayloads),
+      ),
+      maxBytes: resolveOutboundMediaMaxBytes({
+        cfg: params.cfg,
+        channel,
+        accountId: params.accountId,
+      }),
+    },
+    params.deliveryQueueStateContext,
+  );
   if (staged.status !== "staged") {
     // Sensitive media must reach neither the spool nor the row, so there is no
     // replayable copy to promise. Required sends fail closed instead of
@@ -149,18 +158,24 @@ export async function stageAndEnqueueOutboundDelivery(
             delivery,
             params.deliveryIntentId,
             options.getStablePreparation(),
-            undefined,
+            stateDir,
             staged.mediaStageId,
+            params.deliveryQueueStateContext,
           )
         : await enqueueDeliveryOnce(
             delivery,
             params.deliveryIntentId,
-            undefined,
+            stateDir,
             staged.mediaStageId,
+            params.deliveryQueueStateContext,
           );
       if (!queued.created) {
-        cancelDeliveryQueueMediaRetention(staged.mediaStageId);
-        await releaseSpoolArtifacts(staged.artifacts);
+        cancelDeliveryQueueMediaRetention(
+          staged.mediaStageId,
+          stateDir,
+          params.deliveryQueueStateContext,
+        );
+        await releaseSpoolArtifacts(staged.artifacts, stateDir);
       }
       return {
         ...queued,
@@ -169,15 +184,24 @@ export async function stageAndEnqueueOutboundDelivery(
           : {}),
       };
     }
-    const id = await enqueueDelivery(delivery, undefined, staged.mediaStageId);
+    const id = await enqueueDelivery(
+      delivery,
+      stateDir,
+      staged.mediaStageId,
+      params.deliveryQueueStateContext,
+    );
     return {
       id,
       created: true,
       ...(initialProducerClaim ? { producerClaimId: initialProducerClaim.producerClaimId } : {}),
     };
   } catch (err) {
-    cancelDeliveryQueueMediaRetention(staged.mediaStageId);
-    await releaseSpoolArtifacts(staged.artifacts);
+    cancelDeliveryQueueMediaRetention(
+      staged.mediaStageId,
+      stateDir,
+      params.deliveryQueueStateContext,
+    );
+    await releaseSpoolArtifacts(staged.artifacts, stateDir);
     throw err;
   }
 }

--- a/src/infra/outbound/deliver-queue-execute.ts
+++ b/src/infra/outbound/deliver-queue-execute.ts
@@ -9,7 +9,10 @@ import {
 } from "../delivery-recovery.shared.js";
 import { formatErrorMessage } from "../errors.js";
 import { throwIfAborted } from "./abort.js";
-import type { DeliverOutboundPayloadsParams, PlatformSendRoute } from "./deliver-contracts.js";
+import type {
+  InternalDeliverOutboundPayloadsParams,
+  PlatformSendRoute,
+} from "./deliver-contracts.js";
 import { deliverOutboundPayloadsCore } from "./deliver-core.js";
 import { OUTBOUND_DELIVERY_LOG_SCOPE } from "./deliver-log.js";
 import {
@@ -49,7 +52,7 @@ import type { NormalizedOutboundPayload } from "./payloads.js";
 const log = createSubsystemLogger("outbound/deliver");
 
 export async function deliverOutboundPayloadsWithQueueCleanup(
-  params: DeliverOutboundPayloadsParams,
+  params: InternalDeliverOutboundPayloadsParams,
   queueId: string | null,
   auditStartedAt: number,
   producerClaimId?: string,
@@ -70,7 +73,7 @@ export async function deliverOutboundPayloadsWithQueueCleanup(
   const queuePolicy = params.queuePolicy ?? "best_effort";
   const platformQueueId = queueId ?? params.deliveryQueueId;
   const platformQueuePolicy = queueId ? queuePolicy : (params.queuePolicy ?? "required");
-  const platformQueueStateDir = queueId ? undefined : params.deliveryQueueStateDir;
+  const platformQueueStateDir = params.deliveryQueueStateDir;
   const exactReconciliationRequired =
     params.requireUnknownSendReconciliation === true && platformQueueId !== undefined;
   let queuedPreSendState: QueuedPreSendState | undefined;
@@ -93,6 +96,7 @@ export async function deliverOutboundPayloadsWithQueueCleanup(
       params.deliveryCompletion,
       result ? { result } : { platformSendStarted: platformSendStarted && !allPayloadsSuppressed },
       platformQueueStateDir,
+      params.deliveryQueueStateContext,
     );
   };
   // Deliberately process-local: message_sent is best-effort after queue
@@ -127,11 +131,14 @@ export async function deliverOutboundPayloadsWithQueueCleanup(
   };
   const queueOwner = queueId ? params.deliveryQueueOwner : undefined;
   const persistPostSendState = (owner: QueuedDeliveryOwner) =>
-    persistQueuedPostSendState({
-      owner,
-      queuePolicy,
-      preserveBatch: Boolean(reusableProducerClaimId),
-    });
+    persistQueuedPostSendState(
+      {
+        owner,
+        queuePolicy,
+        preserveBatch: Boolean(reusableProducerClaimId),
+      },
+      params.deliveryQueueStateContext,
+    );
   const emitTerminals = (
     terminals: Parameters<typeof emitOutboundAuditTerminals>[0]["terminals"],
   ): void => {
@@ -175,7 +182,7 @@ export async function deliverOutboundPayloadsWithQueueCleanup(
       log.warn(`failed to retire cancelled delivery ${queueId}: ${formatErrorMessage(error)}`);
     }
   };
-  const wrappedParams: DeliverOutboundPayloadsParams = {
+  const wrappedParams: InternalDeliverOutboundPayloadsParams = {
     ...params,
     // A provider marker can represent the whole durable intent only when one payload owns it.
     // Adapters must narrow further when one payload can fan out into multiple platform sends.
@@ -192,14 +199,17 @@ export async function deliverOutboundPayloadsWithQueueCleanup(
         !exactReconciliationRequired &&
         queuedPreSendState === undefined
       ) {
-        queuedPreSendState = await persistQueuedPreSendState({
-          owner: params.deliveryQueueOwner,
-          queuePolicy: platformQueuePolicy,
-          route,
-          // Recovery sends read queue-owned media. Removing the row prevents a
-          // duplicate replay, but the active adapter still needs the files.
-          retainSpoolArtifacts: queueId === null && params.deliveryQueueId !== undefined,
-        });
+        queuedPreSendState = await persistQueuedPreSendState(
+          {
+            owner: params.deliveryQueueOwner,
+            queuePolicy: platformQueuePolicy,
+            route,
+            // Recovery sends read queue-owned media. Removing the row prevents a
+            // duplicate replay, but the active adapter still needs the files.
+            retainSpoolArtifacts: queueId === null && params.deliveryQueueId !== undefined,
+          },
+          params.deliveryQueueStateContext,
+        );
         if (queueId && queuedPreSendState === "acked") {
           queuedPostSendState = "acked";
         }
@@ -254,12 +264,15 @@ export async function deliverOutboundPayloadsWithQueueCleanup(
               platformQueueStateDir,
               platformSendRoute,
               producerClaimId,
+              params.deliveryQueueStateContext,
             );
           } else {
             await markDeliveryPlatformSendDispatched(
               platformQueueId,
               platformQueueStateDir,
               platformSendRoute,
+              undefined,
+              params.deliveryQueueStateContext,
             );
           }
           queuedPreSendState ??= "marked";
@@ -620,6 +633,7 @@ export async function deliverOutboundPayloadsWithQueueCleanup(
                       params.deliveryCompletion,
                       permanentRejection.message,
                       platformQueueStateDir,
+                      params.deliveryQueueStateContext,
                     );
                     ownerRejected = true;
                   }

--- a/src/infra/outbound/deliver-queue-state.ts
+++ b/src/infra/outbound/deliver-queue-state.ts
@@ -1,5 +1,6 @@
 // Persists queue state around the irreversible platform-send boundary.
 import { createSubsystemLogger } from "../../logging/subsystem.js";
+import type { DeliveryQueueStateContext } from "../delivery-queue-sqlite.js";
 import { formatErrorMessage } from "../errors.js";
 import {
   OutboundDeliveryError,
@@ -12,6 +13,7 @@ import {
   ackDelivery,
   failDelivery,
   failDeliveryAfterPlatformSend,
+  failDeliveryBeforePlatformSend,
   markDeliveryPlatformOutcomeUnknown,
   markDeliveryPlatformSendAttemptStarted,
   moveToFailed,
@@ -23,19 +25,27 @@ export type QueuedPostSendState = "marked" | "acked" | "failed";
 
 export type QueuedPreSendState = "marked" | "acked";
 
-type QueuedDeliveryFailureRecorder = typeof failDelivery | typeof failDeliveryAfterPlatformSend;
+type QueuedDeliveryFailureRecorder = (
+  id: string,
+  error: string,
+  stateDir?: string,
+  expectedPlatformSendAttemptId?: string | null,
+) => Promise<void>;
 
 /** Keeps live and recovered queue transitions on the same producer claim. */
-export function createQueuedDeliveryOwner(params: {
-  queueId: string;
-  stateDir?: string;
-  expectedPlatformSendAttemptId?: string | null;
-  signal?: AbortSignal;
-}) {
+export function createQueuedDeliveryOwner(
+  params: {
+    queueId: string;
+    stateDir?: string;
+    expectedPlatformSendAttemptId?: string | null;
+    signal?: AbortSignal;
+  },
+  context?: DeliveryQueueStateContext,
+) {
   let custody: "held" | "released" = "held";
   const owner = {
     queueId: params.queueId,
-    stateDir: params.stateDir,
+    stateDir: context?.stateDir ?? params.stateDir,
     claimId: params.expectedPlatformSendAttemptId,
     signal: params.signal,
     get custody() {
@@ -60,11 +70,14 @@ export function createQueuedDeliveryOwner(params: {
       if (!owner.claimId) {
         return undefined;
       }
-      const release = retireUnsentDelivery({
-        id: owner.queueId,
-        producerClaimId: owner.claimId,
-        stateDir: owner.stateDir,
-      });
+      const release = retireUnsentDelivery(
+        {
+          id: owner.queueId,
+          producerClaimId: owner.claimId,
+          stateDir: owner.stateDir,
+        },
+        context,
+      );
       // Cleanup is returned only after the exact unsent claim has been retired.
       if (release) {
         custody = "released";
@@ -73,19 +86,40 @@ export function createQueuedDeliveryOwner(params: {
     },
     async ack(options?: Parameters<typeof ackDelivery>[2]): Promise<void> {
       owner.signal?.throwIfAborted();
-      await ackDelivery(owner.queueId, owner.stateDir, {
-        ...options,
-        ...(owner.claimId !== undefined ? { expectedPlatformSendAttemptId: owner.claimId } : {}),
-      });
+      await ackDelivery(
+        owner.queueId,
+        owner.stateDir,
+        {
+          ...options,
+          ...(owner.claimId !== undefined ? { expectedPlatformSendAttemptId: owner.claimId } : {}),
+        },
+        context,
+      );
       custody = "released";
     },
     fail(record: QueuedDeliveryFailureRecorder, error: string): Promise<void> {
       owner.signal?.throwIfAborted();
-      return record(owner.queueId, error, owner.stateDir, owner.claimId);
+      // Internal transitions retain captured state; caller-supplied recorders keep their public arguments.
+      const recordInState =
+        record === failDelivery
+          ? failDelivery
+          : record === failDeliveryAfterPlatformSend
+            ? failDeliveryAfterPlatformSend
+            : record === failDeliveryBeforePlatformSend
+              ? failDeliveryBeforePlatformSend
+              : undefined;
+      return recordInState
+        ? recordInState(owner.queueId, error, owner.stateDir, owner.claimId, context)
+        : record(owner.queueId, error, owner.stateDir, owner.claimId);
     },
     async retire(): Promise<void> {
       owner.signal?.throwIfAborted();
-      const spooled = await moveToFailed(owner.queueId, owner.stateDir, owner.claimId ?? null);
+      const spooled = await moveToFailed(
+        owner.queueId,
+        owner.stateDir,
+        owner.claimId ?? null,
+        context,
+      );
       custody = "released";
       await releaseSpoolArtifacts(spooled, owner.stateDir);
     },
@@ -95,12 +129,15 @@ export function createQueuedDeliveryOwner(params: {
 
 export type QueuedDeliveryOwner = ReturnType<typeof createQueuedDeliveryOwner>;
 
-export async function persistQueuedPreSendState(params: {
-  owner: QueuedDeliveryOwner;
-  queuePolicy: OutboundDeliveryQueuePolicy;
-  route: PlatformSendRoute;
-  retainSpoolArtifacts?: boolean;
-}): Promise<QueuedPreSendState> {
+export async function persistQueuedPreSendState(
+  params: {
+    owner: QueuedDeliveryOwner;
+    queuePolicy: OutboundDeliveryQueuePolicy;
+    route: PlatformSendRoute;
+    retainSpoolArtifacts?: boolean;
+  },
+  context?: DeliveryQueueStateContext,
+): Promise<QueuedPreSendState> {
   const { owner } = params;
   owner.signal?.throwIfAborted();
   try {
@@ -111,9 +148,16 @@ export async function persistQueuedPreSendState(params: {
         owner.stateDir,
         route,
         owner.claimId,
+        context,
       );
     } else {
-      await markDeliveryPlatformSendAttemptStarted(owner.queueId, owner.stateDir, route);
+      await markDeliveryPlatformSendAttemptStarted(
+        owner.queueId,
+        owner.stateDir,
+        route,
+        undefined,
+        context,
+      );
     }
     return "marked";
   } catch (markErr: unknown) {
@@ -130,17 +174,20 @@ export async function persistQueuedPreSendState(params: {
   }
 }
 
-export async function persistQueuedPostSendState(params: {
-  owner: QueuedDeliveryOwner;
-  queuePolicy: OutboundDeliveryQueuePolicy;
-  preserveBatch?: boolean;
-  retainSpoolArtifacts?: boolean;
-  onPostSendMarkerError?: (error: unknown) => void;
-}): Promise<QueuedPostSendState> {
+export async function persistQueuedPostSendState(
+  params: {
+    owner: QueuedDeliveryOwner;
+    queuePolicy: OutboundDeliveryQueuePolicy;
+    preserveBatch?: boolean;
+    retainSpoolArtifacts?: boolean;
+    onPostSendMarkerError?: (error: unknown) => void;
+  },
+  context?: DeliveryQueueStateContext,
+): Promise<QueuedPostSendState> {
   const { owner } = params;
   owner.signal?.throwIfAborted();
   try {
-    await markDeliveryPlatformOutcomeUnknown(owner.queueId, owner.stateDir, owner.claimId);
+    await markDeliveryPlatformOutcomeUnknown(owner.queueId, owner.stateDir, owner.claimId, context);
     return "marked";
   } catch (markErr: unknown) {
     if (params.preserveBatch) {

--- a/src/infra/outbound/deliver-queue.ts
+++ b/src/infra/outbound/deliver-queue.ts
@@ -4,11 +4,18 @@ import { deriveDurableFinalDeliveryRequirementsForBatch } from "../../channels/m
 import { createRenderedMessageBatchPlan } from "../../channels/message/rendered-batch.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
+import {
+  captureDeliveryQueueStateContext,
+  type DeliveryQueueStateContext,
+} from "../delivery-queue-sqlite.js";
 import { formatErrorMessage } from "../errors.js";
 import { runWithQuestionChannelDeliveries } from "../question-channel-runtime.js";
 import { resolveDeferredDeliveryAdmission } from "./deferred-delivery-admission.js";
 import { resolveOutboundDurableFinalDeliverySupport } from "./deliver-channel.js";
-import type { DeliverOutboundPayloadsParams } from "./deliver-contracts.js";
+import type {
+  DeliverOutboundPayloadsParams,
+  InternalDeliverOutboundPayloadsParams,
+} from "./deliver-contracts.js";
 import { OUTBOUND_DELIVERY_LOG_SCOPE } from "./deliver-log.js";
 import { buildPayloadSummary } from "./deliver-payload.js";
 import { prepareOutboundPayloadBatch } from "./deliver-prepare.js";
@@ -56,20 +63,37 @@ function isReusablePreparedDeliveryOwner(
 export async function runOutboundDelivery(
   params: DeliverOutboundPayloadsParams,
 ): Promise<OutboundDeliveryResult[]> {
-  return await runOutboundDeliveryInternal(params);
+  return await runOutboundDeliveryInternal({
+    ...params,
+    deliveryQueueStateContext: undefined,
+  });
 }
 
 export async function runOutboundDeliveryInternal(
-  input: DeliverOutboundPayloadsParams,
+  initialInput: InternalDeliverOutboundPayloadsParams,
+  stateContext?: DeliveryQueueStateContext,
 ): Promise<OutboundDeliveryResult[]> {
+  const context =
+    stateContext ??
+    captureDeliveryQueueStateContext(
+      initialInput.deliveryQueueId ? initialInput.deliveryQueueStateDir : undefined,
+    );
+  const input = {
+    ...initialInput,
+    deliveryQueueStateContext: context,
+    deliveryQueueStateDir: context.stateDir,
+  };
   const owner =
     input.deliveryQueueOwner ??
     (input.deliveryQueueId
-      ? createQueuedDeliveryOwner({
-          queueId: input.deliveryQueueId,
-          stateDir: input.deliveryQueueStateDir,
-          expectedPlatformSendAttemptId: input.deliveryProducerClaimId,
-        })
+      ? createQueuedDeliveryOwner(
+          {
+            queueId: input.deliveryQueueId,
+            stateDir: input.deliveryQueueStateDir,
+            expectedPlatformSendAttemptId: input.deliveryProducerClaimId,
+          },
+          input.deliveryQueueStateContext,
+        )
       : undefined);
   try {
     return await runWithQuestionChannelDeliveries(input.payloads.map(readAskUserQuestionId), () =>
@@ -81,7 +105,7 @@ export async function runOutboundDeliveryInternal(
 }
 
 async function runOutboundDeliveryWithIntent(
-  input: DeliverOutboundPayloadsParams,
+  input: InternalDeliverOutboundPayloadsParams,
 ): Promise<OutboundDeliveryResult[]> {
   const { replyToId, replyToMode, ...currentParams } = input;
   const reply = normalizeOutboundReplyFacts({ reply: input.reply, replyToId, replyToMode });
@@ -95,10 +119,14 @@ async function runOutboundDeliveryWithIntent(
     // Serializing preparation prevents concurrent producers from running
     // stateful modifiers before SQLite chooses the stable delivery owner.
     const claim = await withActiveDeliveryClaim(stableIntentId, async () => {
-      const preparation = await withStableDeliveryPreparation({
-        id: stableIntentId,
-        run: async (owner) => await runOutboundDeliveryWithQueue(stableParams, true, owner),
-      });
+      const preparation = await withStableDeliveryPreparation(
+        {
+          id: stableIntentId,
+          stateDir: params.deliveryQueueStateDir,
+          run: async (owner) => await runOutboundDeliveryWithQueue(stableParams, true, owner),
+        },
+        params.deliveryQueueStateContext,
+      );
       return preparation.status === "claimed"
         ? preparation.value
         : await runOutboundDeliveryWithQueue(stableParams, true, undefined, false);
@@ -107,7 +135,11 @@ async function runOutboundDeliveryWithIntent(
       return claim.value;
     }
     const owner = params.reusePendingDeliveryIntent
-      ? findDeliveryIntentOwner(stableIntentId)
+      ? findDeliveryIntentOwner(
+          stableIntentId,
+          params.deliveryQueueStateDir,
+          params.deliveryQueueStateContext,
+        )
       : null;
     if (isReusablePreparedDeliveryOwner(owner)) {
       return [];
@@ -118,7 +150,7 @@ async function runOutboundDeliveryWithIntent(
 }
 
 async function deliverWithProducerLease(
-  params: DeliverOutboundPayloadsParams,
+  params: InternalDeliverOutboundPayloadsParams,
   queueId: string | null,
   auditStartedAt: number,
   producerClaimId: string | undefined,
@@ -139,11 +171,16 @@ async function deliverWithProducerLease(
       if (!platformQueueId || !producerClaimId) {
         throw new Error("Delivery producer lease requires an exact queue owner");
       }
-      const stateDir = queueId ? undefined : params.deliveryQueueStateDir;
+      const stateDir = params.deliveryQueueStateDir;
       const lease = await startDeliveryProducerLease({
         id: platformQueueId,
         renew: async () =>
-          await renewDeliveryPlatformSendLease(platformQueueId, stateDir, producerClaimId),
+          await renewDeliveryPlatformSendLease(
+            platformQueueId,
+            stateDir,
+            producerClaimId,
+            params.deliveryQueueStateContext,
+          ),
       });
       if (params.deliveryQueueOwner) {
         params.deliveryQueueOwner.signal = lease.signal;
@@ -168,7 +205,7 @@ async function deliverWithProducerLease(
 }
 
 async function runOutboundDeliveryWithQueue(
-  params: DeliverOutboundPayloadsParams,
+  params: InternalDeliverOutboundPayloadsParams,
   stableIntentClaimHeld: boolean,
   stablePreparationOwner?: StableDeliveryPreparationOwner,
   allowFreshPreparation = true,
@@ -214,10 +251,18 @@ async function runOutboundDeliveryWithQueue(
   }
   const queuePolicy = params.queuePolicy ?? "best_effort";
   const existingStableDelivery = params.deliveryIntentId
-    ? await loadPendingDelivery(params.deliveryIntentId)
+    ? await loadPendingDelivery(
+        params.deliveryIntentId,
+        params.deliveryQueueStateDir,
+        params.deliveryQueueStateContext,
+      )
     : null;
   if (params.deliveryIntentId && !existingStableDelivery && !stablePreparationOwner) {
-    const owner = findDeliveryIntentOwner(params.deliveryIntentId);
+    const owner = findDeliveryIntentOwner(
+      params.deliveryIntentId,
+      params.deliveryQueueStateDir,
+      params.deliveryQueueStateContext,
+    );
     if (owner) {
       if (params.reusePendingDeliveryIntent && isReusablePreparedDeliveryOwner(owner)) {
         return [];
@@ -309,7 +354,7 @@ async function runOutboundDeliveryWithQueue(
       (params.requireUnknownSendReconciliation === true ||
         support.automaticUnknownSendReconciliation);
   }
-  const deliveryParams: DeliverOutboundPayloadsParams = {
+  const deliveryParams: InternalDeliverOutboundPayloadsParams = {
     ...params,
     payloads: preparedPayloads,
     preparedBatch,
@@ -347,7 +392,14 @@ async function runOutboundDeliveryWithQueue(
 
   const queueId = queued?.id ?? null;
   const queueOwner = queueId
-    ? createQueuedDeliveryOwner({ queueId, expectedPlatformSendAttemptId: queued?.producerClaimId })
+    ? createQueuedDeliveryOwner(
+        {
+          queueId,
+          stateDir: params.deliveryQueueStateDir,
+          expectedPlatformSendAttemptId: queued?.producerClaimId,
+        },
+        params.deliveryQueueStateContext,
+      )
     : params.deliveryQueueOwner;
   deliveryParams.deliveryQueueOwner = queueOwner;
   try {
@@ -359,6 +411,8 @@ async function runOutboundDeliveryWithQueue(
         params.deliveryCompletion,
         queueId,
         queued?.created ? "prepared" : undefined,
+        params.deliveryQueueStateDir,
+        params.deliveryQueueStateContext,
       );
       if (completion.state !== "queued") {
         await queueOwner.ack({ suppressCompletionReceipt: true });
@@ -400,7 +454,11 @@ async function runOutboundDeliveryWithQueue(
       const producerClaimId =
         queued?.producerClaimId ??
         (params.reusePendingDeliveryIntent
-          ? await claimReusableDeliveryPlatformSendAttempt(queueId)
+          ? await claimReusableDeliveryPlatformSendAttempt(
+              queueId,
+              params.deliveryQueueStateDir,
+              params.deliveryQueueStateContext,
+            )
           : undefined);
       if (!producerClaimId) {
         throw new Error(
@@ -412,12 +470,16 @@ async function runOutboundDeliveryWithQueue(
       if (queueOwner) {
         queueOwner.claimId = producerClaimId;
       }
-      let claimedDeliveryParams: DeliverOutboundPayloadsParams = {
+      let claimedDeliveryParams: InternalDeliverOutboundPayloadsParams = {
         ...deliveryParams,
         deliveryProducerLeaseRequired: true,
       };
       if (queued?.created !== true) {
-        const queuedEntry = await loadPendingDelivery(queueId);
+        const queuedEntry = await loadPendingDelivery(
+          queueId,
+          params.deliveryQueueStateDir,
+          params.deliveryQueueStateContext,
+        );
         if (!queuedEntry || queuedEntry.producerClaimId !== producerClaimId) {
           throw new Error(`Delivery platform claim was lost: ${queueId}`);
         }

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -15,6 +15,7 @@ import type {
 } from "../../channels/message/types.js";
 import type { ChannelOutboundAdapter, ChannelPlugin } from "../../channels/plugins/types.public.js";
 import type { OpenClawConfig } from "../../config/config.js";
+import { resolveStateDir } from "../../config/state-dir.js";
 import { renderMessagePresentationFallbackText } from "../../interactive/payload.js";
 import * as mediaCapabilityModule from "../../media/read-capability.js";
 import { createHookRunner } from "../../plugins/hooks.js";
@@ -561,6 +562,8 @@ async function runBestEffortPartialFailureDelivery(params?: { onError?: boolean 
 }
 
 describe("deliverOutboundPayloads", () => {
+  let expectedQueueStateDir: string;
+
   beforeAll(async () => {
     ({
       deliverOutboundPayloads,
@@ -570,6 +573,7 @@ describe("deliverOutboundPayloads", () => {
   });
 
   beforeEach(() => {
+    expectedQueueStateDir = resolveStateDir();
     resetDiagnosticEventsForTest();
     setActivePluginRegistry(defaultRegistry);
     vi.clearAllMocks();
@@ -918,7 +922,7 @@ describe("deliverOutboundPayloads", () => {
     expect(beforeParams?.deliveryQueueId).toBe("queue-1");
     expect(queueMocks.markDeliveryPlatformSendDispatched).toHaveBeenCalledWith(
       "queue-1",
-      undefined,
+      expectedQueueStateDir,
       expect.objectContaining({ replyToId: undefined, threadId: undefined }),
     );
     expect(queueMocks.markDeliveryPlatformSendDispatched).toHaveBeenCalledOnce();
@@ -1325,7 +1329,7 @@ describe("deliverOutboundPayloads", () => {
     expect(completionMocks.completeDurableDelivery).toHaveBeenCalledWith(
       expect.objectContaining({ operationId: "operation-chunked" }),
       expect.objectContaining({ messageId: "chunk-2" }),
-      undefined,
+      expectedQueueStateDir,
     );
   });
 
@@ -2072,7 +2076,11 @@ describe("deliverOutboundPayloads", () => {
     );
     expect(commitParams?.kind).toBe("text");
     expect(commitParams?.result?.messageId).toBe("message-adapter-1");
-    expect(queueMocks.ackDelivery).toHaveBeenCalledWith("mock-queue-id");
+    expect(queueMocks.ackDelivery).toHaveBeenCalledWith(
+      "mock-queue-id",
+      expectedQueueStateDir,
+      undefined,
+    );
     expect(queueMocks.failDelivery).not.toHaveBeenCalled();
   });
 
@@ -2215,7 +2223,7 @@ describe("deliverOutboundPayloads", () => {
 
     expect(queueMocks.markDeliveryPlatformSendAttemptStarted).toHaveBeenCalledWith(
       "mock-queue-id",
-      undefined,
+      expectedQueueStateDir,
       { replyToId: null },
     );
     expect(queueMocks.markDeliveryPlatformOutcomeUnknown).not.toHaveBeenCalled();
@@ -2251,7 +2259,7 @@ describe("deliverOutboundPayloads", () => {
 
       expect(queueMocks.moveToFailed).toHaveBeenCalledWith(
         "mock-queue-id",
-        undefined,
+        expectedQueueStateDir,
         expect.any(String),
       );
       expect(queueMocks.failDeliveryBeforePlatformSend).not.toHaveBeenCalled();
@@ -2282,7 +2290,7 @@ describe("deliverOutboundPayloads", () => {
 
     expect(queueMocks.moveToFailed).toHaveBeenCalledWith(
       "mock-queue-id",
-      undefined,
+      expectedQueueStateDir,
       expect.any(String),
     );
     expect(queueMocks.failDeliveryBeforePlatformSend).not.toHaveBeenCalled();
@@ -2440,7 +2448,7 @@ describe("deliverOutboundPayloads", () => {
 
     expect(queueMocks.moveToFailed).toHaveBeenCalledWith(
       "mock-queue-id",
-      undefined,
+      expectedQueueStateDir,
       expect.any(String),
     );
     expect(queueMocks.failDeliveryBeforePlatformSend).not.toHaveBeenCalled();
@@ -2504,7 +2512,7 @@ describe("deliverOutboundPayloads", () => {
 
     expect(queueMocks.moveToFailed).toHaveBeenCalledWith(
       "mock-queue-id",
-      undefined,
+      expectedQueueStateDir,
       expect.any(String),
     );
     expect(queueMocks.failDeliveryBeforePlatformSend).not.toHaveBeenCalled();
@@ -2533,7 +2541,7 @@ describe("deliverOutboundPayloads", () => {
 
     expect(queueMocks.moveToFailed).toHaveBeenCalledWith(
       "mock-queue-id",
-      undefined,
+      expectedQueueStateDir,
       expect.any(String),
     );
     expect(queueMocks.failDeliveryBeforePlatformSend).not.toHaveBeenCalled();
@@ -2639,7 +2647,8 @@ describe("deliverOutboundPayloads", () => {
     expect(completionMocks.rejectDurableDelivery).toHaveBeenCalledWith(
       expect.objectContaining({ operationId: "operation-rejected" }),
       "atomic message limit",
-      undefined,
+      expectedQueueStateDir,
+      expect.objectContaining({ stateDir: expectedQueueStateDir }),
     );
     expect(queueMocks.failDeliveryBeforePlatformSend).not.toHaveBeenCalled();
     expect(queueMocks.failDelivery).not.toHaveBeenCalled();
@@ -2679,7 +2688,8 @@ describe("deliverOutboundPayloads", () => {
     expect(completionMocks.rejectDurableDelivery).toHaveBeenCalledWith(
       expect.objectContaining({ operationId: "operation-empty-rejection" }),
       "Platform rejected the message before dispatch",
-      undefined,
+      expectedQueueStateDir,
+      expect.objectContaining({ stateDir: expectedQueueStateDir }),
     );
   });
 
@@ -2723,7 +2733,11 @@ describe("deliverOutboundPayloads", () => {
     });
 
     expect(sendMatrix).toHaveBeenCalled();
-    expect(queueMocks.ackDelivery).toHaveBeenCalledWith("mock-queue-id");
+    expect(queueMocks.ackDelivery).toHaveBeenCalledWith(
+      "mock-queue-id",
+      expectedQueueStateDir,
+      undefined,
+    );
     expect(queueMocks.failDelivery).not.toHaveBeenCalled();
   });
 
@@ -3523,7 +3537,7 @@ describe("deliverOutboundPayloads", () => {
     );
     expect(queueMocks.markDeliveryPlatformSendAttemptStarted).toHaveBeenCalledWith(
       "mock-queue-id",
-      undefined,
+      expectedQueueStateDir,
       { replyToId: "hooked-reply" },
     );
   });
@@ -5099,7 +5113,11 @@ describe("deliverOutboundPayloads", () => {
       unsubscribe();
     }
 
-    expect(queueMocks.ackDelivery).toHaveBeenCalledWith("mock-queue-id");
+    expect(queueMocks.ackDelivery).toHaveBeenCalledWith(
+      "mock-queue-id",
+      expectedQueueStateDir,
+      undefined,
+    );
     expect(queueMocks.failDelivery).not.toHaveBeenCalled();
     expect(hookMocks.runner.runMessageSent).toHaveBeenCalledOnce();
     expect(hookMocks.runner.runMessageSent).toHaveBeenCalledWith(

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -1,5 +1,9 @@
+import type { DeliveryQueueStateContext } from "../delivery-queue-sqlite.js";
 // Public facade for outbound delivery planning, queueing, and transport.
-import type { DeliverOutboundPayloadsParams } from "./deliver-contracts.js";
+import type {
+  DeliverOutboundPayloadsParams,
+  InternalDeliverOutboundPayloadsParams,
+} from "./deliver-contracts.js";
 import { runOutboundDelivery, runOutboundDeliveryInternal } from "./deliver-queue.js";
 import type { OutboundDeliveryResult } from "./deliver-types.js";
 
@@ -27,7 +31,8 @@ export async function deliverOutboundPayloads(
 }
 
 export async function deliverOutboundPayloadsInternal(
-  params: DeliverOutboundPayloadsParams,
+  params: InternalDeliverOutboundPayloadsParams,
+  stateContext?: DeliveryQueueStateContext,
 ): Promise<OutboundDeliveryResult[]> {
-  return await runOutboundDeliveryInternal(params);
+  return await runOutboundDeliveryInternal(params, stateContext);
 }

--- a/src/infra/outbound/delivery-completion.ts
+++ b/src/infra/outbound/delivery-completion.ts
@@ -8,9 +8,14 @@ import {
   markConversationDeliverySuppressed,
   markConversationDeliveryUnknown,
   type ConversationDeliveryRecord,
+  type ConversationDeliveryStoreScope,
 } from "../../config/sessions/conversation-delivery-store.js";
 import { patchSessionEntryCore } from "../../config/sessions/session-accessor.js";
 import type { InternalSessionEntry } from "../../config/sessions/types.js";
+import {
+  resolveDeliveryQueueStateEnv,
+  type DeliveryQueueStateContext,
+} from "../delivery-queue-sqlite.js";
 import type { OutboundDeliveryResult } from "./deliver-types.js";
 
 /** Serializable owner callback for a durable queue entry. */
@@ -41,19 +46,25 @@ type DurableDeliveryCompletionResult = {
 
 function scopeForCompletion(
   completion: Extract<DurableDeliveryCompletion, { kind: "conversation" }>,
-) {
+  stateDir?: string,
+  stateContext?: DeliveryQueueStateContext,
+): ConversationDeliveryStoreScope {
   return {
     agentId: completion.agentId,
     ...(completion.storePath ? { storePath: completion.storePath } : {}),
+    env: resolveDeliveryQueueStateEnv(stateDir, stateContext),
   };
 }
 
 function conversationResult(
-  update: () => ConversationDeliveryRecord,
+  completion: Extract<DurableDeliveryCompletion, { kind: "conversation" }>,
+  update: (scope: ConversationDeliveryStoreScope) => ConversationDeliveryRecord,
+  stateDir?: string,
+  stateContext?: DeliveryQueueStateContext,
 ): DurableDeliveryCompletionResult {
   let record: ConversationDeliveryRecord;
   try {
-    record = update();
+    record = update(scopeForCompletion(completion, stateDir, stateContext));
   } catch (error) {
     // Full session deletion can retire the owner before its shared queue settles.
     if (error instanceof ConversationDeliveryMissingError) {
@@ -83,12 +94,20 @@ export async function settlePendingFinalDelivery(
   completion: Extract<DurableDeliveryCompletion, { kind: "pending-final" }>,
   state: Exclude<DurableDeliveryCompletionResult["state"], "rejected" | "stale">,
   expectedStates?: readonly ("prepared" | "queued" | "unknown")[],
-  options: { stateDir?: string; preserveActivity?: boolean } = {},
+  options: {
+    stateDir?: string;
+    preserveActivity?: boolean;
+    stateContext?: DeliveryQueueStateContext;
+  } = {},
 ): Promise<DurableDeliveryCompletionResult> {
   let settled: DurableDeliveryCompletionResult["state"] = "stale";
   let wakeRecovery = false;
   await patchSessionEntryCore(
-    { sessionKey: completion.sessionKey, storePath: completion.storePath },
+    {
+      sessionKey: completion.sessionKey,
+      storePath: completion.storePath,
+      env: resolveDeliveryQueueStateEnv(options.stateDir, options.stateContext),
+    },
     (entry) => {
       const internalEntry: InternalSessionEntry = entry;
       if (
@@ -189,6 +208,8 @@ export async function markDurableDeliveryQueued(
   completion: DurableDeliveryCompletion,
   queueId: string,
   expectedPendingFinalState?: "prepared",
+  stateDir?: string,
+  stateContext?: DeliveryQueueStateContext,
 ): Promise<DurableDeliveryCompletionResult> {
   return completion.kind === "pending-final"
     ? // The reply dispatcher may have claimed direct custody ("queued") before the
@@ -197,13 +218,13 @@ export async function markDurableDeliveryQueued(
         completion,
         "queued",
         expectedPendingFinalState ? ["prepared", "queued"] : undefined,
+        { stateDir, stateContext },
       )
-    : conversationResult(() =>
-        markConversationDeliveryQueued(
-          scopeForCompletion(completion),
-          completion.operationId,
-          queueId,
-        ),
+    : conversationResult(
+        completion,
+        (scope) => markConversationDeliveryQueued(scope, completion.operationId, queueId),
+        stateDir,
+        stateContext,
       );
 }
 
@@ -212,15 +233,23 @@ export async function completeDurableDelivery(
   completion: DurableDeliveryCompletion,
   result: OutboundDeliveryResult,
   stateDir?: string,
+  stateContext?: DeliveryQueueStateContext,
 ): Promise<DurableDeliveryCompletionResult> {
   return completion.kind === "pending-final"
-    ? await settlePendingFinalDelivery(completion, "delivered", undefined, { stateDir })
-    : conversationResult(() =>
-        markConversationDeliverySent(
-          scopeForCompletion(completion),
-          completion.operationId,
-          readPlatformMessageId(result),
-        ),
+    ? await settlePendingFinalDelivery(completion, "delivered", undefined, {
+        stateDir,
+        stateContext,
+      })
+    : conversationResult(
+        completion,
+        (scope) =>
+          markConversationDeliverySent(
+            scope,
+            completion.operationId,
+            readPlatformMessageId(result),
+          ),
+        stateDir,
+        stateContext,
       );
 }
 
@@ -228,11 +257,18 @@ export async function completeDurableDelivery(
 async function suppressDurableDelivery(
   completion: DurableDeliveryCompletion,
   stateDir?: string,
+  stateContext?: DeliveryQueueStateContext,
 ): Promise<DurableDeliveryCompletionResult> {
   return completion.kind === "pending-final"
-    ? await settlePendingFinalDelivery(completion, "suppressed", undefined, { stateDir })
-    : conversationResult(() =>
-        markConversationDeliverySuppressed(scopeForCompletion(completion), completion.operationId),
+    ? await settlePendingFinalDelivery(completion, "suppressed", undefined, {
+        stateDir,
+        stateContext,
+      })
+    : conversationResult(
+        completion,
+        (scope) => markConversationDeliverySuppressed(scope, completion.operationId),
+        stateDir,
+        stateContext,
       );
 }
 
@@ -241,17 +277,20 @@ export async function rejectDurableDelivery(
   completion: DurableDeliveryCompletion,
   error: string,
   stateDir?: string,
+  stateContext?: DeliveryQueueStateContext,
 ): Promise<DurableDeliveryCompletionResult> {
   // Proven no-send: terminal suppression, not the unknown state that owes an
   // uncertainty notice for a send the provider asserts never began.
   return completion.kind === "pending-final"
-    ? await settlePendingFinalDelivery(completion, "suppressed", undefined, { stateDir })
-    : conversationResult(() =>
-        markConversationDeliveryRejected(
-          scopeForCompletion(completion),
-          completion.operationId,
-          error,
-        ),
+    ? await settlePendingFinalDelivery(completion, "suppressed", undefined, {
+        stateDir,
+        stateContext,
+      })
+    : conversationResult(
+        completion,
+        (scope) => markConversationDeliveryRejected(scope, completion.operationId, error),
+        stateDir,
+        stateContext,
       );
 }
 
@@ -259,11 +298,15 @@ export async function rejectDurableDelivery(
 export async function failDurableDelivery(
   completion: DurableDeliveryCompletion,
   stateDir?: string,
+  stateContext?: DeliveryQueueStateContext,
 ): Promise<DurableDeliveryCompletionResult> {
   return completion.kind === "pending-final"
-    ? await settlePendingFinalDelivery(completion, "unknown", undefined, { stateDir })
-    : conversationResult(() =>
-        markConversationDeliveryUnknown(scopeForCompletion(completion), completion.operationId),
+    ? await settlePendingFinalDelivery(completion, "unknown", undefined, { stateDir, stateContext })
+    : conversationResult(
+        completion,
+        (scope) => markConversationDeliveryUnknown(scope, completion.operationId),
+        stateDir,
+        stateContext,
       );
 }
 
@@ -276,10 +319,11 @@ export async function settleDurableDelivery(
   completion: DurableDeliveryCompletion,
   evidence: DurableDeliveryTerminalEvidence,
   stateDir?: string,
+  stateContext?: DeliveryQueueStateContext,
 ): Promise<DurableDeliveryCompletionResult> {
   return "result" in evidence
-    ? completeDurableDelivery(completion, evidence.result, stateDir)
+    ? completeDurableDelivery(completion, evidence.result, stateDir, stateContext)
     : evidence.platformSendStarted
-      ? failDurableDelivery(completion, stateDir)
-      : suppressDurableDelivery(completion, stateDir);
+      ? failDurableDelivery(completion, stateDir, stateContext)
+      : suppressDurableDelivery(completion, stateDir, stateContext);
 }

--- a/src/infra/outbound/delivery-queue-ack.ts
+++ b/src/infra/outbound/delivery-queue-ack.ts
@@ -1,10 +1,14 @@
-// Acknowledges exact outbound custody before releasing its queue-owned media.
+// Settles exact outbound custody before releasing its queue-owned media.
 import { openOpenClawStateDatabase } from "../../state/openclaw-state-db.js";
 import { loadDeliveryQueueEntryInDatabase } from "../delivery-queue-sqlite-bound.js";
 import { transitionOwnedDeliveryQueueEntry } from "../delivery-queue-sqlite-claim.js";
 import {
   completeDeliveryQueueEntryInDatabase,
+  resolveDeliveryQueueStateEnv,
+  type DeliveryQueueStateContext,
   deleteDeliveryQueueEntryInDatabase,
+  prepareDeliveryQueueTerminalEntry,
+  terminalizePendingDeliveryQueueEntryInDatabase,
 } from "../delivery-queue-sqlite.js";
 import { hasLiveDeliveryQueueClaim } from "../delivery-queue-sqlite.types.js";
 import { collectEntrySpoolPaths, releaseSpoolArtifacts } from "./delivery-queue-media-spool.js";
@@ -26,17 +30,21 @@ type AckDeliveryOptions = {
 };
 
 /** Retires an unsent live claim while its adapter preparation still owns resources. */
-export function retireUnsentDelivery(params: {
-  id: string;
-  producerClaimId: string;
-  stateDir?: string;
-}): (() => Promise<void>) | undefined {
+export function retireUnsentDelivery(
+  params: {
+    id: string;
+    producerClaimId: string;
+    stateDir?: string;
+  },
+  context?: DeliveryQueueStateContext,
+): (() => Promise<void>) | undefined {
+  const stateDir = context?.stateDir ?? params.stateDir;
   let release: (() => Promise<void>) | undefined;
   transitionOwnedDeliveryQueueEntry(
     {
       queueName: OUTBOUND_DELIVERY_QUEUE_NAME,
       id: params.id,
-      stateDir: params.stateDir,
+      stateDir,
       platformSendAttemptId: params.producerClaimId,
     },
     (current, database) => {
@@ -54,14 +62,15 @@ export function retireUnsentDelivery(params: {
       const entry = current as QueuedDelivery;
       const artifacts = collectEntrySpoolPaths(
         acceptedPreparedOutboundEntries(entry.preparedBatch).map((prepared) => prepared.payload),
-        params.stateDir,
+        stateDir,
       );
       const retention = artifacts.length
         ? createDeliveryQueueMediaRetention(
             artifacts,
             "outbound-media-recovery-lease",
-            params.stateDir,
+            stateDir,
             database,
+            context,
           )
         : undefined;
       // Cancellation removes custody without recording a successful receipt,
@@ -69,12 +78,13 @@ export function retireUnsentDelivery(params: {
       deleteDeliveryQueueEntryInDatabase(database, OUTBOUND_DELIVERY_QUEUE_NAME, entry.id);
       release = async () => {
         try {
-          await releaseSpoolArtifacts(artifacts, params.stateDir);
+          await releaseSpoolArtifacts(artifacts, stateDir);
         } finally {
-          cancelDeliveryQueueMediaRetention(retention, params.stateDir);
+          cancelDeliveryQueueMediaRetention(retention, stateDir, context);
         }
       };
     },
+    context,
   );
   return release;
 }
@@ -82,14 +92,16 @@ export function retireUnsentDelivery(params: {
 /** Remove a successfully delivered entry, or retain its producer-owned receipt. */
 export async function ackDelivery(
   id: string,
-  stateDir?: string,
+  requestedStateDir?: string,
   options?: AckDeliveryOptions,
+  context?: DeliveryQueueStateContext,
 ): Promise<void> {
+  const stateDir = context?.stateDir ?? requestedStateDir;
   // Read the media references before the row goes, then unlink only after the
   // delete commits. A crash in between leaves an orphan for the retention sweep;
   // unlinking first could strip media from a row that still has to replay.
   const database = openOpenClawStateDatabase({
-    env: stateDir ? { ...process.env, OPENCLAW_STATE_DIR: stateDir } : process.env,
+    env: resolveDeliveryQueueStateEnv(stateDir, context),
   });
   let spoolPaths: string[] = [];
   const settle = (current: QueuedDelivery | null): void => {
@@ -120,6 +132,7 @@ export async function ackDelivery(
         // SAFETY: Pending rows in this namespace retain the prepared outbound payload.
         settle(entry as QueuedDelivery);
       },
+      context,
     );
     if (!settled) {
       throw new Error(`Delivery platform claim was lost: ${id}`);
@@ -137,4 +150,65 @@ export async function ackDelivery(
   if (!options?.retainSpoolArtifacts) {
     await releaseSpoolArtifacts(spoolPaths, stateDir);
   }
+}
+
+type FailPendingDeliveryResult = { status: "failed" } | { status: "not_pending" };
+
+/** Conditionally dead-letter a freshly re-read pending entry without a claimed state. */
+export async function failPendingDelivery(
+  params: {
+    id: string;
+    entry: QueuedDelivery;
+    retainSpoolArtifacts?: boolean;
+    expectedPlatformSendAttemptId?: string | null;
+  },
+  requestedStateDir?: string,
+  context?: DeliveryQueueStateContext,
+): Promise<FailPendingDeliveryResult> {
+  const stateDir = context?.stateDir ?? requestedStateDir;
+  const terminal = { queueName: OUTBOUND_DELIVERY_QUEUE_NAME, id: params.id, entry: params.entry };
+  // An unmatched claim must remain a no-op; standalone calls validate before opening state.
+  const prepared =
+    params.expectedPlatformSendAttemptId === undefined
+      ? prepareDeliveryQueueTerminalEntry(terminal)
+      : undefined;
+  const database = openOpenClawStateDatabase({
+    env: resolveDeliveryQueueStateEnv(stateDir, context),
+  });
+  let terminalized = false;
+  const terminalize = (): undefined => {
+    terminalized =
+      terminalizePendingDeliveryQueueEntryInDatabase(
+        database,
+        prepared ?? prepareDeliveryQueueTerminalEntry(terminal),
+      ).status === "terminalized";
+  };
+  if (params.expectedPlatformSendAttemptId !== undefined) {
+    transitionOwnedDeliveryQueueEntry(
+      {
+        queueName: OUTBOUND_DELIVERY_QUEUE_NAME,
+        id: params.id,
+        stateDir,
+        database,
+        platformSendAttemptId: params.expectedPlatformSendAttemptId,
+      },
+      terminalize,
+      context,
+    );
+  } else {
+    terminalize();
+  }
+  if (terminalized) {
+    if (params.retainSpoolArtifacts !== true) {
+      await releaseSpoolArtifacts(
+        collectEntrySpoolPaths(
+          acceptedPreparedOutboundEntries(params.entry.preparedBatch).map((entry) => entry.payload),
+          stateDir,
+        ),
+        stateDir,
+      );
+    }
+    return { status: "failed" };
+  }
+  return { status: "not_pending" };
 }

--- a/src/infra/outbound/delivery-queue-entry-state.test.ts
+++ b/src/infra/outbound/delivery-queue-entry-state.test.ts
@@ -1,0 +1,293 @@
+import fs from "node:fs";
+import path from "node:path";
+import { setImmediate } from "node:timers/promises";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ChannelOutboundAdapter } from "../../channels/plugins/types.public.js";
+import { sendDurableMessageBatch } from "../../plugin-sdk/channel-outbound.js";
+import { drainPendingDeliveries } from "../../plugin-sdk/delivery-queue-runtime.js";
+import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../../plugins/runtime.js";
+import {
+  resetGatewayWorkAdmission,
+  tryBeginGatewaySuspendAdmission,
+} from "../../process/gateway-work-admission.js";
+import { claimOpenClawStateOwnership } from "../../state/openclaw-state-ownership-operations.js";
+import { OpenClawStateExternalOwnershipError } from "../../state/openclaw-state-ownership.js";
+import { createOutboundTestPlugin, createTestRegistry } from "../../test-utils/channel-plugins.js";
+import { deliverOutboundPayloads } from "./deliver.js";
+import { ackDelivery } from "./delivery-queue-ack.js";
+import type { DeliverFn } from "./delivery-queue-recovery.js";
+import { enqueueDeliveryOnce, loadPendingDelivery } from "./delivery-queue-storage.js";
+import {
+  createRecoveryLog,
+  installDeliveryQueueTmpDirHooks,
+  readQueuedEntries,
+} from "./delivery-queue.test-helpers.js";
+
+describe("delivery queue entry state", () => {
+  const fixtures = installDeliveryQueueTmpDirHooks();
+  const target = "reef:synthetic-peer";
+
+  function installSender(sendText: NonNullable<ChannelOutboundAdapter["sendText"]>) {
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "reef",
+          source: "test",
+          plugin: createOutboundTestPlugin({
+            id: "reef",
+            outbound: { deliveryMode: "direct", sendText },
+          }),
+        },
+      ]),
+    );
+  }
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    resetGatewayWorkAdmission();
+    resetPluginRuntimeStateForTest();
+    vi.unstubAllEnvs();
+  });
+
+  it.each(["sdk", "public-delivery"] as const)(
+    "ignores a recovery-only root and private context for a fresh %s send",
+    async (entrypoint) => {
+      const originalRoot = path.join(fixtures.tmpDir(), "original");
+      const injectedRoot = path.join(fixtures.tmpDir(), "injected");
+      fs.mkdirSync(originalRoot);
+      fs.mkdirSync(injectedRoot);
+      vi.stubEnv("OPENCLAW_STATE_DIR", originalRoot);
+      const sendText = vi.fn(async (input: object) => {
+        expect(input).not.toHaveProperty("deliveryQueueStateContext");
+        expect(readQueuedEntries(originalRoot)).toHaveLength(1);
+        expect(readQueuedEntries(injectedRoot)).toEqual([]);
+        return { channel: "reef" as const, messageId: "public-send" };
+      });
+      installSender(sendText);
+      const input = {
+        cfg: {},
+        channel: "reef" as const,
+        to: target,
+        payloads: [{ text: "public contract" }],
+        queuePolicy: "required" as const,
+        durability: "required" as const,
+        requireUnknownSendReconciliation: false,
+        deliveryIntentId: "public-state-selector",
+        deliveryQueueStateContext: { stateDir: injectedRoot },
+        deliveryQueueStateDir: injectedRoot,
+      };
+      if (entrypoint === "sdk") {
+        await expect(sendDurableMessageBatch(input)).resolves.toMatchObject({ status: "sent" });
+      } else {
+        await expect(deliverOutboundPayloads(input)).resolves.toMatchObject([
+          { messageId: "public-send" },
+        ]);
+      }
+      expect(sendText).toHaveBeenCalledOnce();
+    },
+  );
+
+  it("retains the default root and supervisor mode through awaited preparation", async () => {
+    const originalRoot = path.join(fixtures.tmpDir(), "original");
+    const replacementRoot = path.join(fixtures.tmpDir(), "replacement");
+    fs.mkdirSync(originalRoot);
+    fs.mkdirSync(replacementRoot);
+    vi.stubEnv("OPENCLAW_STATE_DIR", originalRoot);
+    vi.stubEnv("OPENCLAW_SUPERVISOR_MODE", "external");
+    claimOpenClawStateOwnership("queue-fixture", { env: process.env });
+    const context = { stateDir: originalRoot, supervisorMode: "external" as const };
+    const queueId = "default-root-capture";
+    const sendText = vi.fn(async () => {
+      expect(await loadPendingDelivery(queueId, originalRoot, context)).not.toBeNull();
+      expect(await loadPendingDelivery(queueId, replacementRoot)).toBeNull();
+      return { channel: "reef" as const, messageId: "captured-default" };
+    });
+    installSender(sendText);
+    const delivery = deliverOutboundPayloads({
+      cfg: {},
+      channel: "reef",
+      to: target,
+      payloads: [{ text: "default owner" }],
+      queuePolicy: "required",
+      deliveryIntentId: queueId,
+      requireUnknownSendReconciliation: false,
+    });
+    vi.stubEnv("OPENCLAW_STATE_DIR", replacementRoot);
+    vi.stubEnv("OPENCLAW_SUPERVISOR_MODE", "");
+    await expect(delivery).resolves.toMatchObject([{ messageId: "captured-default" }]);
+    expect(await loadPendingDelivery(queueId, originalRoot, context)).toBeNull();
+    expect(await loadPendingDelivery(queueId, replacementRoot)).toBeNull();
+    expect(sendText).toHaveBeenCalledOnce();
+  });
+
+  it("honors the owned root when resuming an existing queue entry", async () => {
+    const originalRoot = path.join(fixtures.tmpDir(), "recovery");
+    const ambientRoot = path.join(fixtures.tmpDir(), "ambient");
+    fs.mkdirSync(originalRoot);
+    fs.mkdirSync(ambientRoot);
+    vi.stubEnv("OPENCLAW_STATE_DIR", ambientRoot);
+    const queueId = "existing-recovery-entry";
+    await enqueueDeliveryOnce(
+      { channel: "reef", to: target, payloads: [{ text: "recovered" }], queuePolicy: "required" },
+      queueId,
+      originalRoot,
+    );
+    const sendText = vi.fn(async () => {
+      expect(await loadPendingDelivery(queueId, originalRoot)).toMatchObject({
+        recoveryState: "send_attempt_started",
+      });
+      return { channel: "reef" as const, messageId: "recovered-root" };
+    });
+    installSender(sendText);
+    await expect(
+      deliverOutboundPayloads({
+        cfg: {},
+        channel: "reef",
+        to: target,
+        payloads: [{ text: "recovered" }],
+        queuePolicy: "required",
+        skipQueue: true,
+        deliveryQueueId: queueId,
+        deliveryQueueStateDir: originalRoot,
+        requireUnknownSendReconciliation: false,
+      }),
+    ).resolves.toMatchObject([{ messageId: "recovered-root" }]);
+    expect(sendText).toHaveBeenCalledOnce();
+    expect(await loadPendingDelivery(queueId, ambientRoot)).toBeNull();
+    await ackDelivery(queueId, originalRoot);
+  });
+
+  it.each([
+    ["default", "custom"],
+    ["default", "builtin"],
+    ["relative", "custom"],
+    ["relative", "builtin"],
+    ["home-relative", "custom"],
+    ["home-relative", "builtin"],
+    ["empty", "custom"],
+    ["empty", "builtin"],
+  ] as const)(
+    "captures the SDK %s root before admission and lazy delivery for a %s callback",
+    async (locator, callback) => {
+      resetGatewayWorkAdmission();
+      const originalDirectory = path.join(fixtures.tmpDir(), "original");
+      const originalRoot = path.join(originalDirectory, "queue");
+      const replacementDirectory = path.join(fixtures.tmpDir(), "replacement");
+      fs.mkdirSync(originalRoot, { recursive: true });
+      fs.mkdirSync(replacementDirectory);
+      vi.stubEnv("OPENCLAW_STATE_DIR", originalRoot);
+      vi.stubEnv("OPENCLAW_SUPERVISOR_MODE", "external");
+      vi.stubEnv("OPENCLAW_HOME", originalDirectory);
+      claimOpenClawStateOwnership("queue-fixture", { env: process.env });
+      const context = { stateDir: originalRoot, supervisorMode: "external" as const };
+      const queueId = "sdk-reconnect-owner";
+      await enqueueDeliveryOnce(
+        { channel: "reef", to: target, payloads: [{ text: "SDK reconnect" }] },
+        queueId,
+        originalRoot,
+      );
+      const sendText = vi.fn(async (input: object) => {
+        expect(input).not.toHaveProperty("deliveryQueueStateContext");
+        return { channel: "reef" as const, messageId: "sdk-builtin" };
+      });
+      installSender(sendText);
+      const custom = vi.fn<DeliverFn>(async (input) => {
+        expect(input).not.toHaveProperty("deliveryQueueStateContext");
+        expect(input).not.toHaveProperty("env");
+        await input.onPlatformSendStart?.({});
+        return [{ channel: "reef", messageId: "sdk-custom" }];
+      });
+      const cwd =
+        locator !== "default" ? vi.spyOn(process, "cwd").mockReturnValue(originalDirectory) : null;
+      const stateDir = {
+        default: undefined,
+        relative: "queue",
+        "home-relative": "  ~/queue  ",
+        empty: "",
+      }[locator];
+      const suspension = tryBeginGatewaySuspendAdmission(() => {});
+      expect(suspension?.commit()).toBe(true);
+      const pending = drainPendingDeliveries({
+        drainKey: `sdk-entry-${locator}-${callback}`,
+        logLabel: "Synthetic SDK reconnect",
+        cfg: {},
+        log: createRecoveryLog(),
+        selectEntry: () => ({ match: true, bypassBackoff: false }),
+        ...(stateDir !== undefined ? { stateDir } : {}),
+        ...(callback === "custom" ? { deliver: custom } : {}),
+      });
+      try {
+        await setImmediate();
+        expect(custom).not.toHaveBeenCalled();
+        expect(sendText).not.toHaveBeenCalled();
+        vi.stubEnv("OPENCLAW_STATE_DIR", replacementDirectory);
+        vi.stubEnv("OPENCLAW_SUPERVISOR_MODE", "");
+        vi.stubEnv("OPENCLAW_HOME", replacementDirectory);
+        cwd?.mockReturnValue(replacementDirectory);
+        expect(suspension?.release()).toBe(true);
+        await pending;
+        if (callback === "custom") {
+          expect(custom).toHaveBeenCalledOnce();
+          expect(custom.mock.calls[0]).toHaveLength(1);
+          expect(sendText).not.toHaveBeenCalled();
+        } else {
+          expect(sendText).toHaveBeenCalledOnce();
+          expect(custom).not.toHaveBeenCalled();
+        }
+        expect(await loadPendingDelivery(queueId, originalRoot, context)).toBeNull();
+      } finally {
+        suspension?.release();
+        await pending;
+        cwd?.mockRestore();
+      }
+    },
+  );
+
+  it("does not gain external ownership while an SDK reconnect waits for admission", async () => {
+    resetGatewayWorkAdmission();
+    const originalRoot = fixtures.tmpDir();
+    vi.stubEnv("OPENCLAW_STATE_DIR", originalRoot);
+    vi.stubEnv("OPENCLAW_SUPERVISOR_MODE", "external");
+    claimOpenClawStateOwnership("queue-fixture", { env: process.env });
+    const context = { stateDir: originalRoot, supervisorMode: "external" as const };
+    const queueId = "sdk-unprivileged-owner";
+    await enqueueDeliveryOnce(
+      { channel: "reef", to: target, payloads: [{ text: "retained" }] },
+      queueId,
+      originalRoot,
+    );
+    const sendText = vi.fn(async () => ({
+      channel: "reef" as const,
+      messageId: "unexpected-send",
+    }));
+    installSender(sendText);
+    vi.stubEnv("OPENCLAW_SUPERVISOR_MODE", "");
+    const suspension = tryBeginGatewaySuspendAdmission(() => {});
+    expect(suspension?.commit()).toBe(true);
+    const custom = vi.fn<DeliverFn>(async (input) => {
+      await input.onPlatformSendStart?.({});
+      return [{ channel: "reef", messageId: "unexpected-dispatch" }];
+    });
+    const pending = drainPendingDeliveries({
+      drainKey: "sdk-unprivileged",
+      logLabel: "Synthetic SDK reconnect",
+      cfg: {},
+      log: createRecoveryLog(),
+      deliver: custom,
+      selectEntry: () => ({ match: true, bypassBackoff: false }),
+    });
+    const outcome = pending.catch((error: unknown) => error);
+    try {
+      await setImmediate();
+      vi.stubEnv("OPENCLAW_SUPERVISOR_MODE", "external");
+      expect(suspension?.release()).toBe(true);
+      await expect(outcome).resolves.toBeInstanceOf(OpenClawStateExternalOwnershipError);
+      expect(custom).not.toHaveBeenCalled();
+      expect(sendText).not.toHaveBeenCalled();
+      expect(await loadPendingDelivery(queueId, originalRoot, context)).not.toBeNull();
+    } finally {
+      suspension?.release();
+      await outcome;
+    }
+  });
+});

--- a/src/infra/outbound/delivery-queue-media-spool.ts
+++ b/src/infra/outbound/delivery-queue-media-spool.ts
@@ -11,6 +11,7 @@ import {
   type OutboundMediaAccess,
 } from "../../media/load-options.js";
 import { loadWebMedia } from "../../media/web-media.js";
+import type { DeliveryQueueStateContext } from "../delivery-queue-sqlite.js";
 import { fileStore } from "../file-store.js";
 import { generateSecureUuid } from "../secure-random.js";
 import { ARTIFACT_NAME_RE, spoolRelativePath } from "./delivery-queue-media-paths.js";
@@ -73,17 +74,21 @@ type StageQueueMediaResult =
  * Copies local media into queue custody and rewrites only the queue payloads.
  * The same loader and capability as the live send authorize every source.
  */
-export async function stageQueuePayloadMedia(params: {
-  payloads: readonly ReplyPayload[];
-  mediaAccess?: OutboundMediaAccess;
-  maxBytes: number;
-  stateDir?: string;
-}): Promise<StageQueueMediaResult> {
+export async function stageQueuePayloadMedia(
+  params: {
+    payloads: readonly ReplyPayload[];
+    mediaAccess?: OutboundMediaAccess;
+    maxBytes: number;
+    stateDir?: string;
+  },
+  context?: DeliveryQueueStateContext,
+): Promise<StageQueueMediaResult> {
+  const stateDir = context?.stateDir ?? params.stateDir;
   if (params.payloads.some(isSensitivePayload)) {
     return { status: "not-durable", reason: "sensitive-media" };
   }
 
-  const spoolRoot = path.resolve(resolveDeliveryQueueMediaDir(params.stateDir));
+  const spoolRoot = path.resolve(resolveDeliveryQueueMediaDir(stateDir));
   const artifactsBySource = new Map<string, string>();
   for (const source of params.payloads.flatMap(payloadMediaSources)) {
     if (isSpoolableSource(source) && !artifactsBySource.has(source)) {
@@ -98,9 +103,15 @@ export async function stageQueuePayloadMedia(params: {
   // or expires it; enqueue then consumes it atomically or fails closed.
   const mediaStageId =
     artifacts.length > 0
-      ? createDeliveryQueueMediaRetention(artifacts, "outbound-media-stage", params.stateDir)
+      ? createDeliveryQueueMediaRetention(
+          artifacts,
+          "outbound-media-stage",
+          stateDir,
+          undefined,
+          context,
+        )
       : undefined;
-  const store = openSpoolStore(params.stateDir, params.maxBytes);
+  const store = openSpoolStore(stateDir, params.maxBytes);
   const publishedSources = new Set<string>();
 
   const stageSource = async (source: string): Promise<string> => {
@@ -162,8 +173,8 @@ export async function stageQueuePayloadMedia(params: {
       stagedPayloads.push(staged);
     }
   } catch (err) {
-    cancelDeliveryQueueMediaRetention(mediaStageId, params.stateDir);
-    await releaseSpoolArtifacts(artifacts, params.stateDir);
+    cancelDeliveryQueueMediaRetention(mediaStageId, stateDir, context);
+    await releaseSpoolArtifacts(artifacts, stateDir);
     throw err;
   }
   return {

--- a/src/infra/outbound/delivery-queue-media-staging.ts
+++ b/src/infra/outbound/delivery-queue-media-staging.ts
@@ -8,6 +8,8 @@ import {
 } from "../../state/openclaw-state-db.js";
 import {
   deleteDeliveryQueueEntry,
+  resolveDeliveryQueueStateEnv,
+  type DeliveryQueueStateContext,
   expireStagingAndLoadDeliveryQueueEntries,
   upsertDeliveryQueueEntry,
   upsertDeliveryQueueEntryInDatabase,
@@ -45,6 +47,7 @@ export function createDeliveryQueueMediaRetention(
   entryKind: "outbound-media-stage" | "outbound-media-recovery-lease",
   stateDir?: string,
   database?: OpenClawStateDatabase,
+  context?: DeliveryQueueStateContext,
 ): string {
   const id = generateSecureUuid();
   const entry: MediaStageEntry = {
@@ -61,7 +64,7 @@ export function createDeliveryQueueMediaRetention(
   };
   const inserted = database
     ? upsertDeliveryQueueEntryInDatabase(insert, database)
-    : upsertDeliveryQueueEntry({ ...insert, stateDir });
+    : upsertDeliveryQueueEntry({ ...insert, stateDir }, context);
   if (!inserted) {
     throw new Error(`Delivery queue media stage already exists: ${id}`);
   }
@@ -69,36 +72,46 @@ export function createDeliveryQueueMediaRetention(
 }
 
 /** Release a stage or recovery lease after its owner settles. */
-export function cancelDeliveryQueueMediaRetention(id: string | undefined, stateDir?: string): void {
+export function cancelDeliveryQueueMediaRetention(
+  id: string | undefined,
+  stateDir?: string,
+  context?: DeliveryQueueStateContext,
+): void {
   if (!id) {
     return;
   }
-  deleteDeliveryQueueEntry(DELIVERY_QUEUE_MEDIA_STAGING_QUEUE_NAME, id, stateDir);
+  deleteDeliveryQueueEntry(DELIVERY_QUEUE_MEDIA_STAGING_QUEUE_NAME, id, stateDir, context);
 }
 
 /**
  * Atomically expire abandoned stages and return every artifact still owned by
  * either a replayable outbound row or a producer that may still commit one.
  */
-export function loadDeliveryQueueMediaRetentionSnapshot(params: {
-  expireBeforeMs: number;
-  stateDir?: string;
-}): { payloads: ReplyPayload[][]; stagedArtifacts: string[] } {
-  const snapshot = expireStagingAndLoadDeliveryQueueEntries({
-    queueNames: [
-      OUTBOUND_DELIVERY_QUEUE_NAME,
-      LEGACY_OUTBOUND_DELIVERY_QUEUE_NAME,
-      OUTBOUND_LEGACY_PREPARATION_QUEUE_NAME,
-      OUTBOUND_DELIVERY_MIGRATION_QUEUE_NAME,
-    ],
-    stagingQueueName: DELIVERY_QUEUE_MEDIA_STAGING_QUEUE_NAME,
-    expireBeforeMs: params.expireBeforeMs,
-    stateDir: params.stateDir,
-  });
+export function loadDeliveryQueueMediaRetentionSnapshot(
+  params: {
+    expireBeforeMs: number;
+    stateDir?: string;
+  },
+  context?: DeliveryQueueStateContext,
+): { payloads: ReplyPayload[][]; stagedArtifacts: string[] } {
+  const snapshot = expireStagingAndLoadDeliveryQueueEntries(
+    {
+      queueNames: [
+        OUTBOUND_DELIVERY_QUEUE_NAME,
+        LEGACY_OUTBOUND_DELIVERY_QUEUE_NAME,
+        OUTBOUND_LEGACY_PREPARATION_QUEUE_NAME,
+        OUTBOUND_DELIVERY_MIGRATION_QUEUE_NAME,
+      ],
+      stagingQueueName: DELIVERY_QUEUE_MEDIA_STAGING_QUEUE_NAME,
+      expireBeforeMs: params.expireBeforeMs,
+      stateDir: params.stateDir,
+    },
+    context,
+  );
   // A failed migration backup still owns its original media, even without a runnable row.
   // The migration receipt releases this custody only after all copies are verified and recorded.
   const database = openOpenClawStateDatabase({
-    env: params.stateDir ? { ...process.env, OPENCLAW_STATE_DIR: params.stateDir } : process.env,
+    env: resolveDeliveryQueueStateEnv(params.stateDir, context),
   }).db;
   const { rows: migrationRows } = executeSqliteQuerySync(
     database,

--- a/src/infra/outbound/delivery-queue-platform-lease.ts
+++ b/src/infra/outbound/delivery-queue-platform-lease.ts
@@ -3,6 +3,7 @@ import {
   dispatchDeliveryQueueEntryPlatformSend,
   renewDeliveryQueueEntryPlatformSendLease,
 } from "../delivery-queue-sqlite-claim.js";
+import type { DeliveryQueueStateContext } from "../delivery-queue-sqlite.js";
 import { OUTBOUND_DELIVERY_QUEUE_NAME } from "./delivery-queue-media-staging.js";
 
 /** Atomically transfer a stable pending producer intent to one platform sender. */
@@ -11,27 +12,35 @@ export async function claimDeliveryPlatformSendAttempt(
   stateDir?: string,
   reconciledPlatformSendStartedAt?: number,
   reconciledPlatformSendAttemptId?: string,
+  context?: DeliveryQueueStateContext,
 ): Promise<string | undefined> {
-  return claimDeliveryQueueEntryPlatformSend({
-    queueName: OUTBOUND_DELIVERY_QUEUE_NAME,
-    id,
-    stateDir,
-    ...(reconciledPlatformSendStartedAt !== undefined ? { reconciledPlatformSendStartedAt } : {}),
-    ...(reconciledPlatformSendAttemptId !== undefined ? { reconciledPlatformSendAttemptId } : {}),
-  });
+  return claimDeliveryQueueEntryPlatformSend(
+    {
+      queueName: OUTBOUND_DELIVERY_QUEUE_NAME,
+      id,
+      stateDir,
+      ...(reconciledPlatformSendStartedAt !== undefined ? { reconciledPlatformSendStartedAt } : {}),
+      ...(reconciledPlatformSendAttemptId !== undefined ? { reconciledPlatformSendAttemptId } : {}),
+    },
+    context,
+  );
 }
 
 /** Claim and atomically upgrade a live reusable producer to renewable ownership. */
 export async function claimReusableDeliveryPlatformSendAttempt(
   id: string,
   stateDir?: string,
+  context?: DeliveryQueueStateContext,
 ): Promise<string | undefined> {
-  return claimDeliveryQueueEntryPlatformSend({
-    queueName: OUTBOUND_DELIVERY_QUEUE_NAME,
-    id,
-    stateDir,
-    requiresProducerClaim: true,
-  });
+  return claimDeliveryQueueEntryPlatformSend(
+    {
+      queueName: OUTBOUND_DELIVERY_QUEUE_NAME,
+      id,
+      stateDir,
+      requiresProducerClaim: true,
+    },
+    context,
+  );
 }
 
 /** Extend the exact active producer lease without changing ownership. */
@@ -39,13 +48,17 @@ export async function renewDeliveryPlatformSendLease(
   id: string,
   stateDir: string | undefined,
   claimId: string,
+  context?: DeliveryQueueStateContext,
 ): Promise<number | undefined> {
-  return renewDeliveryQueueEntryPlatformSendLease({
-    queueName: OUTBOUND_DELIVERY_QUEUE_NAME,
-    id,
-    stateDir,
-    claimId,
-  });
+  return renewDeliveryQueueEntryPlatformSendLease(
+    {
+      queueName: OUTBOUND_DELIVERY_QUEUE_NAME,
+      id,
+      stateDir,
+      claimId,
+    },
+    context,
+  );
 }
 
 /** Promote or refresh the exact live owner at recipient-visible dispatch. */
@@ -54,14 +67,18 @@ export function markOwnedDeliveryPlatformSendDispatched(
   stateDir: string | undefined,
   route: { replyToId?: string | null } | undefined,
   claimId: string,
+  context?: DeliveryQueueStateContext,
 ): void {
-  const dispatched = dispatchDeliveryQueueEntryPlatformSend({
-    queueName: OUTBOUND_DELIVERY_QUEUE_NAME,
-    id,
-    stateDir,
-    route,
-    claimId,
-  });
+  const dispatched = dispatchDeliveryQueueEntryPlatformSend(
+    {
+      queueName: OUTBOUND_DELIVERY_QUEUE_NAME,
+      id,
+      stateDir,
+      route,
+      claimId,
+    },
+    context,
+  );
   if (!dispatched) {
     throw new Error(`Delivery platform claim was lost: ${id}`);
   }

--- a/src/infra/outbound/delivery-queue-preparation.ts
+++ b/src/infra/outbound/delivery-queue-preparation.ts
@@ -8,6 +8,7 @@ import {
 } from "../delivery-queue-sqlite-namespace.js";
 import {
   loadDeliveryQueueEntry,
+  type DeliveryQueueStateContext,
   terminalizePendingDeliveryQueueEntry,
   type DeliveryQueueEntryState,
 } from "../delivery-queue-sqlite.js";
@@ -66,28 +67,39 @@ function createStablePreparation(
   };
 }
 
-function failStablePreparation(entry: StableDeliveryPreparation, stateDir?: string): void {
-  terminalizePendingDeliveryQueueEntry({
-    queueName: OUTBOUND_DELIVERY_PREPARATION_QUEUE_NAME,
-    id: entry.id,
-    entry,
-    stateDir,
-  });
+function failStablePreparation(
+  entry: StableDeliveryPreparation,
+  stateDir?: string,
+  context?: DeliveryQueueStateContext,
+): void {
+  terminalizePendingDeliveryQueueEntry(
+    {
+      queueName: OUTBOUND_DELIVERY_PREPARATION_QUEUE_NAME,
+      id: entry.id,
+      entry,
+      stateDir,
+    },
+    context,
+  );
 }
 
 function claimStablePreparation(
   id: string,
   stateDir?: string,
+  context?: DeliveryQueueStateContext,
 ): { status: "claimed"; entry: StableDeliveryPreparation } | { status: "existing" } {
   const ownerId = randomUUID();
   const proposed = createStablePreparation(id, ownerId);
   if (
-    upsertDeliveryQueueEntryOnceAcrossNamespaces({
-      queueName: OUTBOUND_DELIVERY_PREPARATION_QUEUE_NAME,
-      conflictQueueNames: STABLE_PREPARATION_CONFLICT_QUEUES,
-      entry: proposed,
-      stateDir,
-    })
+    upsertDeliveryQueueEntryOnceAcrossNamespaces(
+      {
+        queueName: OUTBOUND_DELIVERY_PREPARATION_QUEUE_NAME,
+        conflictQueueNames: STABLE_PREPARATION_CONFLICT_QUEUES,
+        entry: proposed,
+        stateDir,
+      },
+      context,
+    )
   ) {
     return { status: "claimed", entry: proposed };
   }
@@ -96,6 +108,8 @@ function claimStablePreparation(
     OUTBOUND_DELIVERY_PREPARATION_QUEUE_NAME,
     id,
     stateDir,
+    "pending",
+    context,
   ) as StableDeliveryPreparation | null;
   if (!current) {
     return { status: "existing" };
@@ -104,26 +118,32 @@ function claimStablePreparation(
     return { status: "existing" };
   }
   if (current.preparationState !== "claimed") {
-    failStablePreparation(current, stateDir);
+    failStablePreparation(current, stateDir, context);
     return { status: "existing" };
   }
   const reclaimed = createStablePreparation(id, ownerId);
-  return replacePendingDeliveryQueueEntry({
-    queueName: OUTBOUND_DELIVERY_PREPARATION_QUEUE_NAME,
-    expectedEntry: current,
-    replacementEntry: reclaimed,
-    stateDir,
-  })
+  return replacePendingDeliveryQueueEntry(
+    {
+      queueName: OUTBOUND_DELIVERY_PREPARATION_QUEUE_NAME,
+      expectedEntry: current,
+      replacementEntry: reclaimed,
+      stateDir,
+    },
+    context,
+  )
     ? { status: "claimed", entry: reclaimed }
     : { status: "existing" };
 }
 
-export async function withStableDeliveryPreparation<T>(params: {
-  id: string;
-  stateDir?: string;
-  run: (owner: StableDeliveryPreparationOwner) => Promise<T>;
-}): Promise<{ status: "claimed"; value: T } | { status: "existing" }> {
-  const claim = claimStablePreparation(params.id, params.stateDir);
+export async function withStableDeliveryPreparation<T>(
+  params: {
+    id: string;
+    stateDir?: string;
+    run: (owner: StableDeliveryPreparationOwner) => Promise<T>;
+  },
+  context?: DeliveryQueueStateContext,
+): Promise<{ status: "claimed"; value: T } | { status: "existing" }> {
+  const claim = claimStablePreparation(params.id, params.stateDir, context);
   if (claim.status === "existing") {
     return claim;
   }
@@ -134,12 +154,15 @@ export async function withStableDeliveryPreparation<T>(params: {
   const replaceEntry = (next: StableDeliveryPreparation): void => {
     if (
       leaseLost ||
-      !replacePendingDeliveryQueueEntry({
-        queueName: OUTBOUND_DELIVERY_PREPARATION_QUEUE_NAME,
-        expectedEntry: entry,
-        replacementEntry: next,
-        stateDir: params.stateDir,
-      })
+      !replacePendingDeliveryQueueEntry(
+        {
+          queueName: OUTBOUND_DELIVERY_PREPARATION_QUEUE_NAME,
+          expectedEntry: entry,
+          replacementEntry: next,
+          stateDir: params.stateDir,
+        },
+        context,
+      )
     ) {
       leaseLost = true;
       throw new StableDeliveryPreparationLostError(params.id);
@@ -183,11 +206,14 @@ export async function withStableDeliveryPreparation<T>(params: {
     const value = await params.run(owner);
     if (
       !published &&
-      !completePendingDeliveryQueueEntry({
-        queueName: OUTBOUND_DELIVERY_PREPARATION_QUEUE_NAME,
-        expectedEntry: entry,
-        stateDir: params.stateDir,
-      })
+      !completePendingDeliveryQueueEntry(
+        {
+          queueName: OUTBOUND_DELIVERY_PREPARATION_QUEUE_NAME,
+          expectedEntry: entry,
+          stateDir: params.stateDir,
+        },
+        context,
+      )
     ) {
       throw new Error(`Stable outbound preparation could not be settled: ${params.id}`);
     }
@@ -200,14 +226,17 @@ export async function withStableDeliveryPreparation<T>(params: {
           preparationOwnerId: undefined,
           preparationLeaseExpiresAt: 0,
         };
-        replacePendingDeliveryQueueEntry({
-          queueName: OUTBOUND_DELIVERY_PREPARATION_QUEUE_NAME,
-          expectedEntry: entry,
-          replacementEntry: released,
-          stateDir: params.stateDir,
-        });
+        replacePendingDeliveryQueueEntry(
+          {
+            queueName: OUTBOUND_DELIVERY_PREPARATION_QUEUE_NAME,
+            expectedEntry: entry,
+            replacementEntry: released,
+            stateDir: params.stateDir,
+          },
+          context,
+        );
       } else {
-        failStablePreparation(entry, params.stateDir);
+        failStablePreparation(entry, params.stateDir, context);
       }
     }
     throw error;

--- a/src/infra/outbound/delivery-queue-recovery.ts
+++ b/src/infra/outbound/delivery-queue-recovery.ts
@@ -8,6 +8,10 @@ import type {
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import {
+  captureDeliveryQueueStateContext,
+  type DeliveryQueueStateContext,
+} from "../delivery-queue-sqlite.js";
+import {
   createDeliveryRecoveryCoordinator,
   createEmptyDeliveryRecoverySummary,
   findPlatformMessageRejectedError,
@@ -84,6 +88,11 @@ import {
 import { acceptedPreparedOutboundEntries } from "./prepared-batch.js";
 
 export type DeliverFn = (params: DeliverOutboundPayloadsParams) => Promise<unknown>;
+
+type InternalRecoveryDeliver = (
+  params: DeliverOutboundPayloadsParams,
+  context: DeliveryQueueStateContext,
+) => Promise<unknown>;
 
 export interface RecoveryLogger {
   info(msg: string): void;
@@ -330,17 +339,20 @@ function buildRecoveryDeliverParams(
   } satisfies Parameters<DeliverFn>[0];
 }
 
-async function settleQueuedFailure(params: {
-  entry: QueuedDelivery;
-  cfg: OpenClawConfig;
-  log: RecoveryLogger;
-  stateDir?: string;
-  error: string;
-  claimedAttemptId?: string;
-  rejectionError?: string;
-  events?: readonly IndexedMessageSentEvent[];
-  terminals?: ReturnType<typeof failedOutboundAuditTerminals>;
-}): Promise<"moved-to-failed" | "failed" | "already-gone"> {
+async function settleQueuedFailure(
+  params: {
+    entry: QueuedDelivery;
+    cfg: OpenClawConfig;
+    log: RecoveryLogger;
+    stateDir?: string;
+    error: string;
+    claimedAttemptId?: string;
+    rejectionError?: string;
+    events?: readonly IndexedMessageSentEvent[];
+    terminals?: ReturnType<typeof failedOutboundAuditTerminals>;
+  },
+  stateContext: DeliveryQueueStateContext,
+): Promise<"moved-to-failed" | "failed" | "already-gone"> {
   let terminalized = false;
   try {
     const unknownSend = needsUnknownSendReconciliation(params.entry);
@@ -357,6 +369,7 @@ async function settleQueuedFailure(params: {
       settlement,
       params.stateDir,
       params.claimedAttemptId,
+      stateContext,
     );
     if (!entry) {
       return "already-gone";
@@ -369,8 +382,9 @@ async function settleQueuedFailure(params: {
             entry.deliveryCompletion,
             settlement.rejectionError,
             params.stateDir,
+            stateContext,
           )
-        : failDurableDelivery(entry.deliveryCompletion, params.stateDir));
+        : failDurableDelivery(entry.deliveryCompletion, params.stateDir, stateContext));
     }
     const spoolPaths = collectEntrySpoolPaths(queuedDeliveryPayloads(entry), params.stateDir);
     const leaseId =
@@ -379,10 +393,12 @@ async function settleQueuedFailure(params: {
             spoolPaths,
             "outbound-media-recovery-lease",
             params.stateDir,
+            undefined,
+            stateContext,
           )
         : undefined;
     try {
-      if (!finalizeDeliveryFailureSettlement(entry, params.stateDir)) {
+      if (!finalizeDeliveryFailureSettlement(entry, params.stateDir, stateContext)) {
         return "already-gone";
       }
       terminalized = true;
@@ -419,7 +435,7 @@ async function settleQueuedFailure(params: {
       }
       await releaseSpoolArtifacts(spoolPaths, params.stateDir);
     } finally {
-      cancelDeliveryQueueMediaRetention(leaseId, params.stateDir);
+      cancelDeliveryQueueMediaRetention(leaseId, params.stateDir, stateContext);
     }
   } catch (error) {
     params.log.warn(
@@ -553,22 +569,31 @@ function recoveryPlatformAttemptId(
         : undefined;
 }
 
-async function resolveCompletedOwnerBeforeRecovery(opts: {
-  owner: QueuedDeliveryOwner;
-  entry: QueuedDelivery;
-  cfg: OpenClawConfig;
-  log: RecoveryLogger;
-  stateDir?: string;
-  onRecovered?: (entry: QueuedDelivery) => void;
-  onFailed?: (entry: QueuedDelivery, errMsg: string) => void;
-}): Promise<"continue" | "recovered" | "failed" | "moved-to-failed"> {
+async function resolveCompletedOwnerBeforeRecovery(
+  opts: {
+    owner: QueuedDeliveryOwner;
+    entry: QueuedDelivery;
+    cfg: OpenClawConfig;
+    log: RecoveryLogger;
+    stateDir?: string;
+    onRecovered?: (entry: QueuedDelivery) => void;
+    onFailed?: (entry: QueuedDelivery, errMsg: string) => void;
+  },
+  stateContext: DeliveryQueueStateContext,
+): Promise<"continue" | "recovered" | "failed" | "moved-to-failed"> {
   const completion = opts.entry.deliveryCompletion;
   if (!completion) {
     return "continue";
   }
   let operation: Awaited<ReturnType<typeof markDurableDeliveryQueued>>;
   try {
-    operation = await markDurableDeliveryQueued(completion, opts.entry.id);
+    operation = await markDurableDeliveryQueued(
+      completion,
+      opts.entry.id,
+      undefined,
+      opts.stateDir,
+      stateContext,
+    );
   } catch (error) {
     const errMsg = `delivery owner state unavailable: ${formatErrorMessage(error)}`;
     await opts.owner.fail(failDelivery, errMsg).catch(() => undefined);
@@ -580,10 +605,13 @@ async function resolveCompletedOwnerBeforeRecovery(opts: {
     return "continue";
   }
   if (operation.state === "unknown") {
-    const settled = await settleQueuedFailure({
-      ...opts,
-      error: "delivery owner state is unknown",
-    });
+    const settled = await settleQueuedFailure(
+      {
+        ...opts,
+        error: "delivery owner state is unknown",
+      },
+      stateContext,
+    );
     return settled === "already-gone" ? "failed" : settled;
   }
   try {
@@ -642,48 +670,64 @@ function isPermanentDeliveryError(error: string): boolean {
   return PERMANENT_ERROR_PATTERNS.some((re) => re.test(error));
 }
 
-async function persistRecoveredPostSendState(opts: {
-  owner: QueuedDeliveryOwner;
-  entry: QueuedDelivery;
-  log: RecoveryLogger;
-  producerClaimId?: string;
-}): Promise<QueuedPostSendState> {
+async function persistRecoveredPostSendState(
+  opts: {
+    owner: QueuedDeliveryOwner;
+    entry: QueuedDelivery;
+    log: RecoveryLogger;
+    producerClaimId?: string;
+  },
+  stateContext: DeliveryQueueStateContext,
+): Promise<QueuedPostSendState> {
   // Recovery keeps its media lease until the adapter settles, even if the
   // canonical post-send marker has to finalize the queue with a direct ack.
-  return persistQueuedPostSendState({
-    owner: opts.owner,
-    queuePolicy: opts.entry.queuePolicy ?? "best_effort",
-    preserveBatch: Boolean(opts.producerClaimId),
-    retainSpoolArtifacts: true,
-    onPostSendMarkerError: (error) => {
-      opts.log.warn(
-        `Delivery entry ${opts.entry.id} failed to persist post-send state; falling back to direct ack: ${formatErrorMessage(error)}`,
-      );
+  return persistQueuedPostSendState(
+    {
+      owner: opts.owner,
+      queuePolicy: opts.entry.queuePolicy ?? "best_effort",
+      preserveBatch: Boolean(opts.producerClaimId),
+      retainSpoolArtifacts: true,
+      onPostSendMarkerError: (error) => {
+        opts.log.warn(
+          `Delivery entry ${opts.entry.id} failed to persist post-send state; falling back to direct ack: ${formatErrorMessage(error)}`,
+        );
+      },
     },
-  });
+    stateContext,
+  );
 }
 
-async function drainQueuedEntry(opts: {
-  entry: QueuedDelivery;
-  cfg: OpenClawConfig;
-  deliver: DeliverFn;
-  log: RecoveryLogger;
-  stateDir?: string;
-  shouldContinue?: () => boolean;
-  onRecovered?: (entry: QueuedDelivery) => void;
-  onFailed?: (entry: QueuedDelivery, errMsg: string) => void;
-}): Promise<"recovered" | "failed" | "moved-to-failed" | "already-gone" | "stopped"> {
+async function drainQueuedEntry(
+  opts: {
+    entry: QueuedDelivery;
+    cfg: OpenClawConfig;
+    deliver: DeliverFn;
+    log: RecoveryLogger;
+    stateDir?: string;
+    shouldContinue?: () => boolean;
+    onRecovered?: (entry: QueuedDelivery) => void;
+    onFailed?: (entry: QueuedDelivery, errMsg: string) => void;
+  },
+  stateContext: DeliveryQueueStateContext,
+  internalDeliver?: InternalRecoveryDeliver,
+): Promise<"recovered" | "failed" | "moved-to-failed" | "already-gone" | "stopped"> {
   const { entry } = opts;
-  const owner = createQueuedDeliveryOwner({
-    queueId: entry.id,
-    stateDir: opts.stateDir,
-    expectedPlatformSendAttemptId: recoveryPlatformAttemptId(entry),
-  });
+  const deliver: DeliverFn = internalDeliver
+    ? (params) => internalDeliver(params, stateContext)
+    : opts.deliver;
+  const owner = createQueuedDeliveryOwner(
+    {
+      queueId: entry.id,
+      stateDir: opts.stateDir,
+      expectedPlatformSendAttemptId: recoveryPlatformAttemptId(entry),
+    },
+    stateContext,
+  );
   const maxRetries = resolveMaxRetries(entry);
   const attemptBudgetExhausted = resolveAttemptCount(entry) >= maxRetries;
   let reconciledPlatformSendAttemptId: string | undefined;
   let reconciledPlatformSendStartedAt: number | undefined;
-  const ownerState = await resolveCompletedOwnerBeforeRecovery({ ...opts, owner });
+  const ownerState = await resolveCompletedOwnerBeforeRecovery({ ...opts, owner }, stateContext);
   if (ownerState !== "continue") {
     return ownerState;
   }
@@ -702,7 +746,12 @@ async function drainQueuedEntry(opts: {
       try {
         const result = buildReconciledSentResult(entry, reconciliation);
         if (entry.deliveryCompletion) {
-          await completeDurableDelivery(entry.deliveryCompletion, result, opts.stateDir);
+          await completeDurableDelivery(
+            entry.deliveryCompletion,
+            result,
+            opts.stateDir,
+            stateContext,
+          );
         }
         await owner.ack();
         emitRecoveredTerminalSuccess(entry, result);
@@ -772,7 +821,7 @@ async function drainQueuedEntry(opts: {
         }
         return "failed";
       }
-      return settleQueuedFailure({ ...opts, error: errMsg });
+      return settleQueuedFailure({ ...opts, error: errMsg }, stateContext);
     }
   }
   const payloadOutcomes: OutboundPayloadDeliveryOutcome[] = [];
@@ -822,6 +871,7 @@ async function drainQueuedEntry(opts: {
         opts.stateDir,
         reconciledPlatformSendStartedAt,
         reconciledPlatformSendAttemptId,
+        stateContext,
       )
     : undefined;
   if (requiresProducerClaim && !producerClaimId) {
@@ -830,12 +880,21 @@ async function drainQueuedEntry(opts: {
   }
   owner.claimId = recoveryPlatformAttemptId(entry, producerClaimId);
   const reservation = producerClaimId
-    ? await reserveDeliveryAttempt(entry.id, maxRetries, opts.stateDir, producerClaimId)
-    : await reserveDeliveryAttempt(entry.id, maxRetries, opts.stateDir);
+    ? await reserveDeliveryAttempt(
+        entry.id,
+        maxRetries,
+        opts.stateDir,
+        producerClaimId,
+        stateContext,
+      )
+    : await reserveDeliveryAttempt(entry.id, maxRetries, opts.stateDir, undefined, stateContext);
   if (reservation.status === "exhausted") {
     const errMsg = `delivery retry budget exhausted (${reservation.attemptCount}/${maxRetries})`;
     opts.onFailed?.(entry, errMsg);
-    return settleQueuedFailure({ ...opts, error: errMsg, claimedAttemptId: producerClaimId });
+    return settleQueuedFailure(
+      { ...opts, error: errMsg, claimedAttemptId: producerClaimId },
+      stateContext,
+    );
   }
   const recoverySpoolPaths = collectEntrySpoolPaths(queuedDeliveryPayloads(entry), opts.stateDir);
   let mediaRecoveryLeaseId: string | undefined;
@@ -848,6 +907,8 @@ async function drainQueuedEntry(opts: {
             recoverySpoolPaths,
             "outbound-media-recovery-lease",
             opts.stateDir,
+            undefined,
+            stateContext,
           )
         : undefined;
     const deliveryParams = buildRecoveryDeliverParams(
@@ -857,7 +918,7 @@ async function drainQueuedEntry(opts: {
       producerClaimId,
     );
     let dispatchAdmitted = false;
-    const result = await opts.deliver({
+    const result = await deliver({
       ...deliveryParams,
       deliveryQueueOwner: owner,
       onPayloadDeliveryOutcome: collectPayloadOutcome,
@@ -867,12 +928,15 @@ async function drainQueuedEntry(opts: {
       },
       onDeliveryResult: async (deliveryResult) => {
         collectResults([deliveryResult]);
-        postSendState ??= await persistRecoveredPostSendState({
-          owner,
-          entry,
-          log: opts.log,
-          ...(producerClaimId ? { producerClaimId } : {}),
-        });
+        postSendState ??= await persistRecoveredPostSendState(
+          {
+            owner,
+            entry,
+            log: opts.log,
+            ...(producerClaimId ? { producerClaimId } : {}),
+          },
+          stateContext,
+        );
       },
       onPlatformSendDispatch: async () => {
         await deliveryParams.onPlatformSendDispatch?.();
@@ -909,6 +973,7 @@ async function drainQueuedEntry(opts: {
           entry.deliveryCompletion,
           { platformSendStarted: true },
           opts.stateDir,
+          stateContext,
         );
       }
       opts.onFailed?.(entry, error);
@@ -925,12 +990,15 @@ async function drainQueuedEntry(opts: {
       const errMsg = formatErrorMessage(failedOutcome.error);
       opts.onFailed?.(entry, errMsg);
       if (results.length > 0 || failedOutcomes.some((outcome) => outcome.sentBeforeError)) {
-        postSendState ??= await persistRecoveredPostSendState({
-          owner,
-          entry,
-          log: opts.log,
-          ...(producerClaimId ? { producerClaimId } : {}),
-        });
+        postSendState ??= await persistRecoveredPostSendState(
+          {
+            owner,
+            entry,
+            log: opts.log,
+            ...(producerClaimId ? { producerClaimId } : {}),
+          },
+          stateContext,
+        );
         opts.log.warn(
           `Delivery entry ${entry.id} partially sent before best-effort recovery failed; preserving unknown_after_send`,
         );
@@ -961,16 +1029,20 @@ async function drainQueuedEntry(opts: {
         entry.deliveryCompletion,
         terminalResult ? { result: terminalResult } : { platformSendStarted: false },
         opts.stateDir,
+        stateContext,
       );
     }
     postSendState ??=
       results.length > 0
-        ? await persistRecoveredPostSendState({
-            owner,
-            entry,
-            log: opts.log,
-            ...(producerClaimId ? { producerClaimId } : {}),
-          })
+        ? await persistRecoveredPostSendState(
+            {
+              owner,
+              entry,
+              log: opts.log,
+              ...(producerClaimId ? { producerClaimId } : {}),
+            },
+            stateContext,
+          )
         : undefined;
     if (postSendState === "failed") {
       const errMsg = "recovered send completed but queue finalization failed";
@@ -1020,6 +1092,7 @@ async function drainQueuedEntry(opts: {
         reservation.attemptCount,
         opts.stateDir,
         producerClaimId,
+        stateContext,
       );
       return "stopped";
     }
@@ -1036,12 +1109,15 @@ async function drainQueuedEntry(opts: {
       // A rejected batch can still contain successful earlier sends. Preserve
       // that concrete evidence so reconnect recovery never replays the batch.
       try {
-        postSendState ??= await persistRecoveredPostSendState({
-          owner,
-          entry,
-          log: opts.log,
-          ...(producerClaimId ? { producerClaimId } : {}),
-        });
+        postSendState ??= await persistRecoveredPostSendState(
+          {
+            owner,
+            entry,
+            log: opts.log,
+            ...(producerClaimId ? { producerClaimId } : {}),
+          },
+          stateContext,
+        );
       } catch (persistErr) {
         // Never overwrite concrete send evidence with a generic retry state.
         opts.log.error(
@@ -1079,23 +1155,26 @@ async function drainQueuedEntry(opts: {
     }
     const permanentPlatformRejection = findPlatformMessageRejectedError(err);
     if (permanentPlatformRejection || isPermanentDeliveryError(errMsg)) {
-      return settleQueuedFailure({
-        ...opts,
-        error: errMsg,
-        claimedAttemptId: producerClaimId,
-        ...(permanentPlatformRejection
-          ? { rejectionError: permanentPlatformRejection.message }
-          : {}),
-        events: messageSentEvents,
-        // Identified results already exited through hasSendEvidence. These
-        // canonical no-send decisions retain suppression reasons across restart.
-        terminals: failedOutboundAuditTerminals({
-          payloadCount: queuedPayloadCount(entry),
-          results: deliveredResults,
-          payloadOutcomes,
-          failureStage: "queue",
-        }),
-      });
+      return settleQueuedFailure(
+        {
+          ...opts,
+          error: errMsg,
+          claimedAttemptId: producerClaimId,
+          ...(permanentPlatformRejection
+            ? { rejectionError: permanentPlatformRejection.message }
+            : {}),
+          events: messageSentEvents,
+          // Identified results already exited through hasSendEvidence. These
+          // canonical no-send decisions retain suppression reasons across restart.
+          terminals: failedOutboundAuditTerminals({
+            payloadCount: queuedPayloadCount(entry),
+            results: deliveredResults,
+            payloadOutcomes,
+            failureStage: "queue",
+          }),
+        },
+        stateContext,
+      );
     }
     try {
       const recordFailure = isProvenDeliveryNotSentError(err)
@@ -1113,8 +1192,10 @@ async function drainQueuedEntry(opts: {
     // Early fallback acks make the row non-replayable before the adapter has
     // necessarily finished reading every payload. Release only after the whole
     // recovered attempt settles, and only if no pending row still owns it.
-    cancelDeliveryQueueMediaRetention(mediaRecoveryLeaseId, opts.stateDir);
-    const pending = await loadUnfinishedDelivery(entry.id, opts.stateDir).catch(() => entry);
+    cancelDeliveryQueueMediaRetention(mediaRecoveryLeaseId, opts.stateDir, stateContext);
+    const pending = await loadUnfinishedDelivery(entry.id, opts.stateDir, stateContext).catch(
+      () => entry,
+    );
     if (!pending) {
       await releaseSpoolArtifacts(recoverySpoolPaths, opts.stateDir);
     }
@@ -1140,6 +1221,8 @@ type QueuedRecoveryContext =
 async function processQueuedRecovery(
   opts: Parameters<typeof drainQueuedEntry>[0],
   context: QueuedRecoveryContext,
+  stateContext: DeliveryQueueStateContext,
+  internalDeliver?: InternalRecoveryDeliver,
 ): Promise<"continue" | "stop"> {
   const { entry, log } = opts;
   if (context.shouldContinue?.() === false) {
@@ -1148,7 +1231,7 @@ async function processQueuedRecovery(
   const label =
     context.kind === "startup" ? `Delivery ${entry.id}` : `${context.logLabel}: entry ${entry.id}`;
   if (entry.settlement) {
-    await settleQueuedFailure({ ...opts, error: entry.settlement.error });
+    await settleQueuedFailure({ ...opts, error: entry.settlement.error }, stateContext);
     return "continue";
   }
   if (hasActiveDeliveryOwner(entry, Date.now())) {
@@ -1168,7 +1251,7 @@ async function processQueuedRecovery(
     { agentId: entry.session?.agentId },
   );
   if (admission.status !== "allowed") {
-    const settled = await settleQueuedFailure({ ...opts, error: admission.reason });
+    const settled = await settleQueuedFailure({ ...opts, error: admission.reason }, stateContext);
     const logLabel = context.kind === "startup" ? "Recovery" : context.logLabel;
     if (settled === "already-gone") {
       log.info(
@@ -1197,10 +1280,13 @@ async function processQueuedRecovery(
       log.warn(`${label} exceeded max retries (${attemptCount}/${maxRetries}) — moving to failed/`);
       context.summary.skippedMaxRetries += 1;
     }
-    const settled = await settleQueuedFailure({
-      ...opts,
-      error: "delivery retry budget exhausted",
-    });
+    const settled = await settleQueuedFailure(
+      {
+        ...opts,
+        error: "delivery retry budget exhausted",
+      },
+      stateContext,
+    );
     if (context.kind === "drain" && settled === "moved-to-failed") {
       log.warn(`${label} exceeded max retries and was moved to failed/`);
     }
@@ -1231,53 +1317,63 @@ async function processQueuedRecovery(
   if (context.shouldContinue?.() === false) {
     return "stop";
   }
-  const result = await drainQueuedEntry({
-    ...opts,
-    ...(context.shouldContinue ? { shouldContinue: context.shouldContinue } : {}),
-    onRecovered: (recovered) => {
-      if (context.kind === "startup") {
-        context.summary.recovered += 1;
-        log.info(`Recovered delivery ${recovered.id} on ${recovered.channel}`);
-      } else {
-        log.info(`${context.logLabel}: drained delivery ${recovered.id} on ${recovered.channel}`);
-      }
+  const result = await drainQueuedEntry(
+    {
+      ...opts,
+      ...(context.shouldContinue ? { shouldContinue: context.shouldContinue } : {}),
+      onRecovered: (recovered) => {
+        if (context.kind === "startup") {
+          context.summary.recovered += 1;
+          log.info(`Recovered delivery ${recovered.id} on ${recovered.channel}`);
+        } else {
+          log.info(`${context.logLabel}: drained delivery ${recovered.id} on ${recovered.channel}`);
+        }
+      },
+      onFailed: (failed, error) => {
+        if (context.kind === "startup") {
+          context.summary.failed += 1;
+        }
+        if (isPermanentDeliveryError(error)) {
+          log.warn(`${label} hit permanent error — moving to failed/: ${error}`);
+        } else {
+          log.warn(
+            context.kind === "startup"
+              ? `Retry failed for delivery ${failed.id}: ${error}`
+              : `${context.logLabel}: retry failed for entry ${failed.id}: ${error}`,
+          );
+        }
+      },
     },
-    onFailed: (failed, error) => {
-      if (context.kind === "startup") {
-        context.summary.failed += 1;
-      }
-      if (isPermanentDeliveryError(error)) {
-        log.warn(`${label} hit permanent error — moving to failed/: ${error}`);
-      } else {
-        log.warn(
-          context.kind === "startup"
-            ? `Retry failed for delivery ${failed.id}: ${error}`
-            : `${context.logLabel}: retry failed for entry ${failed.id}: ${error}`,
-        );
-      }
-    },
-  });
+    stateContext,
+    internalDeliver,
+  );
   return result === "stopped" ? "stop" : "continue";
 }
 
-export async function drainPendingDeliveriesCore(opts: {
-  drainKey: string;
-  logLabel: string;
-  cfg: OpenClawConfig;
-  log: RecoveryLogger;
-  stateDir?: string;
-  deliver: DeliverFn;
-  selectEntry: (entry: QueuedDelivery, now: number) => DeliveryRecoveryDrainDecision;
-  shouldContinue?: () => boolean;
-}): Promise<void> {
+export async function drainPendingDeliveriesCore(
+  params: {
+    drainKey: string;
+    logLabel: string;
+    cfg: OpenClawConfig;
+    log: RecoveryLogger;
+    stateDir?: string;
+    deliver: DeliverFn;
+    selectEntry: (entry: QueuedDelivery, now: number) => DeliveryRecoveryDrainDecision;
+    shouldContinue?: () => boolean;
+  },
+  internalDeliver?: InternalRecoveryDeliver,
+  capturedState?: DeliveryQueueStateContext,
+): Promise<void> {
+  const stateContext = capturedState ?? captureDeliveryQueueStateContext(params.stateDir);
+  const opts = { ...params, stateDir: stateContext.stateDir };
   const drained = await recoveryCoordinator.withDrain(opts.drainKey, async () => {
     const now = Date.now();
-    const matchingEntries = (await loadUnfinishedDeliveries(opts.stateDir)).filter(
+    const matchingEntries = (await loadUnfinishedDeliveries(opts.stateDir, stateContext)).filter(
       (entry) => entry.settlement || opts.selectEntry(entry, now).match,
     );
     await recoveryCoordinator.scan({
       entries: matchingEntries,
-      loadEntry: (id) => loadUnfinishedDelivery(id, opts.stateDir),
+      loadEntry: (id) => loadUnfinishedDelivery(id, opts.stateDir, stateContext),
       onMissingEntry: (entry) => {
         opts.log.info(`${opts.logLabel}: entry ${entry.id} already gone, skipping`);
       },
@@ -1292,6 +1388,8 @@ export async function drainPendingDeliveriesCore(opts: {
             selectEntry: opts.selectEntry,
             ...(opts.shouldContinue ? { shouldContinue: opts.shouldContinue } : {}),
           },
+          stateContext,
+          internalDeliver,
         ),
     });
   });
@@ -1305,16 +1403,21 @@ export async function drainPendingDeliveriesCore(opts: {
  * The gateway startup owner runs legacy migration before invoking this recovery pass.
  * Uses exponential backoff and moves entries that exhaust their retry budget to failed/.
  */
-export async function recoverPendingDeliveries(opts: {
-  deliver: DeliverFn;
-  log: RecoveryLogger;
-  cfg: OpenClawConfig;
-  stateDir?: string;
-  /** Maximum wall-clock time for recovery in ms. Remaining entries are deferred to next startup. Default: 60 000. */
-  maxRecoveryMs?: number;
-  shouldContinue?: () => boolean;
-}): Promise<DeliveryRecoverySummary> {
-  const pending = await loadUnfinishedDeliveries(opts.stateDir);
+export async function recoverPendingDeliveries(
+  params: {
+    deliver: DeliverFn;
+    log: RecoveryLogger;
+    cfg: OpenClawConfig;
+    stateDir?: string;
+    /** Maximum wall-clock time for recovery in ms. Remaining entries are deferred to next startup. Default: 60 000. */
+    maxRecoveryMs?: number;
+    shouldContinue?: () => boolean;
+  },
+  internalDeliver?: InternalRecoveryDeliver,
+): Promise<DeliveryRecoverySummary> {
+  const stateContext = captureDeliveryQueueStateContext(params.stateDir);
+  const opts = { ...params, stateDir: stateContext.stateDir };
+  const pending = await loadUnfinishedDeliveries(opts.stateDir, stateContext);
   if (pending.length === 0) {
     return createEmptyDeliveryRecoverySummary();
   }
@@ -1329,7 +1432,7 @@ export async function recoverPendingDeliveries(opts: {
   };
   await recoveryCoordinator.scan({
     entries: pending,
-    loadEntry: (id) => loadUnfinishedDelivery(id, opts.stateDir),
+    loadEntry: (id) => loadUnfinishedDelivery(id, opts.stateDir, stateContext),
     deadlineMs: deadline,
     onDeadlineExceeded,
     onClaimConflict: (entry) => {
@@ -1348,6 +1451,8 @@ export async function recoverPendingDeliveries(opts: {
           onDeadlineExceeded,
           ...(opts.shouldContinue ? { shouldContinue: opts.shouldContinue } : {}),
         },
+        stateContext,
+        internalDeliver,
       ),
   });
 

--- a/src/infra/outbound/delivery-queue-state-context.test.ts
+++ b/src/infra/outbound/delivery-queue-state-context.test.ts
@@ -1,0 +1,244 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { claimOpenClawStateOwnership } from "../../state/openclaw-state-ownership-operations.js";
+import { OpenClawStateExternalOwnershipError } from "../../state/openclaw-state-ownership.js";
+import { deleteTestEnvValue, setTestEnvValue, withEnvAsync } from "../../test-utils/env.js";
+import { createInitialDeliveryProducerClaim } from "../delivery-queue-sqlite-claim.js";
+import type { DeliveryQueueStateContext } from "../delivery-queue-sqlite.js";
+import { ackDelivery, retireUnsentDelivery } from "./delivery-queue-ack.js";
+import {
+  createDeliveryQueueMediaRetention,
+  loadDeliveryQueueMediaRetentionSnapshot,
+} from "./delivery-queue-media-staging.js";
+import { renewDeliveryPlatformSendLease } from "./delivery-queue-platform-lease.js";
+import { withStableDeliveryPreparation } from "./delivery-queue-preparation.js";
+import { recoverPendingDeliveries, type DeliverFn } from "./delivery-queue-recovery.js";
+import {
+  enqueueDelivery,
+  enqueuePreparedDeliveryOnce,
+  failDeliveryAfterPlatformSend,
+  findDeliveryIntentOwner,
+  loadPendingDelivery,
+  markDeliveryPlatformSendDispatched,
+  reserveDeliveryAttempt,
+} from "./delivery-queue-storage.js";
+import {
+  createRecoveryLog,
+  installDeliveryQueueTmpDirHooks,
+} from "./delivery-queue.test-helpers.js";
+
+vi.mock("./channel-resolution.js", () => ({
+  resolveOutboundChannelMessageAdapter: () => undefined,
+}));
+
+describe("captured delivery queue state", () => {
+  const { tmpDir } = installDeliveryQueueTmpDirHooks();
+
+  function claimState(): DeliveryQueueStateContext {
+    const context: DeliveryQueueStateContext = {
+      stateDir: tmpDir(),
+      supervisorMode: "external",
+    };
+    claimOpenClawStateOwnership("queue-fixture", {
+      env: {
+        OPENCLAW_STATE_DIR: context.stateDir,
+        OPENCLAW_SUPERVISOR_MODE: "external",
+      },
+    });
+    return context;
+  }
+
+  it("keeps preparation, retry evidence, and ACK on the captured state after ambient changes", async () => {
+    const context = claimState();
+    const otherState = path.join(tmpDir(), "other-state");
+    await withEnvAsync(
+      { OPENCLAW_STATE_DIR: otherState, OPENCLAW_SUPERVISOR_MODE: undefined },
+      async () => {
+        const id = "captured-intent";
+        const claim = createInitialDeliveryProducerClaim();
+        const preparation = await withStableDeliveryPreparation(
+          {
+            id,
+            run: async (owner) => {
+              await Promise.resolve();
+              owner.beforeFirstModifier();
+              owner.markPrepared();
+              const queued = await enqueuePreparedDeliveryOnce(
+                {
+                  channel: "matrix",
+                  to: "!synthetic:example",
+                  payloads: [{ text: "synthetic" }],
+                  initialProducerClaim: claim,
+                  completionRetention: "permanent",
+                },
+                id,
+                owner.current(),
+                undefined,
+                undefined,
+                context,
+              );
+              owner.markPublished();
+              return queued;
+            },
+          },
+          context,
+        );
+        expect(preparation).toEqual({ status: "claimed", value: { id, created: true } });
+        expect(
+          await renewDeliveryPlatformSendLease(id, undefined, claim.producerClaimId, context),
+        ).toBeGreaterThan(Date.now());
+        expect(
+          await reserveDeliveryAttempt(id, 2, undefined, claim.producerClaimId, context),
+        ).toEqual({ status: "reserved", attemptCount: 1 });
+        await markDeliveryPlatformSendDispatched(
+          id,
+          undefined,
+          undefined,
+          claim.producerClaimId,
+          context,
+        );
+        await failDeliveryAfterPlatformSend(
+          id,
+          "synthetic failure",
+          undefined,
+          claim.producerClaimId,
+          context,
+        );
+        expect(await loadPendingDelivery(id, undefined, context)).toMatchObject({
+          retryCount: 1,
+          lastError: "synthetic failure",
+          recoveryState: "unknown_after_send",
+          platformSendAttemptId: claim.producerClaimId,
+        });
+        await ackDelivery(
+          id,
+          undefined,
+          { expectedPlatformSendAttemptId: claim.producerClaimId },
+          context,
+        );
+        expect(findDeliveryIntentOwner(id, undefined, context)).toMatchObject({
+          status: "completed",
+        });
+        await expect(fs.stat(otherState)).rejects.toMatchObject({ code: "ENOENT" });
+      },
+    );
+  });
+
+  it.each(["read", "ack"] as const)(
+    "does not gain external ownership from later ambient mode during %s",
+    async (operation) => {
+      const external = claimState();
+      const id = await enqueueDelivery(
+        { channel: "matrix", to: "!synthetic:example", payloads: [{ text: "synthetic" }] },
+        undefined,
+        undefined,
+        external,
+      );
+      const captured: DeliveryQueueStateContext = { stateDir: external.stateDir };
+      await withEnvAsync({ OPENCLAW_SUPERVISOR_MODE: "external" }, async () => {
+        const result =
+          operation === "read"
+            ? loadPendingDelivery(id, undefined, captured)
+            : ackDelivery(id, undefined, undefined, captured);
+        await expect(result).rejects.toBeInstanceOf(OpenClawStateExternalOwnershipError);
+        expect(await loadPendingDelivery(id, undefined, external)).not.toBeNull();
+      });
+    },
+  );
+
+  it.each(["custom", "internal"] as const)(
+    "settles %s recovery on its captured state without changing public callback input",
+    async (route) => {
+      const context = claimState();
+      const id = await enqueueDelivery(
+        { channel: "matrix", to: "!synthetic:example", payloads: [{ text: "synthetic" }] },
+        undefined,
+        undefined,
+        context,
+      );
+      const otherState = path.join(tmpDir(), "other-state");
+      await withEnvAsync(
+        { OPENCLAW_STATE_DIR: context.stateDir, OPENCLAW_SUPERVISOR_MODE: "external" },
+        async () => {
+          const send: DeliverFn = async (params) => {
+            expect(params).not.toHaveProperty("deliveryQueueStateContext");
+            setTestEnvValue("OPENCLAW_STATE_DIR", otherState);
+            deleteTestEnvValue("OPENCLAW_SUPERVISOR_MODE");
+            await params.onPlatformSendStart?.({});
+            return [{ channel: "matrix", messageId: "synthetic-result" }];
+          };
+          const custom = vi.fn(send);
+          const internal = vi.fn(
+            async (params: Parameters<DeliverFn>[0], captured: DeliveryQueueStateContext) => {
+              expect(captured).toEqual(context);
+              return send(params);
+            },
+          );
+          const summary = await recoverPendingDeliveries(
+            { cfg: {}, log: createRecoveryLog(), deliver: custom },
+            route === "internal" ? internal : undefined,
+          );
+          expect(summary).toMatchObject({ recovered: 1, failed: 0 });
+          if (route === "custom") {
+            expect(custom).toHaveBeenCalledOnce();
+            expect(custom.mock.calls[0]).toHaveLength(1);
+            expect(internal).not.toHaveBeenCalled();
+          } else {
+            expect(internal).toHaveBeenCalledOnce();
+            expect(custom).not.toHaveBeenCalled();
+          }
+          expect(await loadPendingDelivery(id, undefined, context)).toBeNull();
+          await expect(fs.stat(otherState)).rejects.toMatchObject({ code: "ENOENT" });
+        },
+      );
+    },
+  );
+
+  it("retains captured state through late cleanup of an unsent media owner", async () => {
+    const context = claimState();
+    const artifact = path.join(
+      context.stateDir,
+      "delivery-queue-media",
+      "00000000-0000-4000-8000-000000000001.ogg",
+    );
+    await fs.mkdir(path.dirname(artifact), { recursive: true });
+    await fs.writeFile(artifact, "synthetic audio");
+    const stage = createDeliveryQueueMediaRetention(
+      [artifact],
+      "outbound-media-stage",
+      undefined,
+      undefined,
+      context,
+    );
+    const claim = createInitialDeliveryProducerClaim();
+    const id = await enqueueDelivery(
+      {
+        channel: "matrix",
+        to: "!synthetic:example",
+        payloads: [{ mediaUrl: artifact }],
+        initialProducerClaim: claim,
+      },
+      undefined,
+      stage,
+      context,
+    );
+    const release = retireUnsentDelivery({ id, producerClaimId: claim.producerClaimId }, context);
+    expect(release).toBeTypeOf("function");
+    expect(await fs.readFile(artifact, "utf8")).toBe("synthetic audio");
+    await withEnvAsync(
+      {
+        OPENCLAW_STATE_DIR: path.join(tmpDir(), "other-state"),
+        OPENCLAW_SUPERVISOR_MODE: undefined,
+      },
+      async () => {
+        await release?.();
+        expect(await loadPendingDelivery(id, undefined, context)).toBeNull();
+        expect(
+          loadDeliveryQueueMediaRetentionSnapshot({ expireBeforeMs: 0 }, context).stagedArtifacts,
+        ).toEqual([]);
+        await expect(fs.stat(artifact)).rejects.toMatchObject({ code: "ENOENT" });
+      },
+    );
+  });
+});

--- a/src/infra/outbound/delivery-queue-storage.ts
+++ b/src/infra/outbound/delivery-queue-storage.ts
@@ -1,6 +1,5 @@
 // Delivery queue storage persists replayable outbound send intents and tracks
 // platform-send recovery state in the shared SQLite queue.
-import { openOpenClawStateDatabase } from "../../state/openclaw-state-db.js";
 import {
   promoteDeliveryQueueEntryPlatformSend,
   transitionOwnedDeliveryQueueEntry,
@@ -13,19 +12,19 @@ import {
 } from "../delivery-queue-sqlite-namespace.js";
 import {
   getDeliveryQueueEntryOwners,
+  type DeliveryQueueStateContext,
   loadDeliveryQueueEntries,
   loadDeliveryQueueEntry,
   reserveDeliveryQueueEntryAttempt,
-  prepareDeliveryQueueTerminalEntry,
   terminalizePendingDeliveryQueueEntry,
-  terminalizePendingDeliveryQueueEntryInDatabase,
   updateDeliveryQueueEntry,
   upsertDeliveryQueueEntry,
   upsertDeliveryQueueEntryInDatabase,
   type DeliveryQueueEntryState,
 } from "../delivery-queue-sqlite.js";
 import { generateSecureUuid } from "../secure-random.js";
-import { collectEntrySpoolPaths, releaseSpoolArtifacts } from "./delivery-queue-media-spool.js";
+import { failPendingDelivery } from "./delivery-queue-ack.js";
+import { collectEntrySpoolPaths } from "./delivery-queue-media-spool.js";
 import {
   DELIVERY_QUEUE_MEDIA_STAGING_QUEUE_NAME,
   LEGACY_OUTBOUND_DELIVERY_QUEUE_NAME,
@@ -81,11 +80,16 @@ const OUTBOUND_DELIVERY_NAMESPACE_DESCRIPTORS = [
   { queueName: LEGACY_OUTBOUND_DELIVERY_QUEUE_NAME, namespace: "legacy", retired: true },
 ] as const;
 
-export function findDeliveryIntentOwner(id: string, stateDir?: string) {
+export function findDeliveryIntentOwner(
+  id: string,
+  stateDir?: string,
+  context?: DeliveryQueueStateContext,
+) {
   const owners = getDeliveryQueueEntryOwners(
     OUTBOUND_DELIVERY_NAMESPACE_DESCRIPTORS.map(({ queueName }) => queueName),
     id,
     stateDir,
+    context,
   );
   for (const descriptor of OUTBOUND_DELIVERY_NAMESPACE_DESCRIPTORS) {
     const owner = owners.get(descriptor.queueName);
@@ -155,6 +159,7 @@ export async function enqueueDelivery(
   params: QueuedDeliveryAdmissionPayload,
   stateDir?: string,
   mediaStageId?: string,
+  context?: DeliveryQueueStateContext,
 ): Promise<string> {
   const id = generateSecureUuid();
   const entry = createQueuedDelivery(
@@ -163,14 +168,17 @@ export async function enqueueDelivery(
     params.deliveryCompletion !== undefined || params.completionRetention !== undefined,
   );
   if (mediaStageId) {
-    const result = commitStagedDeliveryQueueEntryOnceAcrossNamespaces({
-      queueName: OUTBOUND_DELIVERY_QUEUE_NAME,
-      entry,
-      stagingId: mediaStageId,
-      stagingQueueName: DELIVERY_QUEUE_MEDIA_STAGING_QUEUE_NAME,
-      conflictQueueNames: [],
-      stateDir,
-    });
+    const result = commitStagedDeliveryQueueEntryOnceAcrossNamespaces(
+      {
+        queueName: OUTBOUND_DELIVERY_QUEUE_NAME,
+        entry,
+        stagingId: mediaStageId,
+        stagingQueueName: DELIVERY_QUEUE_MEDIA_STAGING_QUEUE_NAME,
+        conflictQueueNames: [],
+        stateDir,
+      },
+      context,
+    );
     if (result === "missing") {
       throw new Error(`Delivery queue media stage expired before enqueue: ${mediaStageId}`);
     }
@@ -178,11 +186,14 @@ export async function enqueueDelivery(
       throw new Error(`Delivery queue entry already exists: ${OUTBOUND_DELIVERY_QUEUE_NAME}/${id}`);
     }
   } else {
-    upsertDeliveryQueueEntry({
-      queueName: OUTBOUND_DELIVERY_QUEUE_NAME,
-      entry,
-      stateDir,
-    });
+    upsertDeliveryQueueEntry(
+      {
+        queueName: OUTBOUND_DELIVERY_QUEUE_NAME,
+        entry,
+        stateDir,
+      },
+      context,
+    );
   }
   return id;
 }
@@ -193,43 +204,41 @@ export async function enqueueDeliveryOnce(
   id: string,
   stateDir?: string,
   mediaStageId?: string,
+  context?: DeliveryQueueStateContext,
 ): Promise<{ id: string; created: boolean }> {
   const normalizedId = id.trim();
   if (!normalizedId) {
     throw new Error("Stable delivery queue id is required");
   }
   const entry = createQueuedDelivery(params, normalizedId, true);
-  const created = mediaStageId
-    ? (() => {
-        const result = commitStagedDeliveryQueueEntryOnceAcrossNamespaces({
-          queueName: OUTBOUND_DELIVERY_QUEUE_NAME,
-          entry,
-          stagingId: mediaStageId,
-          stagingQueueName: DELIVERY_QUEUE_MEDIA_STAGING_QUEUE_NAME,
-          conflictQueueNames: [
-            OUTBOUND_DELIVERY_MIGRATION_QUEUE_NAME,
-            OUTBOUND_DELIVERY_PREPARATION_QUEUE_NAME,
-            OUTBOUND_LEGACY_PREPARATION_QUEUE_NAME,
-            LEGACY_OUTBOUND_DELIVERY_QUEUE_NAME,
-          ],
-          stateDir,
-        });
-        if (result === "missing") {
-          throw new Error(`Delivery queue media stage expired before enqueue: ${mediaStageId}`);
-        }
-        return result === "created";
-      })()
-    : upsertDeliveryQueueEntryOnceAcrossNamespaces({
-        queueName: OUTBOUND_DELIVERY_QUEUE_NAME,
-        conflictQueueNames: [
-          OUTBOUND_DELIVERY_MIGRATION_QUEUE_NAME,
-          OUTBOUND_DELIVERY_PREPARATION_QUEUE_NAME,
-          OUTBOUND_LEGACY_PREPARATION_QUEUE_NAME,
-          LEGACY_OUTBOUND_DELIVERY_QUEUE_NAME,
-        ],
-        entry,
-        stateDir,
-      });
+  const queueParams = {
+    queueName: OUTBOUND_DELIVERY_QUEUE_NAME,
+    conflictQueueNames: [
+      OUTBOUND_DELIVERY_MIGRATION_QUEUE_NAME,
+      OUTBOUND_DELIVERY_PREPARATION_QUEUE_NAME,
+      OUTBOUND_LEGACY_PREPARATION_QUEUE_NAME,
+      LEGACY_OUTBOUND_DELIVERY_QUEUE_NAME,
+    ],
+    entry,
+    stateDir,
+  };
+  let created: boolean;
+  if (mediaStageId) {
+    const result = commitStagedDeliveryQueueEntryOnceAcrossNamespaces(
+      {
+        ...queueParams,
+        stagingId: mediaStageId,
+        stagingQueueName: DELIVERY_QUEUE_MEDIA_STAGING_QUEUE_NAME,
+      },
+      context,
+    );
+    if (result === "missing") {
+      throw new Error(`Delivery queue media stage expired before enqueue: ${mediaStageId}`);
+    }
+    created = result === "created";
+  } else {
+    created = upsertDeliveryQueueEntryOnceAcrossNamespaces(queueParams, context);
+  }
   return { id: normalizedId, created };
 }
 
@@ -240,30 +249,34 @@ export async function enqueuePreparedDeliveryOnce(
   preparation: StableDeliveryPreparation,
   stateDir?: string,
   mediaStageId?: string,
+  context?: DeliveryQueueStateContext,
 ): Promise<{ id: string; created: boolean }> {
   const normalizedId = id.trim();
   if (!normalizedId || normalizedId !== preparation.id) {
     throw new Error("Stable delivery preparation id is invalid");
   }
   const entry = createQueuedDelivery(params, normalizedId, true);
-  const result = movePendingDeliveryQueueEntryNamespace({
-    sourceQueueName: OUTBOUND_DELIVERY_PREPARATION_QUEUE_NAME,
-    destinationQueueName: OUTBOUND_DELIVERY_QUEUE_NAME,
-    conflictQueueNames: [
-      OUTBOUND_DELIVERY_MIGRATION_QUEUE_NAME,
-      OUTBOUND_LEGACY_PREPARATION_QUEUE_NAME,
-      LEGACY_OUTBOUND_DELIVERY_QUEUE_NAME,
-    ],
-    expectedSourceEntry: preparation,
-    destinationEntry: entry,
-    ...(mediaStageId
-      ? {
-          stagingQueueName: DELIVERY_QUEUE_MEDIA_STAGING_QUEUE_NAME,
-          stagingId: mediaStageId,
-        }
-      : {}),
-    stateDir,
-  });
+  const result = movePendingDeliveryQueueEntryNamespace(
+    {
+      sourceQueueName: OUTBOUND_DELIVERY_PREPARATION_QUEUE_NAME,
+      destinationQueueName: OUTBOUND_DELIVERY_QUEUE_NAME,
+      conflictQueueNames: [
+        OUTBOUND_DELIVERY_MIGRATION_QUEUE_NAME,
+        OUTBOUND_LEGACY_PREPARATION_QUEUE_NAME,
+        LEGACY_OUTBOUND_DELIVERY_QUEUE_NAME,
+      ],
+      expectedSourceEntry: preparation,
+      destinationEntry: entry,
+      ...(mediaStageId
+        ? {
+            stagingQueueName: DELIVERY_QUEUE_MEDIA_STAGING_QUEUE_NAME,
+            stagingId: mediaStageId,
+          }
+        : {}),
+      stateDir,
+    },
+    context,
+  );
   if (result === "staging-missing") {
     throw new Error(`Delivery queue media stage expired before enqueue: ${mediaStageId}`);
   }
@@ -281,6 +294,7 @@ export async function failDelivery(
   error: string,
   stateDir?: string,
   expectedPlatformSendAttemptId?: string | null,
+  context?: DeliveryQueueStateContext,
 ): Promise<void> {
   updateQueuedDelivery(
     id,
@@ -297,6 +311,7 @@ export async function failDelivery(
       recoveryState: entry.recoveryState === "producer_claimed" ? undefined : entry.recoveryState,
     }),
     expectedPlatformSendAttemptId,
+    context,
   );
 }
 
@@ -306,6 +321,7 @@ export async function failDeliveryBeforePlatformSend(
   error: string,
   stateDir?: string,
   expectedPlatformSendAttemptId?: string | null,
+  context?: DeliveryQueueStateContext,
 ): Promise<void> {
   updateQueuedDelivery(
     id,
@@ -323,6 +339,7 @@ export async function failDeliveryBeforePlatformSend(
       recoveryState: undefined,
     }),
     expectedPlatformSendAttemptId,
+    context,
   );
 }
 
@@ -332,6 +349,7 @@ export async function failDeliveryAfterPlatformSend(
   error: string,
   stateDir?: string,
   expectedPlatformSendAttemptId?: string | null,
+  context?: DeliveryQueueStateContext,
 ): Promise<void> {
   updateQueuedDelivery(
     id,
@@ -347,6 +365,7 @@ export async function failDeliveryAfterPlatformSend(
       recoveryState: "unknown_after_send",
     }),
     expectedPlatformSendAttemptId,
+    context,
   );
 }
 
@@ -358,14 +377,18 @@ export async function reserveDeliveryAttempt(
   maxAttempts: number,
   stateDir?: string,
   expectedPlatformSendAttemptId?: string,
+  context?: DeliveryQueueStateContext,
 ) {
-  return reserveDeliveryQueueEntryAttempt({
-    queueName: OUTBOUND_DELIVERY_QUEUE_NAME,
-    id,
-    maxAttempts,
-    stateDir,
-    ...(expectedPlatformSendAttemptId ? { expectedPlatformSendAttemptId } : {}),
-  });
+  return reserveDeliveryQueueEntryAttempt(
+    {
+      queueName: OUTBOUND_DELIVERY_QUEUE_NAME,
+      id,
+      maxAttempts,
+      stateDir,
+      ...(expectedPlatformSendAttemptId ? { expectedPlatformSendAttemptId } : {}),
+    },
+    context,
+  );
 }
 
 /** Restore the exact pre-attempt row when lifecycle closure wins before provider dispatch. */
@@ -374,6 +397,7 @@ export function restoreDeliveryAttemptBeforeDispatch(
   reservedAttemptCount: number,
   stateDir?: string,
   claimedAttemptId?: string,
+  context?: DeliveryQueueStateContext,
 ): void {
   updateQueuedDelivery(
     entry.id,
@@ -394,6 +418,7 @@ export function restoreDeliveryAttemptBeforeDispatch(
       };
     },
     claimedAttemptId ?? null,
+    context,
   );
 }
 
@@ -402,6 +427,7 @@ function updateQueuedDelivery(
   stateDir: string | undefined,
   update: (entry: QueuedDelivery) => QueuedDelivery,
   expectedPlatformSendAttemptId?: string | null,
+  context?: DeliveryQueueStateContext,
 ): void {
   if (expectedPlatformSendAttemptId !== undefined) {
     const updated = transitionOwnedDeliveryQueueEntry(
@@ -420,14 +446,19 @@ function updateQueuedDelivery(
           database,
         );
       },
+      context,
     );
     if (!updated) {
       throw lostPlatformClaim(id);
     }
     return;
   }
-  updateDeliveryQueueEntry(OUTBOUND_DELIVERY_QUEUE_NAME, id, stateDir, (entry) =>
-    update(entry as QueuedDelivery),
+  updateDeliveryQueueEntry(
+    OUTBOUND_DELIVERY_QUEUE_NAME,
+    id,
+    stateDir,
+    (entry) => update(entry as QueuedDelivery),
+    context,
   );
 }
 
@@ -436,28 +467,38 @@ export async function markDeliveryPlatformSendAttemptStarted(
   stateDir?: string,
   route?: { replyToId?: string | null },
   producerClaimId?: string,
+  context?: DeliveryQueueStateContext,
 ): Promise<void> {
   if (producerClaimId) {
-    const promoted = promoteDeliveryQueueEntryPlatformSend({
-      queueName: OUTBOUND_DELIVERY_QUEUE_NAME,
-      id,
-      claimId: producerClaimId,
-      stateDir,
-      route,
-    });
+    const promoted = promoteDeliveryQueueEntryPlatformSend(
+      {
+        queueName: OUTBOUND_DELIVERY_QUEUE_NAME,
+        id,
+        claimId: producerClaimId,
+        stateDir,
+        route,
+      },
+      context,
+    );
     if (!promoted) {
       throw new Error(`Delivery platform claim was lost: ${id}`);
     }
     return;
   }
-  updateQueuedDelivery(id, stateDir, (entry) => ({
-    ...entry,
-    availableAt: undefined,
-    producerClaimId: undefined,
-    platformSendStartedAt: entry.platformSendStartedAt ?? Date.now(),
-    ...(route && "replyToId" in route ? { effectiveReplyToId: route.replyToId ?? null } : {}),
-    recoveryState: "send_attempt_started",
-  }));
+  updateQueuedDelivery(
+    id,
+    stateDir,
+    (entry) => ({
+      ...entry,
+      availableAt: undefined,
+      producerClaimId: undefined,
+      platformSendStartedAt: entry.platformSendStartedAt ?? Date.now(),
+      ...(route && "replyToId" in route ? { effectiveReplyToId: route.replyToId ?? null } : {}),
+      recoveryState: "send_attempt_started",
+    }),
+    undefined,
+    context,
+  );
 }
 
 /** Refresh the attempt timestamp before recipient-visible or finalizing platform I/O. */
@@ -466,9 +507,16 @@ export async function markDeliveryPlatformSendDispatched(
   stateDir?: string,
   route?: { replyToId?: string | null },
   expectedPlatformSendAttemptId?: string | null,
+  context?: DeliveryQueueStateContext,
 ): Promise<void> {
   if (typeof expectedPlatformSendAttemptId === "string") {
-    markOwnedDeliveryPlatformSendDispatched(id, stateDir, route, expectedPlatformSendAttemptId);
+    markOwnedDeliveryPlatformSendDispatched(
+      id,
+      stateDir,
+      route,
+      expectedPlatformSendAttemptId,
+      context,
+    );
     return;
   }
   updateQueuedDelivery(
@@ -486,6 +534,7 @@ export async function markDeliveryPlatformSendDispatched(
         entry.recoveryState === "unknown_after_send" ? entry.recoveryState : "send_attempt_started",
     }),
     expectedPlatformSendAttemptId,
+    context,
   );
 }
 
@@ -493,6 +542,7 @@ export async function markDeliveryPlatformOutcomeUnknown(
   id: string,
   stateDir?: string,
   expectedPlatformSendAttemptId?: string | null,
+  context?: DeliveryQueueStateContext,
 ): Promise<void> {
   updateQueuedDelivery(
     id,
@@ -512,6 +562,7 @@ export async function markDeliveryPlatformOutcomeUnknown(
       recoveryState: "unknown_after_send",
     }),
     expectedPlatformSendAttemptId,
+    context,
   );
 }
 
@@ -519,27 +570,40 @@ export async function markDeliveryPlatformOutcomeUnknown(
 export const loadPendingDelivery = async (
   id: string,
   stateDir?: string,
+  context?: DeliveryQueueStateContext,
 ): Promise<QueuedDelivery | null> =>
-  loadDeliveryQueueEntry(OUTBOUND_DELIVERY_QUEUE_NAME, id, stateDir) as QueuedDelivery | null;
+  loadDeliveryQueueEntry(
+    OUTBOUND_DELIVERY_QUEUE_NAME,
+    id,
+    stateDir,
+    "pending",
+    context,
+  ) as QueuedDelivery | null;
 
 /** Failed settlement retains owner metadata, but is never eligible for sending. */
-export async function loadUnfinishedDeliveries(stateDir?: string): Promise<QueuedDelivery[]> {
+export async function loadUnfinishedDeliveries(
+  stateDir?: string,
+  context?: DeliveryQueueStateContext,
+): Promise<QueuedDelivery[]> {
   return loadDeliveryQueueEntries(
     OUTBOUND_DELIVERY_QUEUE_NAME,
     stateDir,
     "unfinished",
+    context,
   ) as QueuedDelivery[]; // SAFETY: Pending and unfinished rows in this namespace retain the prepared payload.
 }
 
 export async function loadUnfinishedDelivery(
   id: string,
   stateDir?: string,
+  context?: DeliveryQueueStateContext,
 ): Promise<QueuedDelivery | null> {
   return loadDeliveryQueueEntry(
     OUTBOUND_DELIVERY_QUEUE_NAME,
     id,
     stateDir,
     "unfinished",
+    context,
   ) as QueuedDelivery | null; // SAFETY: Pending and unfinished rows in this namespace retain the prepared payload.
 }
 
@@ -563,6 +627,7 @@ export async function stageDeliveryFailureSettlement(
   settlement: DeliveryFailureSettlement,
   stateDir?: string,
   claimedAttemptId?: string,
+  context?: DeliveryQueueStateContext,
 ): Promise<QueuedDelivery | undefined> {
   if (entry.settlement) {
     const current = loadDeliveryQueueEntry(
@@ -570,6 +635,7 @@ export async function stageDeliveryFailureSettlement(
       entry.id,
       stateDir,
       "unfinished",
+      context,
     );
     return current && JSON.stringify(current) === JSON.stringify(entry)
       ? (current as QueuedDelivery) // SAFETY: Exact serialized equality with the typed entry preserves its shape.
@@ -577,7 +643,7 @@ export async function stageDeliveryFailureSettlement(
   }
   const reclaim = entry.recoveryState === "producer_claimed" && claimedAttemptId === undefined;
   const attemptId = reclaim
-    ? await claimDeliveryPlatformSendAttempt(entry.id, stateDir)
+    ? await claimDeliveryPlatformSendAttempt(entry.id, stateDir, undefined, undefined, context)
     : (claimedAttemptId ?? entry.platformSendAttemptId ?? null);
   if (reclaim && !attemptId) {
     return undefined;
@@ -612,6 +678,7 @@ export async function stageDeliveryFailureSettlement(
         database,
       );
     },
+    context,
   );
   return staged;
 }
@@ -620,15 +687,19 @@ export async function stageDeliveryFailureSettlement(
 export function finalizeDeliveryFailureSettlement(
   entry: QueuedDelivery,
   stateDir?: string,
+  context?: DeliveryQueueStateContext,
 ): boolean {
   return (
-    terminalizePendingDeliveryQueueEntry({
-      queueName: OUTBOUND_DELIVERY_QUEUE_NAME,
-      id: entry.id,
-      entry,
-      stateDir,
-      expectedStatus: "failed",
-    }).status === "terminalized"
+    terminalizePendingDeliveryQueueEntry(
+      {
+        queueName: OUTBOUND_DELIVERY_QUEUE_NAME,
+        id: entry.id,
+        entry,
+        stateDir,
+        expectedStatus: "failed",
+      },
+      context,
+    ).status === "terminalized"
   );
 }
 
@@ -661,10 +732,12 @@ export function loadPendingLegacyDeliveryPreparations(
 /** Move a queue entry out of the pending retry set. */
 export async function moveToFailed(
   id: string,
-  stateDir?: string,
+  requestedStateDir?: string,
   expectedPlatformSendAttemptId?: string | null,
+  context?: DeliveryQueueStateContext,
 ): Promise<string[]> {
-  const entry = await loadPendingDelivery(id, stateDir);
+  const stateDir = context?.stateDir ?? requestedStateDir;
+  const entry = await loadPendingDelivery(id, stateDir, context);
   if (!entry) {
     throw new Error(`No pending outbound delivery queue entry ${id}`);
   }
@@ -676,64 +749,10 @@ export async function moveToFailed(
       ...(expectedPlatformSendAttemptId !== undefined ? { expectedPlatformSendAttemptId } : {}),
     },
     stateDir,
+    context,
   );
   if (result.status !== "failed") {
     throw lostPlatformClaim(id);
   }
   return collectEntrySpoolPaths(queuedDeliveryPayloads(entry), stateDir);
-}
-
-type FailPendingDeliveryResult = { status: "failed" } | { status: "not_pending" };
-
-/** Conditionally dead-letter a freshly re-read pending entry without a claimed state. */
-export async function failPendingDelivery(
-  params: {
-    id: string;
-    entry: QueuedDelivery;
-    retainSpoolArtifacts?: boolean;
-    expectedPlatformSendAttemptId?: string | null;
-  },
-  stateDir?: string,
-): Promise<FailPendingDeliveryResult> {
-  const terminal = { queueName: OUTBOUND_DELIVERY_QUEUE_NAME, id: params.id, entry: params.entry };
-  // An unmatched claim must remain a no-op; standalone calls validate before opening state.
-  const prepared =
-    params.expectedPlatformSendAttemptId === undefined
-      ? prepareDeliveryQueueTerminalEntry(terminal)
-      : undefined;
-  const database = openOpenClawStateDatabase({
-    env: stateDir ? { ...process.env, OPENCLAW_STATE_DIR: stateDir } : process.env,
-  });
-  let terminalized = false;
-  const terminalize = (): undefined => {
-    terminalized =
-      terminalizePendingDeliveryQueueEntryInDatabase(
-        database,
-        prepared ?? prepareDeliveryQueueTerminalEntry(terminal),
-      ).status === "terminalized";
-  };
-  if (params.expectedPlatformSendAttemptId !== undefined) {
-    transitionOwnedDeliveryQueueEntry(
-      {
-        queueName: OUTBOUND_DELIVERY_QUEUE_NAME,
-        id: params.id,
-        stateDir,
-        database,
-        platformSendAttemptId: params.expectedPlatformSendAttemptId,
-      },
-      terminalize,
-    );
-  } else {
-    terminalize();
-  }
-  if (terminalized) {
-    if (params.retainSpoolArtifacts !== true) {
-      await releaseSpoolArtifacts(
-        collectEntrySpoolPaths(queuedDeliveryPayloads(params.entry), stateDir),
-        stateDir,
-      );
-    }
-    return { status: "failed" };
-  }
-  return { status: "not_pending" };
 }

--- a/src/infra/outbound/delivery-queue.storage.test.ts
+++ b/src/infra/outbound/delivery-queue.storage.test.ts
@@ -4,6 +4,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { openOpenClawStateDatabase } from "../../state/openclaw-state-db.js";
+import { failPendingDelivery } from "./delivery-queue-ack.js";
 import { OUTBOUND_DELIVERY_QUEUE_NAME } from "./delivery-queue-media-staging.js";
 import { renewDeliveryPlatformSendLease } from "./delivery-queue-platform-lease.js";
 import {
@@ -14,7 +15,6 @@ import {
   failDelivery,
   failDeliveryAfterPlatformSend,
   failDeliveryBeforePlatformSend,
-  failPendingDelivery,
   loadPendingDelivery,
   markDeliveryPlatformOutcomeUnknown,
   markDeliveryPlatformSendDispatched,

--- a/src/plugin-sdk/delivery-queue-runtime.ts
+++ b/src/plugin-sdk/delivery-queue-runtime.ts
@@ -1,4 +1,5 @@
 // Delivery queue runtime helpers persist and replay outbound plugin delivery work.
+import { captureDeliveryQueueStateContext } from "../infra/delivery-queue-sqlite.js";
 import {
   drainPendingDeliveriesCore,
   type DeliverFn,
@@ -24,19 +25,24 @@ const loadOutboundDeliverRuntime = createLazyRuntimeModule(
  * loaded lazily so importing this SDK subpath does not eagerly bind send internals.
  */
 export async function drainPendingDeliveries(opts: DrainPendingDeliveriesOptions): Promise<void> {
+  const capturedState = captureDeliveryQueueStateContext(opts.stateDir);
   await runWithGatewayIndependentRootWorkAdmission(async () => {
     // Keep lazy resolution and draining in one lease so suspension cannot split the handoff.
     const deliver =
       opts.deliver ?? (await loadOutboundDeliverRuntime()).deliverOutboundPayloadsInternal;
-    await drainPendingDeliveriesCore({
-      ...opts,
-      deliver,
-      // Conversation records belong to the Gateway recovery loop, which reconstructs current
-      // route authority before delivery. Plugin reconnect drains cannot safely consume them.
-      selectEntry: (entry, now) =>
-        entry.deliveryCompletion?.kind === "conversation"
-          ? { match: false, bypassBackoff: false }
-          : opts.selectEntry(entry, now),
-    });
+    await drainPendingDeliveriesCore(
+      {
+        ...opts,
+        deliver,
+        // Conversation records belong to the Gateway recovery loop, which reconstructs current
+        // route authority before delivery. Plugin reconnect drains cannot safely consume them.
+        selectEntry: (entry, now) =>
+          entry.deliveryCompletion?.kind === "conversation"
+            ? { match: false, bypassBackoff: false }
+            : opts.selectEntry(entry, now),
+      },
+      opts.deliver ? undefined : deliver,
+      capturedState,
+    );
   }, "delivery-queue:drain");
 }


### PR DESCRIPTION
Related: #130741

## What Problem This Solves

Fixes an issue where an in-flight message or reconnect recovery could update a different delivery queue if the process state directory changed while work was awaiting preparation or admission. That could leave the original delivery unfinished or apply completion and cleanup to the wrong store.

## Why This Change Was Made

Capture the resolved state directory and supervisor mode at the existing send and recovery entry points, then carry them through staging, claims, leases, completion, acknowledgement, and cleanup. Existing queue owners retain responsibility for transitions. Public SDK options and callback shapes remain unchanged; no schema, retention, retry-budget, or timeout change is required.

## User Impact

Queued sends and recovered deliveries finish against the store that admitted them, including during reconnect and restart recovery. Explicit state-directory selectors retain their existing normalization behavior.

## Evidence

- 236 focused and sibling tests passed, including 19 new regression cases. The four selector regressions failed before the correction and passed afterward.
- Canonical checks completed across the initial run and a corrected continuation: 27 stages passed before attributable lint failures; 17 affected and remaining checks then passed. This was not one uninterrupted green invocation.
- Normal build and all 153 public SDK consumer surfaces passed. The private QA declaration profile and restored normal profile passed their consumer checks; private declarations are absent from normal output.
- Current-main integration preserves all 27 original non-documentation files unchanged and retains both adjacent documentation additions.
- CI exposed 22 stale private-call expectations in two existing outbound test files. Their corrections preserve exact queue-root, claim, retention, ordering, outcome, and public callback checks. All 261 owning and state-context cases, 20 targeted check stages, and a fresh independent P0/P1 review passed. Production is unchanged by this correction.

Declaration regeneration produced a 469-byte aggregate shrink across 48 public declaration files under the existing variance policy. Original declaration bytes were not retained beyond hashes, so that particular difference is not claimed to be byte-identical or fully attributed. The supported-profile consumer and touched-contract checks passed.

This component proof does not establish the separate real-provider Swarm 500 ms target, which remains tracked in #130741.
