### PR TITLE
fix: keep test homes private with group-writable umasks

### DIFF
--- a/src/test-utils/temp-home.test.ts
+++ b/src/test-utils/temp-home.test.ts
@@ -95,6 +95,11 @@ describe("createTempHomeEnv", () => {
           expect(resolveEffectiveHomeDir()).toBe(tempHome.home);
           const homeStat = await fs.stat(tempHome.home);
           expect(homeStat.isDirectory()).toBe(true);
+          if (process.platform !== "win32") {
+            const stateStat = await fs.stat(path.join(tempHome.home, ".openclaw"));
+            expect(homeStat.mode & 0o777).toBe(0o700);
+            expect(stateStat.mode & 0o777).toBe(0o700);
+          }
         } finally {
           await tempHome.restore();
         }

--- a/src/test-utils/temp-home.ts
+++ b/src/test-utils/temp-home.ts
@@ -54,7 +54,7 @@ export async function createTempHomeEnv(prefix: string): Promise<TempHomeEnv> {
   const snapshot = captureEnv([...HOME_ENV_KEYS]);
   try {
     await fs.rm(home, { recursive: true, force: true });
-    await fs.mkdir(stateDir, { recursive: true });
+    await fs.mkdir(stateDir, { recursive: true, mode: 0o700 });
     setTestEnvValue("HOME", home);
     setTestEnvValue("USERPROFILE", home);
     deleteTestEnvValue("OPENCLAW_HOME");


### PR DESCRIPTION
## What Problem This Solves

Fixes backup and snapshot tests that reject their own temporary home directories when the host uses a group-writable umask such as `0002`.

## User Impact

No user-visible runtime change. Stateful tests get private fixture homes, while production snapshot ownership and privacy checks remain unchanged.

## Why This Change Was Made

The shared temporary-home helper created `home-N/.openclaw` using the caller's default directory mode. With `umask 0002`, the home became `0775`, and snapshot admission correctly refused it. Create both new directories with mode `0700` and extend the existing setup/cleanup contract to verify their actual POSIX permissions.

This is a maintainer-requested follow-up to the main-branch QA campaign that produced #146897.

## Evidence

- Unchanged backup privacy suite: 33 passed normally, but exactly 8 failed with child-only `umask 0002`.
- New permission assertions fail before the fix (`0775` instead of `0700`).
- Fixed helper and complete backup privacy suite under `umask 0002`: 47 passed.
- Normal helper/backup/atomicity/media-cleanup/browser-proxy sibling coverage: 60 passed.
- Formatting and `git diff --check` passed. Independent Codex review through P2 found no actionable issues.
- Complete changed-file checks passed, including core/core-test typechecks, lint, formatting, and repository guards.
- Linux AWS Crabbox, Node24.18.1, exact head `43b5ec211333`: all47 helper/privacy tests pass under the runner's original `umask 0002`. Separate browser579, media129, and shard-inventory24 tests also pass, without skips.
- [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34751920786) and ClawSweeper review are green.
