### PR TITLE
improve: speed up Doctor checks for absent plugin state

### DIFF
--- a/extensions/crabbox/doctor-contract-api.test.ts
+++ b/extensions/crabbox/doctor-contract-api.test.ts
@@ -10,8 +10,8 @@ import type {
 import { useAutoCleanupTempDirTracker } from "openclaw/plugin-sdk/test-env";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { stateMigrations } from "./doctor-contract-api.js";
+import { crabboxLegacyWarmImageCaptureSelector } from "./src/crabbox-worker-warm-image-records.js";
 import {
-  crabboxLegacyWarmImageCaptureSelector,
   listCrabboxLegacyWarmLeases,
   openCrabboxWarmImageStore,
 } from "./src/crabbox-worker-warm-image-store.js";
@@ -251,7 +251,9 @@ describe("Crabbox warm-profile Doctor migration", () => {
         return update(key, callback, options);
       });
       const context: PluginDoctorStateMigrationContext = { openPluginStateKeyedStore: openStore };
-      vi.spyOn(context, "openPluginStateKeyedStore").mockReturnValue(store);
+      vi.spyOn(context, "openPluginStateKeyedStore").mockImplementation((options) =>
+        options.namespace === "warm-images" ? store : openStore(options),
+      );
 
       const result = await migration.migrateLegacyState(input(context));
 

--- a/extensions/crabbox/doctor-contract-api.ts
+++ b/extensions/crabbox/doctor-contract-api.ts
@@ -1,5 +1,14 @@
-import type { PluginDoctorStateMigration } from "openclaw/plugin-sdk/runtime-doctor-migrations";
+import type {
+  PluginDoctorStateMigration,
+  PluginDoctorStateMigrationContext,
+} from "openclaw/plugin-sdk/runtime-doctor-migrations";
 import { asOptionalRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+import {
+  crabboxLegacyWarmImageCaptureSelector,
+  LEGACY_WARM_LEASE_MAX_ENTRIES,
+  projectCrabboxLegacyWarmLeases,
+  WARM_IMAGE_MAX_ENTRIES,
+} from "./src/crabbox-worker-warm-image-records.js";
 import type {
   WarmAllocationRecord,
   WarmImageRecord,
@@ -141,14 +150,24 @@ function migrateImage({
   return { ...image, lastDemandAtMs: null, preparationKey: null, cacheKey: null, purpose: null };
 }
 
+async function listLegacyWarmLeases(context: PluginDoctorStateMigrationContext) {
+  return projectCrabboxLegacyWarmLeases(
+    await context
+      .openPluginStateKeyedStore<unknown>({
+        namespace: "warm-leases",
+        maxEntries: LEGACY_WARM_LEASE_MAX_ENTRIES,
+        overflowPolicy: "evict-oldest",
+      })
+      .entries(),
+  );
+}
+
 export const stateMigrations: PluginDoctorStateMigration[] = [
   {
     id: "crabbox-warm-profile-v3",
     label: "Crabbox warm profiles",
     doctorOnly: true,
-    async detectLegacyState({ context, env }) {
-      const { WARM_IMAGE_MAX_ENTRIES, listCrabboxLegacyWarmLeases } =
-        await import("./src/crabbox-worker-warm-image-store.js");
+    async detectLegacyState({ context }) {
       const images = await context
         .openPluginStateKeyedStore<unknown>({
           namespace: "warm-images",
@@ -157,7 +176,7 @@ export const stateMigrations: PluginDoctorStateMigration[] = [
         })
         .entries();
       const pending = images.filter(({ value }) => asOptionalRecord(value)?.version !== 3).length;
-      const leases = listCrabboxLegacyWarmLeases(env);
+      const leases = await listLegacyWarmLeases(context);
       return pending || leases.length
         ? {
             preview: [
@@ -174,12 +193,7 @@ export const stateMigrations: PluginDoctorStateMigration[] = [
           }
         : null;
     },
-    async migrateLegacyState({ context, env }) {
-      const {
-        WARM_IMAGE_MAX_ENTRIES,
-        crabboxLegacyWarmImageCaptureSelector,
-        listCrabboxLegacyWarmLeases,
-      } = await import("./src/crabbox-worker-warm-image-store.js");
+    async migrateLegacyState({ context }) {
       const changes: string[] = [];
       const warnings: string[] = [];
       const store = context.openPluginStateKeyedStore<unknown>({
@@ -258,7 +272,7 @@ export const stateMigrations: PluginDoctorStateMigration[] = [
           );
         }
       }
-      const leases = listCrabboxLegacyWarmLeases(env);
+      const leases = await listLegacyWarmLeases(context);
       if (leases.length) {
         warnings.push(
           `${leases.length} legacy Crabbox lease row(s) still block warm-profile admission; their original cold/checkpoint choices are unknown.`,

--- a/extensions/crabbox/src/crabbox-worker-warm-image-records.ts
+++ b/extensions/crabbox/src/crabbox-worker-warm-image-records.ts
@@ -1,0 +1,25 @@
+// Doctor and runtime share record policy without loading a state-store implementation.
+import { createHash } from "node:crypto";
+import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+
+export const WARM_IMAGE_MAX_ENTRIES = 128;
+export const LEGACY_WARM_LEASE_MAX_ENTRIES = 256;
+
+export function crabboxLegacyWarmImageCaptureSelector(key: string, record: unknown): string {
+  return `legacy-${createHash("sha256").update(JSON.stringify({ key, record })).digest("hex")}`;
+}
+
+// Recovery selectors bind the original row bytes; preserve property order and prefixes.
+export const legacyLeaseSelector = (key: string, value: unknown) =>
+  `legacy-lease-${createHash("sha256").update(JSON.stringify({ key, value })).digest("hex")}`;
+
+export function projectCrabboxLegacyWarmLeases(
+  entries: readonly { key: string; value: unknown }[],
+) {
+  return entries.map(({ key, value }) => ({
+    leaseId: key,
+    machineClass:
+      isRecord(value) && typeof value.machineClass === "string" ? value.machineClass : undefined,
+    selector: legacyLeaseSelector(key, value),
+  }));
+}

--- a/extensions/crabbox/src/crabbox-worker-warm-image-store.ts
+++ b/extensions/crabbox/src/crabbox-worker-warm-image-store.ts
@@ -1,8 +1,13 @@
-import { createHash } from "node:crypto";
 import type { WorkerProvider } from "openclaw/plugin-sdk/plugin-entry";
 import { createPluginStateSyncKeyedStore } from "openclaw/plugin-sdk/plugin-state-store-runtime";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { CrabboxOperatingSystem } from "./crabbox-worker-profile.js";
+import {
+  legacyLeaseSelector,
+  LEGACY_WARM_LEASE_MAX_ENTRIES,
+  projectCrabboxLegacyWarmLeases,
+  WARM_IMAGE_MAX_ENTRIES,
+} from "./crabbox-worker-warm-image-records.js";
 
 type WorkerNodeRuntimeIdentity = NonNullable<
   NonNullable<Parameters<WorkerProvider["provision"]>[2]>["nodeRuntimeIdentity"]
@@ -66,36 +71,21 @@ export type WarmProfileRecord = {
     | { type: "retire"; checkpointId: string };
 };
 
-export const WARM_IMAGE_MAX_ENTRIES = 128;
 export class CrabboxWarmImageRequestError extends Error {}
 // Match the former enrollment registry's capacity without evicting replay obligations;
 // 256 bounded lease records leave ample room under the plugin store's 1 MiB row limit.
 const WARM_IMAGE_MAX_ALLOCATIONS = 256;
 const CAPTURE_WARNING_AGE_MS = 1_200_000;
 
-export function crabboxLegacyWarmImageCaptureSelector(key: string, record: unknown): string {
-  return `legacy-${createHash("sha256").update(JSON.stringify({ key, record })).digest("hex")}`;
-}
-
 const openLegacyLeases = (env?: NodeJS.ProcessEnv) =>
   createPluginStateSyncKeyedStore<unknown>("crabbox", {
     namespace: "warm-leases",
-    maxEntries: 256,
+    maxEntries: LEGACY_WARM_LEASE_MAX_ENTRIES,
     overflowPolicy: "evict-oldest",
     ...(env ? { env } : {}),
   });
-const legacyLeaseSelector = (key: string, value: unknown) =>
-  `legacy-lease-${createHash("sha256").update(JSON.stringify({ key, value })).digest("hex")}`;
-
 export function listCrabboxLegacyWarmLeases(env?: NodeJS.ProcessEnv) {
-  return openLegacyLeases(env)
-    .entries()
-    .map(({ key, value }) => ({
-      leaseId: key,
-      machineClass:
-        isRecord(value) && typeof value.machineClass === "string" ? value.machineClass : undefined,
-      selector: legacyLeaseSelector(key, value),
-    }));
+  return projectCrabboxLegacyWarmLeases(openLegacyLeases(env).entries());
 }
 
 export function assertCrabboxWarmImageMigrationReady(): void {

--- a/extensions/crabbox/src/crabbox-worker-warm-image.ts
+++ b/extensions/crabbox/src/crabbox-worker-warm-image.ts
@@ -21,6 +21,7 @@ import {
   resolveCrabboxWarmImagePolicy,
   type CrabboxWarmImagePolicy,
 } from "./crabbox-worker-warm-image-policy.js";
+import { WARM_IMAGE_MAX_ENTRIES } from "./crabbox-worker-warm-image-records.js";
 import {
   assertCrabboxWarmImageMigrationReady,
   crabboxWarmImageCaptureStatus,
@@ -32,7 +33,6 @@ import {
   openCrabboxWarmImageStore,
   listCrabboxWarmImages,
   sameCrabboxWarmImageGeneration as sameImage,
-  WARM_IMAGE_MAX_ENTRIES,
   withCrabboxWarmImageDisplayFacts,
   withCrabboxWarmImageGeneration,
   withoutCrabboxWarmImageOperation,

--- a/extensions/voice-call/doctor-contract-api.test.ts
+++ b/extensions/voice-call/doctor-contract-api.test.ts
@@ -52,6 +52,41 @@ function createDoctorContext(
   };
 }
 
+describe.each(["default", "custom"] as const)("absent %s Voice Call store", (location) => {
+  it.each(["detectLegacyState", "migrateLegacyState"] as const)(
+    "%s leaves absent state untouched without loading repair machinery",
+    async (method) => {
+      const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-voice-call-absent-"));
+      const store = path.join(root, location === "default" ? "voice-calls" : "custom-store");
+      const env = { ...process.env, HOME: root, OPENCLAW_STATE_DIR: root };
+      vi.doMock("openclaw/plugin-sdk/doctor-repair-runtime", () => {
+        throw new Error("absent Voice Call state must not load repair machinery");
+      });
+      try {
+        const result = await expectDefined(stateMigrations[0], "voice-call state migration")[
+          method
+        ]({
+          config:
+            location === "custom"
+              ? { plugins: { entries: { "voice-call": { config: { store } } } } }
+              : {},
+          env,
+          stateDir: root,
+          oauthDir: path.join(root, "oauth"),
+          context: createDoctorContext(env),
+        });
+        expect(result).toEqual(
+          method === "detectLegacyState" ? null : { changes: [], warnings: [] },
+        );
+        expect(await fs.readdir(root)).toEqual([]);
+      } finally {
+        vi.doUnmock("openclaw/plugin-sdk/doctor-repair-runtime");
+        await fs.rm(root, { recursive: true, force: true });
+      }
+    },
+  );
+});
+
 describe("voice-call doctor state migration", () => {
   let stateDir = "";
   let storePath = "";

--- a/extensions/voice-call/doctor-contract-api.ts
+++ b/extensions/voice-call/doctor-contract-api.ts
@@ -1,4 +1,5 @@
 // Voice Call API module exposes the plugin public contract.
+import { existsSync } from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -270,9 +271,14 @@ export const stateMigrations: PluginDoctorStateMigration[] = [
     id: "voice-call-calls-jsonl-to-plugin-state",
     label: "Voice Call call log",
     async detectLegacyState(params) {
+      const storePath = resolveVoiceCallStorePath(params);
+      // An absent store has neither legacy logs nor a plugin-local database.
+      // Existing stores still need schema detection even without calls.jsonl.
+      if (!existsSync(storePath)) {
+        return null;
+      }
       const { detectOpenClawStateDatabaseSchemaMigrations } =
         await import("openclaw/plugin-sdk/doctor-repair-runtime");
-      const storePath = resolveVoiceCallStorePath(params);
       const filePath = resolveVoiceCallLegacyCallLogPath(storePath);
       const { entries } = await readLegacyCallRecords(filePath);
       const schemaMigrations = detectOpenClawStateDatabaseSchemaMigrations({
@@ -296,11 +302,14 @@ export const stateMigrations: PluginDoctorStateMigration[] = [
       };
     },
     async migrateLegacyState(params) {
-      const { detectOpenClawStateDatabaseSchemaMigrations, repairOpenClawStateDatabaseSchema } =
-        await import("openclaw/plugin-sdk/doctor-repair-runtime");
       const changes: string[] = [];
       const warnings: string[] = [];
       const storePath = resolveVoiceCallStorePath(params);
+      if (!existsSync(storePath)) {
+        return { changes, warnings };
+      }
+      const { detectOpenClawStateDatabaseSchemaMigrations, repairOpenClawStateDatabaseSchema } =
+        await import("openclaw/plugin-sdk/doctor-repair-runtime");
       const filePath = resolveVoiceCallLegacyCallLogPath(storePath);
       const { entries, warnings: readWarnings } = await readLegacyCallRecords(filePath);
       warnings.push(...readWarnings);

--- a/src/memory-host-sdk/event-store.ts
+++ b/src/memory-host-sdk/event-store.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 import { z } from "zod";
 import { resolveWorkspaceStateIdentity } from "../agents/workspace-state-identity.js";
-import {
+import type {
   pluginStateEntriesInKeyRange,
   registerPluginStateSequencedJournalEntry,
 } from "../plugin-state/plugin-state-store.js";
@@ -300,7 +300,7 @@ export async function registerMemoryHostEvent(params: {
   }
   const keyStartInclusive = eventKeyPrefix(params.workspaceDir);
   const recordedAt = Date.now();
-  await registerPluginStateSequencedJournalEntry({
+  const journal: Parameters<typeof registerPluginStateSequencedJournalEntry>[0] = {
     pluginId: MEMORY_HOST_EVENTS_PLUGIN_ID,
     cursorOptions: {
       namespace: MEMORY_HOST_EVENT_CURSORS_NAMESPACE,
@@ -320,7 +320,10 @@ export async function registerMemoryHostEvent(params: {
       valueKind: "event",
     },
     journalValue: (sequence) => ({ kind: "event", event, recordedAt, sequence }),
-  });
+  };
+  // Capture workspace keys and event time together before the lazy store load yields.
+  const pluginState = await import("../plugin-state/plugin-state-store.js");
+  await pluginState.registerPluginStateSequencedJournalEntry(journal);
 }
 
 export async function listStoredMemoryHostEvents(params: {
@@ -337,7 +340,7 @@ export async function listStoredMemoryHostEvents(params: {
         ),
       )
     : (maxMemoryHostEventsForTests ?? MAX_MEMORY_HOST_EVENTS);
-  const entries = pluginStateEntriesInKeyRange({
+  const query: Parameters<typeof pluginStateEntriesInKeyRange>[0] = {
     pluginId: MEMORY_HOST_EVENTS_PLUGIN_ID,
     namespace: MEMORY_HOST_EVENTS_NAMESPACE,
     keyStartInclusive: eventKeyPrefix(params.workspaceDir),
@@ -345,10 +348,14 @@ export async function listStoredMemoryHostEvents(params: {
     limit,
     order: "desc",
     ...(params.env ? { env: params.env } : {}),
-  }).flatMap((entry): PersistedMemoryHostEvent[] => {
-    const value = entry.value as StoredMemoryHostEvent;
-    return value.kind === "event" ? [{ ...entry, value }] : [];
-  });
+  };
+  const pluginState = await import("../plugin-state/plugin-state-store.js");
+  const entries = pluginState
+    .pluginStateEntriesInKeyRange(query)
+    .flatMap((entry): PersistedMemoryHostEvent[] => {
+      const value = entry.value as StoredMemoryHostEvent;
+      return value.kind === "event" ? [{ ...entry, value }] : [];
+    });
   return entries.toReversed();
 }
 


### PR DESCRIPTION
## What Problem This Solves

Cold Doctor state checks load a broad runtime dependency graph even when they already have the required store context or the plugin's state directory is absent.

## User Impact

Doctor avoids unnecessary imports while preserving the existing migration owners, state formats, validation and recovery behavior. Existing Voice Call databases still receive schema checks even without a legacy call log. No configuration, schema, retention, resource-custody or public SDK contract changes are introduced.

The measured improvement is local test-case time. Full command and Linux CI speedups are not yet established.

## Why This Change Was Made

Crabbox Doctor now reads both required namespaces through its supplied context and shares unchanged limits, selectors and row projection with the runtime through a lightweight private module. Memory Host defers its state-store dependency until an actual read or write; every original key, timestamp and query argument is prepared before that await. Voice Call returns the existing empty result before loading repair machinery only when its entire store root is absent.

These changes belong together: the first two partial versions merely moved the same cold load to the next detector. The complete change removes that unnecessary load from the observed sweep. Runtime storage operations remain with their existing owners.

## Evidence

An uninstrumented original/candidate/original comparison ran the same first two corpus cases in the same order, preserving both Doctor/startup passes and all assertions. First-case times were 39.02 / 31.08 / 36.83 seconds. The two-case total was 40.90 seconds for the candidate versus 48.00 seconds averaged across the controls, a 14.8% local reduction. The diagnostic sweep separately retained all 46 declared migration owners and 512 callback invocations, while first detection fell from 18.38 to 10.05 seconds.

The candidate's dirty checkout triggered an extra canonical pretest build, so its overall local command was slower. No wrapper or CI speedup is claimed; committed CI must establish the job-level result. This was a same-host macOS source-mode sample using Node 24.21 and pnpm 12.3.4, not the full corpus or a Linux benchmark.

All 235 focused tests, the full build and required changed-file checks passed. Four absent-state regression cases fail at the original repair imports and pass with the fix; retained cases cover database-only repair, malformed logs, partial writes/retry, capacity, concurrent sequencing, rollback and reopen. Two fresh plain-Node processes also exercised the compiled public SDK: append/read followed by a separate lock-owned export and persisted read, with exact event bytes and cleanup verified.

[Exact-head CI34751724130](https://github.com/openclaw/openclaw/actions/runs/34751724130) passed, including both startup corpus files (58 tests) and all 91 affected plugin Doctor cases. The actual tested merge preserves the eight candidate files. The full corpus group took242.96s; that is an observation, not a controlled before/after improvement.

The repository-required [published-updater compatibility cell passed](https://github.com/openclaw/openclaw/actions/runs/34752500037): published openclaw@2026.9.4 updater to exact candidate607628d8, using existing base-scenario state and trusted harnessf3bdcc10. The actual file-tag update is followed by automatic-migration assertions before the subsequent standalone Doctor phase, preserved-state checks and Gateway health/readiness/status. The lane passed in393s, one attempt, zero retries; artifact hashes and phase order were verified. The explicit file spec bypasses the published driver's same-version no-op. Inner updater/repair JSON and a direct installed-tree hash are not uploaded, so zero repair and byte-for-byte installed-tree attestation are not claimed. This resolves the review's required compatibility items without changing migration or stored-data contracts.

Independent P2 review found no actionable defect across two evidence batches; maintainer review covered the full owners and the split-context limitations. Source checks confirm unchanged selectors, limits, persisted types, normalizer and journal/query arguments. The final eight source files are identical to their tested and reviewed bytes after the mechanical refresh onto current main.

Production adds 45 net lines for the shared lightweight record owner, prepared arguments and absent-directory checks; tests add 37. No new loader, cache, SDK seam, worker, shard, wait or deadline. Changelog remains release-owned.
