### PR TITLE
refactor(memory-wiki): share freshness result construction

### DIFF
--- a/extensions/memory-wiki/src/claim-health.test.ts
+++ b/extensions/memory-wiki/src/claim-health.test.ts
@@ -1,6 +1,10 @@
 // Memory Wiki tests cover claim health plugin behavior.
 import { describe, expect, it } from "vitest";
-import { assessClaimFreshness, buildPageContradictionClusters } from "./claim-health.js";
+import {
+  assessClaimFreshness,
+  assessPageFreshness,
+  buildPageContradictionClusters,
+} from "./claim-health.js";
 import type { WikiClaim, WikiPageSummary } from "./markdown.js";
 
 function createPage(params: {
@@ -163,5 +167,38 @@ describe("assessClaimFreshness", () => {
     expect(freshness.level).toBe("unknown");
     expect(freshness.lastTouchedAt).toBeUndefined();
     expect(freshness.reason).toBe("missing updatedAt");
+  });
+});
+
+describe("wiki freshness boundaries", () => {
+  it.each([
+    { age: 29, level: "fresh", daysSinceTouch: 29 },
+    { age: 30, level: "aging", daysSinceTouch: 30 },
+    { age: 89, level: "aging", daysSinceTouch: 89 },
+    { age: 90, level: "stale", daysSinceTouch: 90 },
+    { age: -1, level: "fresh", daysSinceTouch: 0 },
+  ])("classifies a timestamp $age days old as $level", ({ age, level, daysSinceTouch }) => {
+    const now = new Date("2026-06-01T00:00:00.000Z");
+    const timestamp = new Date(now.getTime() - age * 24 * 60 * 60 * 1000).toISOString();
+    const page = createPage({
+      relativePath: "entities/alpha.md",
+      title: "Alpha",
+      contradictions: [],
+    });
+    page.updatedAt = timestamp;
+    const claim: WikiClaim = {
+      text: "Alpha has timestamped evidence.",
+      updatedAt: timestamp,
+      evidence: [],
+    };
+    const expected = {
+      level,
+      reason: `last touched ${timestamp}`,
+      daysSinceTouch,
+      lastTouchedAt: timestamp,
+    };
+
+    expect(assessPageFreshness(page, now)).toEqual(expected);
+    expect(assessClaimFreshness({ page, claim, now })).toEqual(expected);
   });
 });

--- a/extensions/memory-wiki/src/claim-health.ts
+++ b/extensions/memory-wiki/src/claim-health.ts
@@ -78,24 +78,14 @@ function buildFreshnessFromTimestamp(params: { timestamp?: string; now?: Date })
     };
   }
   const daysSinceTouch = clampDaysSinceTouch(Math.floor((now.getTime() - timestampMs) / DAY_MS));
-  if (daysSinceTouch >= WIKI_STALE_DAYS) {
-    return {
-      level: "stale",
-      reason: `last touched ${params.timestamp}`,
-      daysSinceTouch,
-      lastTouchedAt: params.timestamp,
-    };
-  }
-  if (daysSinceTouch >= WIKI_AGING_DAYS) {
-    return {
-      level: "aging",
-      reason: `last touched ${params.timestamp}`,
-      daysSinceTouch,
-      lastTouchedAt: params.timestamp,
-    };
-  }
+  const level =
+    daysSinceTouch >= WIKI_STALE_DAYS
+      ? "stale"
+      : daysSinceTouch >= WIKI_AGING_DAYS
+        ? "aging"
+        : "fresh";
   return {
-    level: "fresh",
+    level,
     reason: `last touched ${params.timestamp}`,
     daysSinceTouch,
     lastTouchedAt: params.timestamp,


### PR DESCRIPTION
## What Problem This Solves

Wiki freshness classification repeats the same result fields for fresh, aging, and stale timestamps.

## User Impact

No user-visible behavior changes.

## Why This Change Was Made

Select the level using the existing 30/90-day thresholds and construct the result once. Production changes: −10 lines; tests +37.

## Evidence

- Added public page/claim boundary cases for 29/30/89/90 days and future timestamps. Actual before/after modules matched 32 page and 16,384 claim/evidence cases using the actual pure normalization helpers. All 11 claim-health cases passed in hosted job103710915379.
- Independent source review and fresh P2 autoreview are clean. Targeted formatting and the normal commit hook passed with installed oxfmt 0.65.0.
- [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34752317756) passed at `646fe5e3cce26654e7b9ce7ab0c5afc83466246f` (attempt1), including type/lint/format gates. The borrowed local dependency install remains incompatible; package-backed proof is hosted.

Compatibility proof requested in [review](https://github.com/openclaw/openclaw/pull/146935#issuecomment-5652781435): this is a read-only result-construction change. The `WikiFreshness` fields, unknown result, 30/90-day thresholds, future-date clamp and claim/evidence/page timestamp selection are unchanged. No persisted schema, embedding metadata, store write or migration code changes. The 32 page/16,384 claim comparisons and 11 actual hosted cases verify the unchanged result contract. A data migration is not applicable because the stored data format is untouched.
