### PR TITLE
refactor(telegram): share HTML text escaping

### DIFF
--- a/extensions/telegram/src/format.ts
+++ b/extensions/telegram/src/format.ts
@@ -29,12 +29,8 @@ export function escapeTelegramHtml(text: string): string {
   return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }
 
-function escapeHtml(text: string): string {
-  return escapeTelegramHtml(text);
-}
-
 function escapeHtmlAttr(text: string): string {
-  return escapeHtml(text).replace(/"/g, "&quot;");
+  return escapeTelegramHtml(text).replace(/"/g, "&quot;");
 }
 
 function isTelegramRichLinkHref(href: string): boolean {
@@ -92,7 +88,7 @@ function buildTelegramCodeBlockOpen(span: { language?: string }): string {
 
 function renderTelegramHtml(ir: MarkdownIR): string {
   return renderTelegramMarkdownIR(ir, {
-    escapeText: escapeHtml,
+    escapeText: escapeTelegramHtml,
     buildLink: buildTelegramLink,
     buildCodeBlockOpen: buildTelegramCodeBlockOpen,
   });
@@ -320,7 +316,7 @@ function escapeUnsupportedTelegramHtml(
       const end = text.indexOf(">", index + 1);
       if (end !== -1) {
         const rawTag = text.slice(index, end + 1);
-        result += preserveTelegramHtmlTag(rawTag, openTags, escapeHtml, support);
+        result += preserveTelegramHtmlTag(rawTag, openTags, escapeTelegramHtml, support);
         index = end + 1;
       } else {
         result += "&lt;";
@@ -354,21 +350,6 @@ export function resolveTelegramHtmlVisibleText(html: string): string {
   return stripTelegramHtmlForPlainText(html);
 }
 
-function encodePlainTextForTelegramHtmlStrip(text: string): string {
-  return text.replace(/[&<>]/g, (char) => {
-    switch (char) {
-      case "&":
-        return "&amp;";
-      case "<":
-        return "&lt;";
-      case ">":
-        return "&gt;";
-      default:
-        return char;
-    }
-  });
-}
-
 export function telegramHtmlToPlainTextFallback(html: string): string {
   const withPlainTables = html.replace(TELEGRAM_RICH_HTML_TABLE_PATTERN, (tableHtml) => {
     const rows = parseTelegramRichHtmlTableRows(tableHtml);
@@ -389,11 +370,9 @@ export function telegramHtmlToPlainTextFallback(html: string): string {
       ).trim();
       const label = stripTelegramHtmlForPlainText(labelHtml).trim();
       if (!href) {
-        return encodePlainTextForTelegramHtmlStrip(label);
+        return escapeTelegramHtml(label);
       }
-      return encodePlainTextForTelegramHtmlStrip(
-        !label || label === href ? href : `${label} (${href})`,
-      );
+      return escapeTelegramHtml(!label || label === href ? href : `${label} (${href})`);
     },
   );
   return stripTelegramHtmlForPlainText(withPlainLinks);
@@ -491,7 +470,7 @@ function wrapStandaloneFileRef(match: string, prefix: string, filename: string):
   if (/https?:\/\/$/i.test(prefix)) {
     return match;
   }
-  return `${prefix}<code>${escapeHtml(filename)}</code>`;
+  return `${prefix}<code>${escapeTelegramHtml(filename)}</code>`;
 }
 
 function wrapSegmentFileRefs(
@@ -505,7 +484,7 @@ function wrapSegmentFileRefs(
   }
   const wrappedStandalone = text.replace(getFileReferencePattern(), wrapStandaloneFileRef);
   return wrappedStandalone.replace(getOrphanedTldPattern(), (match, prefix: string, tld: string) =>
-    prefix === ">" ? match : `${prefix}<code>${escapeHtml(tld)}</code>`,
+    prefix === ">" ? match : `${prefix}<code>${escapeTelegramHtml(tld)}</code>`,
   );
 }
 
@@ -635,7 +614,7 @@ function renderTelegramRichHtmlRawTableFallback(
     rows.length > 0
       ? renderTelegramMonospaceGrid(rows)
       : stripTelegramHtmlForPlainText(tableHtml).trim();
-  return `<pre><code>${escapeHtml([caption, tableText].filter(Boolean).join("\n"))}</code></pre>\n\n`;
+  return `<pre><code>${escapeTelegramHtml([caption, tableText].filter(Boolean).join("\n"))}</code></pre>\n\n`;
 }
 
 type TelegramHtmlTag = {


### PR DESCRIPTION
## What Problem This Solves

Telegram formatting has two private escape functions that duplicate the existing HTML text encoder.

## User Impact

No user-visible behavior changes.

## Why This Change Was Made

Route their callers to the existing encoder and keep attribute quote escaping separate. Production changes: −21 lines; tests unchanged.

## Evidence

- [CI attempt 1](https://github.com/openclaw/openclaw/actions/runs/34752319683) passed at exact head `03a93ad0ddfc0cfa8a61e6cc2930bee27402cdb6`. The [covering job](https://github.com/openclaw/openclaw/actions/runs/34752319683/job/103710906062) passed all 65 format tests and all 44 Markdown-wrapping tests. Type/lint checks and pinned formatting also passed.
- Before/after encoder, attribute and unsupported-HTML results matched 4,691 inputs; public plain-text fallback matched 5,051 inputs with the actual entity decoder. These comparisons supplement the hosted suites; no live Telegram execution is claimed.
- Independent source review, fresh P2 autoreview and the [exact-head ClawSweeper review](https://github.com/openclaw/openclaw/pull/146936#issuecomment-5652780063) are clean, with no Before merge item or rank-up move. The formatter baseline remains unchanged on the main snapshot used for native preparation.
