### PR TITLE
refactor(media): remove duplicate spaced path fallback

### DIFF
--- a/src/media/parse.ts
+++ b/src/media/parse.ts
@@ -532,16 +532,6 @@ export function splitMediaFromOutput(
         }
       }
 
-      if (!hasValidMedia && !unwrapped && /\s/.test(payloadValue)) {
-        const spacedFallback = cleanCandidate(payloadValue);
-        if (isValidMedia(spacedFallback, { allowSpaces: true, allowBareFilename: true })) {
-          media.splice(mediaStartIndex, media.length - mediaStartIndex, spacedFallback);
-          hasValidMedia = true;
-          foundMediaToken = true;
-          invalidParts.length = 0;
-        }
-      }
-
       if (!hasValidMedia) {
         const fallback = cleanCandidate(payloadValue);
         if (isValidMedia(fallback, { allowSpaces: true, allowBareFilename: true })) {


### PR DESCRIPTION
## What Problem This Solves

Media directive parsing repeats the same fallback for filenames containing spaces.

## User Impact

No user-visible behavior changes. Accepted attachments, visible text, and attachment ordering are preserved.

## Why This Change Was Made

The general fallback already performs the same normalization and validation. Its append is equivalent because no attachment has been added while the shared success flag is false. Production changes: −10 lines; tests unchanged.

## Evidence

- 768 actual parser cases for local, bare, quoted, file, Windows, and UNC paths produced identical complete serialized results. This supplementary check did not exercise remote URL, Markdown, fence, or audio paths.
- Independent review and fresh P2 autoreview are clean. Targeted formatting and the normal commit hook passed with installed oxfmt 0.65.0.
- [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34752313435) passed at `b7561dcad9e2eee7077fcaa2f65e3f3d72b2cc84` (attempt1), including type/lint/format gates. Actual job103710914720 passed all127 parser cases covering attachment variants, invalid paths, remote validation, ordered segments and Markdown; no target skips or test-name filters. The borrowed dependencies remain incompatible, so package-backed proof is hosted.
