### PR TITLE
refactor(auto-reply): inline thinking level support check

### DIFF
--- a/src/auto-reply/thinking.ts
+++ b/src/auto-reply/thinking.ts
@@ -315,23 +315,6 @@ export function resolveThinkingProfile(params: {
   return profile;
 }
 
-function supportsThinkingLevel(
-  provider: string | null | undefined,
-  model: string | null | undefined,
-  level: ThinkLevel,
-  catalog?: ThinkingCatalogEntry[],
-  agentRuntime?: string | null,
-  configuredReasoning?: boolean,
-): boolean {
-  return resolveThinkingProfile({
-    provider,
-    model,
-    catalog,
-    agentRuntime,
-    configuredReasoning,
-  }).levels.some((entry) => entry.id === level);
-}
-
 /** List thinking level ids supported by provider/model. */
 export function listThinkingLevels(
   provider?: string | null,
@@ -414,14 +397,14 @@ export function isThinkingLevelSupported(params: {
   agentRuntime?: string | null;
   configuredReasoning?: boolean;
 }): boolean {
-  return supportsThinkingLevel(
-    params.provider,
-    params.model,
-    params.level,
-    params.catalog,
-    params.agentRuntime,
-    params.configuredReasoning,
-  );
+  const { provider, model, level, catalog, agentRuntime, configuredReasoning } = params;
+  return resolveThinkingProfile({
+    provider,
+    model,
+    catalog,
+    agentRuntime,
+    configuredReasoning,
+  }).levels.some((entry) => entry.id === level);
 }
 
 function resolveSupportedThinkingLevelFromProfile(


### PR DESCRIPTION
## What Problem This Solves

The public thinking-level support check delegates to a private wrapper with one caller.

## User Impact

No user-visible behavior changes.

## Why This Change Was Made

Inline the wrapper while preserving input capture order and the same five explicit profile fields. Production changes: −17 lines; tests unchanged.

## Evidence

- Actual support-wrapper code matched 13,824 membership/config cases and seven getter-order/error cases through a recording resolver seam. The profile implementation is byte-identical; this does not claim live provider execution.
- Root and independent source reviews and staged P2 autoreview are clean. The six inputs are captured in the same order, and only the same five profile fields are forwarded.
- Exact-head [CI attempt 1](https://github.com/openclaw/openclaw/actions/runs/34752322247) passed at `fccea874e3ebffcf7e6ce2ce0526769778001e68`, including selected types, lint and formatting. [The actual thinking test job](https://github.com/openclaw/openclaw/actions/runs/34752322247/job/103710899977) passed thinking.levels 47/47, thinking.test 30/30 and empty-profile 8/8, with no skips in those targets. [The aggregate gate](https://github.com/openclaw/openclaw/actions/runs/34752322247/job/103711961670) passed.
- The [latest exact-head review](https://github.com/openclaw/openclaw/pull/146937#issuecomment-5652781407) has no findings, Before merge items or Rank-up moves.
