### PR TITLE
refactor(terminal): simplify copy-sensitive token checks

### DIFF
--- a/packages/terminal-core/src/note.ts
+++ b/packages/terminal-core/src/note.ts
@@ -5,8 +5,6 @@ import { iterateGraphemes, visibleWidth } from "./ansi.js";
 import { stylePromptTitle } from "./prompt-style.js";
 
 const MIN_NOTE_COLUMNS = 80;
-const URL_PREFIX_RE = /^(https?:\/\/|file:\/\/)/i;
-const WINDOWS_DRIVE_RE = /^[a-zA-Z]:[\\/]/;
 const FILE_LIKE_RE = /^[a-zA-Z0-9._-]+$/;
 const suppressNotesStorage = new AsyncLocalStorage<boolean>();
 
@@ -22,23 +20,6 @@ function isSuppressedByEnv(value: string | undefined): boolean {
 }
 
 function isCopySensitiveToken(word: string): boolean {
-  if (!word) {
-    return false;
-  }
-  if (URL_PREFIX_RE.test(word)) {
-    return true;
-  }
-  if (
-    word.startsWith("/") ||
-    word.startsWith("~/") ||
-    word.startsWith("./") ||
-    word.startsWith("../")
-  ) {
-    return true;
-  }
-  if (WINDOWS_DRIVE_RE.test(word) || word.startsWith("\\\\")) {
-    return true;
-  }
   if (word.includes("/") || word.includes("\\")) {
     return true;
   }


### PR DESCRIPTION
## What Problem This Solves

Terminal note wrapping repeats path-prefix checks already covered by its slash and backslash checks.

## User Impact

No user-visible behavior changes.

## Why This Change Was Made

Remove the redundant checks and retain file-like underscore handling. Production changes: −19 lines; tests unchanged.

## Evidence

- 11,127 actual predicate inputs matched the original; downstream wrapping source is byte-identical. This does not claim execution of width measurement or the terminal renderer. Existing public wrapping tests passed on the exact head in hosted CI.
- Independent source review and fresh P2 autoreview are clean. Targeted formatting and the normal commit hook passed with installed oxfmt 0.65.0.
- Exact-head CI [34752315164, attempt 1](https://github.com/openclaw/openclaw/actions/runs/34752315164) passed. Job [103710903284](https://github.com/openclaw/openclaw/actions/runs/34752315164/job/103710903284) executed all 21 wrapNoteMessage cases and 74 renderTable cases successfully; current lint/type/format gates passed. The shared local install was not reconciled.
