### PR TITLE
refactor(outbound): simplify media source preparation

### DIFF
--- a/src/infra/outbound/message-action-params.test.ts
+++ b/src/infra/outbound/message-action-params.test.ts
@@ -19,7 +19,6 @@ vi.mock("../../channels/plugins/message-action-discovery.js", () => ({
 import {
   collectActionMediaSourceHints,
   hydrateAttachmentParamsForAction,
-  normalizeSandboxMediaList,
   normalizeSandboxMediaParams,
   resolveExtraActionMediaSourceParamKeys,
   resolveAttachmentMediaPolicy,
@@ -141,40 +140,6 @@ describe("message action media helpers", () => {
       mediaReadFile,
     });
   });
-
-  maybeIt.each([
-    { name: "Docker", containerWorkdir: "/workspace" },
-    { name: "OpenShell", containerWorkdir: "/sandbox" },
-  ])(
-    "normalizes $name media lists and dedupes resolved workspace paths",
-    async ({ containerWorkdir }) => {
-      const sandboxRoot = await fs.mkdtemp(path.join(os.tmpdir(), "msg-params-list-"));
-      try {
-        await expect(
-          normalizeSandboxMediaList({
-            values: [" data:text/plain;base64,QQ== "],
-          }),
-        ).rejects.toThrow(/data:/i);
-        await expect(
-          normalizeSandboxMediaList({
-            values: [
-              ` file://${containerWorkdir}/assets/photo.png `,
-              `${containerWorkdir}/assets/photo.png`,
-              "buffer://message-send/attachment",
-              " ",
-            ],
-            sandboxRoot: ` ${sandboxRoot} `,
-            sandboxContainerWorkdir: containerWorkdir,
-          }),
-        ).resolves.toEqual([
-          path.join(sandboxRoot, "assets", "photo.png"),
-          "buffer://message-send/attachment",
-        ]);
-      } finally {
-        await fs.rm(sandboxRoot, { recursive: true, force: true });
-      }
-    },
-  );
 
   maybeIt.each([
     { name: "Docker", containerWorkdir: "/workspace" },

--- a/src/infra/outbound/message-action-params.ts
+++ b/src/infra/outbound/message-action-params.ts
@@ -597,35 +597,22 @@ export async function normalizeSandboxMediaParams(params: {
   }
 }
 
-/** Normalizes a list of media hints against an optional sandbox root. */
-export async function normalizeSandboxMediaList(params: {
-  values: string[];
+/** Normalizes a media hint against an optional sandbox root. */
+export async function normalizeSandboxMediaSource(params: {
+  value: string;
   sandboxRoot?: string;
   sandboxContainerWorkdir?: string;
-}): Promise<string[]> {
+}): Promise<string> {
   const sandboxRoot = params.sandboxRoot?.trim();
-  const normalized: string[] = [];
-  const seen = new Set<string>();
-  for (const value of params.values) {
-    const raw = value?.trim();
-    if (!raw) {
-      continue;
-    }
-    assertMediaNotDataUrl(raw);
-    const resolved = sandboxRoot
-      ? await resolveSandboxedMediaSource({
-          media: raw,
-          sandboxRoot,
-          containerWorkdir: params.sandboxContainerWorkdir,
-        })
-      : raw;
-    if (seen.has(resolved)) {
-      continue;
-    }
-    seen.add(resolved);
-    normalized.push(resolved);
-  }
-  return normalized;
+  const raw = params.value.trim();
+  assertMediaNotDataUrl(raw);
+  return sandboxRoot
+    ? await resolveSandboxedMediaSource({
+        media: raw,
+        sandboxRoot,
+        containerWorkdir: params.sandboxContainerWorkdir,
+      })
+    : raw;
 }
 
 async function hydrateAttachmentActionPayload(params: {

--- a/src/infra/outbound/message-action-send.media.test.ts
+++ b/src/infra/outbound/message-action-send.media.test.ts
@@ -16,6 +16,8 @@ import {
   setMessageActionTestPlugin as setTestPlugin,
 } from "./message-action-runner.test-helpers.js";
 
+const maybeIt = process.platform === "win32" ? it.skip : it;
+
 const workspaceConfig = {
   channels: {
     workspace: {
@@ -290,4 +292,125 @@ describe("runMessageAction media behavior", () => {
       ]);
     });
   });
+
+  maybeIt.each([
+    { name: "Docker", containerWorkdir: "/workspace" },
+    { name: "OpenShell", containerWorkdir: "/sandbox" },
+  ])(
+    "dedupes resolved $name media while retaining first-entry metadata",
+    async ({ containerWorkdir }) => {
+      setTestPlugin(workspacePlugin, "workspace");
+
+      await withSandbox(async (sandboxDir) => {
+        await runDrySend({
+          cfg: workspaceConfig,
+          actionParams: {
+            channel: "workspace",
+            target: "12345678",
+            message: "attachments ready",
+            media: `file://${containerWorkdir}/assets/photo.png`,
+            filename: "first.png",
+            contentType: "image/png",
+            mediaUrls: [
+              ` file://${containerWorkdir}/assets/photo.png `,
+              `${containerWorkdir}/assets/photo.png`,
+              "buffer://message-send/attachment",
+              " ",
+            ],
+            attachments: [
+              {
+                path: `${containerWorkdir}/assets/photo.png`,
+                name: "later.bin",
+                mimeType: "application/octet-stream",
+                type: "file",
+              },
+              {
+                path: `${containerWorkdir}/last.txt`,
+                name: "last.txt",
+                mimeType: "text/plain",
+                type: "file",
+              },
+            ],
+          },
+          sandboxRoot: ` ${sandboxDir} `,
+          sandboxContainerWorkdir: containerWorkdir,
+        });
+
+        expect(channelResolutionMocks.executeSendAction).toHaveBeenCalledTimes(1);
+        const sendArgs = firstMockArg(
+          channelResolutionMocks.executeSendAction,
+          "executeSendAction",
+        );
+        const mediaUrls = [
+          path.join(sandboxDir, "assets", "photo.png"),
+          "buffer://message-send/attachment",
+          path.join(sandboxDir, "last.txt"),
+        ];
+        expect(sendArgs.mediaUrls).toEqual(mediaUrls);
+        expect(requireRecord(sendArgs.payload).mediaUrls).toEqual(mediaUrls);
+        expect(requireRecord(sendArgs.payload).attachments).toEqual([
+          { path: mediaUrls[0], type: "file", name: "first.png", mimeType: "image/png" },
+          { path: mediaUrls[1] },
+          { path: mediaUrls[2], type: "file", name: "last.txt", mimeType: "text/plain" },
+        ]);
+      });
+    },
+  );
+
+  it.each([
+    { name: "omitted", sandboxRoot: undefined },
+    { name: "blank", sandboxRoot: "   " },
+  ])("preserves ordered remote media when the sandbox root is $name", async ({ sandboxRoot }) => {
+    setTestPlugin(workspacePlugin, "workspace");
+    const mediaUrls = [
+      "https://example.com/first.png?sig=1",
+      "http://example.com/second.png",
+      "mxc://matrix.org/opaque-media",
+      "buffer://message-send/attachment",
+    ];
+
+    await runDrySend({
+      cfg: workspaceConfig,
+      actionParams: {
+        channel: "workspace",
+        target: "12345678",
+        message: "attachments ready",
+        mediaUrls: [` ${mediaUrls[0]} `, mediaUrls[0], ...mediaUrls.slice(1), " "],
+      },
+      sandboxRoot,
+    });
+
+    expect(channelResolutionMocks.executeSendAction).toHaveBeenCalledTimes(1);
+    const sendArgs = firstMockArg(channelResolutionMocks.executeSendAction, "executeSendAction");
+    expect(sendArgs.mediaUrls).toEqual(mediaUrls);
+    expect(requireRecord(sendArgs.payload).mediaUrls).toEqual(mediaUrls);
+    expect(requireRecord(sendArgs.payload)).not.toHaveProperty("attachments");
+  });
+
+  it.each([false, true])(
+    "rejects a later invalid media hint before any dispatch (sandbox=%s)",
+    async (sandboxed) => {
+      setTestPlugin(workspacePlugin, "workspace");
+      await withSandbox(async (sandboxDir) => {
+        await expect(
+          runDrySend({
+            cfg: workspaceConfig,
+            actionParams: {
+              channel: "workspace",
+              target: "12345678",
+              message: "must not send partially",
+              mediaUrls: [
+                "https://example.com/first.png",
+                " data:text/plain;base64,QQ== ",
+                "https://example.com/last.png",
+              ],
+            },
+            sandboxRoot: sandboxed ? sandboxDir : undefined,
+          }),
+        ).rejects.toThrow("data: URLs are not supported for media. Use buffer instead.");
+        expect(channelResolutionMocks.executeSendAction).not.toHaveBeenCalled();
+        expect(channelResolutionMocks.callGatewayLeastPrivilege).not.toHaveBeenCalled();
+      });
+    },
+  );
 });

--- a/src/infra/outbound/message-action-send.ts
+++ b/src/infra/outbound/message-action-send.ts
@@ -40,7 +40,7 @@ import {
   executeGatewayAction,
 } from "./message-action-execution.js";
 import { stageGatewayWorkspaceMedia } from "./message-action-gateway-media.js";
-import { collectAttachmentSources, normalizeSandboxMediaList } from "./message-action-params.js";
+import { collectAttachmentSources, normalizeSandboxMediaSource } from "./message-action-params.js";
 import {
   applySendLocationToActionParams,
   applySendPayloadPartsToActionParams,
@@ -178,14 +178,11 @@ export async function buildMessagePayload(params: {
 
   const normalizedMedia = await Promise.all(
     mediaEntries.map(async (entry) => {
-      const normalizedUrl = (
-        await normalizeSandboxMediaList({
-          values: [entry.url],
-          sandboxRoot: input.sandboxRoot,
-          sandboxContainerWorkdir: input.sandboxContainerWorkdir,
-        })
-      )[0];
-      entry.url = normalizedUrl ?? entry.url;
+      entry.url = await normalizeSandboxMediaSource({
+        value: entry.url,
+        sandboxRoot: input.sandboxRoot,
+        sandboxContainerWorkdir: input.sandboxContainerWorkdir,
+      });
       return entry;
     }),
   );


### PR DESCRIPTION
## What Problem This Solves

Outgoing-message preparation retained duplicate list and deduplication bookkeeping for media sources.

## User Impact

User impact: no user-visible change. Attachment order, first-entry metadata, sandbox mapping, and rejection before dispatch are preserved; no public API, configuration, or transport policy changes.

## Why This Change Was Made

Keep per-source validation and sandbox resolution in the existing parameter owner, while payload assembly alone handles ordered, metadata-aware deduplication. This removes obsolete singleton-list wrapping without removing the asynchronous boundary.

Production: **+19/−35 (net −16)**. Tests: **+123/−35 (net +88)**, moving two private-helper cases to stronger caller-level coverage.

## Evidence

- The same five-file owner/sibling suite passed at each stage: original **86**, characterization on original production **92**, and candidate **90** after retiring exactly two helper cases. All retained native test identities, per-file order, and statuses matched; all six added characterizations passed.
- All **30 required changed checks** passed in Testbox, including core/test typechecks, formatting, typed lint, and dead-export scans. The native command exited 0 and the one-shot lease completed.
- Codex P2 reviews before commit and against the exact signed commit reported no findings.
- With the exact four-file patch composed on captured main `4aff70f27016`, the same **90-case suite passed** using its normal frozen installation, including fs-safe 0.10.0 and jszip 3.10.2. Separately, **six existing read/cleanup cases passed** on clean main with those dependencies; 30 unselected cases were filtered out. This supporting dependency-only run is distinct from the composed Media proof.

The tests exercise real normalization, filesystem handling, and managed attachment projections with existing outbound/Gateway test doubles. They do not claim a live external-channel send or Windows execution. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34751638806) passed with 114 successful jobs and 17 skipped, including the required gate.

<details>
<summary>Proof limits and retained observations</summary>

Normal warm caches were preserved. Existing Vite import-analysis warnings remained. Bookkeeping-only observer stops for emitted cache metadata and empty Git rerere records were retained and closed with read-only verification; accepted tests and the signed commit were not replayed. The rerere-record producer remains unknown. The six-case run's collector expected a multi-shard report set; native single-invocation JSON and read-only closure confirmed the six passes without rerunning tests. Raw-index metadata successors remain unattributed, with semantic entries and flags preserved. Testbox command success is distinct from its backing Actions lifecycle, which can show cancellation after one-shot cleanup.

</details>
