### PR TITLE
refactor(auto-reply): share ACP runtime mode action

### DIFF
--- a/src/auto-reply/reply/commands-acp.test.ts
+++ b/src/auto-reply/reply/commands-acp.test.ts
@@ -1105,8 +1105,8 @@ describe("/acp command", () => {
         }
       },
       setSessionRuntimeMode: async (input: { sessionKey: string; runtimeMode: string }) => {
-        await hoisted.setModeMock(input);
-        return { mode: input.runtimeMode };
+        const options = await hoisted.setModeMock(input);
+        return options ?? { runtimeMode: input.runtimeMode };
       },
       setSessionConfigOption: async (input: { key: string; value: string }) => {
         const options = await hoisted.setConfigOptionMock(input);
@@ -2381,6 +2381,14 @@ describe("/acp command", () => {
 
   it.each([
     {
+      action: "set-mode",
+      command: "/acp set-mode plan",
+      effectiveOptions: { runtimeMode: "plan" },
+      managerMock: hoisted.setModeMock,
+      managerInput: { runtimeMode: "plan" },
+      expectedText: `✅ Updated ACP runtime mode for ${defaultAcpSessionKey}: plan. Effective options: runtimeMode=plan`,
+    },
+    {
       action: "cwd",
       command: "/acp cwd /tmp/worktree",
       effectiveOptions: { cwd: "/tmp/worktree" },
@@ -2425,19 +2433,27 @@ describe("/acp command", () => {
       ...testCase.managerInput,
     });
     expect(
-      hoisted.setConfigOptionMock.mock.calls.length +
+      hoisted.setModeMock.mock.calls.length +
+        hoisted.setConfigOptionMock.mock.calls.length +
         hoisted.updateSessionRuntimeOptionsMock.mock.calls.length,
     ).toBe(1);
   });
 
-  it("preserves the dedicated runtime-option failure boundary", async () => {
+  it.each([
+    {
+      command: "/acp model openai/gpt-5.5",
+      label: "model",
+      managerMock: hoisted.setConfigOptionMock,
+    },
+    { command: "/acp set-mode plan", label: "runtime mode", managerMock: hoisted.setModeMock },
+  ])("preserves the $label failure boundary", async ({ command, label, managerMock }) => {
     mockBoundThreadSession();
-    hoisted.setConfigOptionMock.mockRejectedValueOnce("backend failure");
+    managerMock.mockRejectedValueOnce("backend failure");
 
-    const result = await runThreadAcpCommand("/acp model openai/gpt-5.5", baseCfg);
+    const result = await runThreadAcpCommand(command, baseCfg);
 
     expect(result?.reply?.text).toBe(
-      "ACP error (ACP_TURN_FAILED): Could not update ACP model.\nnext: Retry, or use `/acp cancel` and send the message again.",
+      `ACP error (ACP_TURN_FAILED): Could not update ACP ${label}.\nnext: Retry, or use \`/acp cancel\` and send the message again.`,
     );
   });
 

--- a/src/auto-reply/reply/commands-acp/runtime-options.ts
+++ b/src/auto-reply/reply/commands-acp/runtime-options.ts
@@ -227,30 +227,15 @@ export async function handleAcpSetModeAction(
   params: HandleCommandsParams,
   restTokens: string[],
 ): Promise<CommandHandlerResult> {
-  return await withSingleTargetValue({
-    commandParams: params,
-    restTokens,
+  return await handleSingleRuntimeOptionAction(params, restTokens, {
     usage: ACP_SET_MODE_USAGE,
-    run: async ({ target, value }) =>
-      await withAcpCommandErrorBoundary({
-        run: async () => {
-          const runtimeMode = validateRuntimeModeInput(value);
-          const options = await getAcpSessionManager().setSessionRuntimeMode({
-            cfg: params.cfg,
-            ...target,
-            runtimeMode,
-          });
-          return {
-            runtimeMode,
-            options,
-          };
-        },
-        fallbackCode: "ACP_TURN_FAILED",
-        fallbackMessage: "Could not update ACP runtime mode.",
-        onSuccess: ({ runtimeMode, options }) =>
-          commandReply(
-            `✅ Updated ACP runtime mode for ${target.sessionKey}: ${runtimeMode}. Effective options: ${formatRuntimeOptionsText(options)}`,
-          ),
+    optionLabel: "runtime mode",
+    parseValue: validateRuntimeModeInput,
+    update: async (target, value) =>
+      await getAcpSessionManager().setSessionRuntimeMode({
+        cfg: params.cfg,
+        ...target,
+        runtimeMode: value,
       }),
   });
 }


### PR DESCRIPTION
## What Problem This Solves

ACP runtime mode repeats the parsing, update and reply flow already shared by other runtime options.

## User Impact

No user-visible behavior changes.

## Why This Change Was Made

Use the existing single-option action owner while preserving validation, target resolution, manager input and exact success/error replies. Production changes: −15 lines; tests: +16 lines.

## Evidence

- Actual handler code matched 110 before/after cases covering argument validation, target errors, manager calls, effective options and error replies through recording target/manager seams. No backend runtime execution is claimed.
- At reviewed head `266d3f1b503068e5d1cfd6f4bd018dad1200168e`, [normal CI run 34752356636, attempt 1](https://github.com/openclaw/openclaw/actions/runs/34752356636) passed. [Job 103711023350](https://github.com/openclaw/openclaw/actions/runs/34752356636/job/103711023350) executed all 79 ACP command cases, including the new set-mode success and failure cases; the descriptor passed 304 tests across 18 files. The manager fixture matches the actual runtimeMode result contract.
- [Aggregate gate 103712228758](https://github.com/openclaw/openclaw/actions/runs/34752356636/job/103712228758) passed, including selected lint, types and formatting. Root and independent full source reviews and staged P2 autoreview are clean. [Latest exact-head ClawSweeper review](https://github.com/openclaw/openclaw/pull/146943#issuecomment-5652797792) has no findings, before-merge items or rank-up moves.
