### PR TITLE
fix(ui): show Gateway uptime in the Debug overlay

### DIFF
--- a/ui/src/pages/debug/debug-overlay-sections.ts
+++ b/ui/src/pages/debug/debug-overlay-sections.ts
@@ -178,7 +178,7 @@ export const DEBUG_OVERLAY_SECTIONS: readonly DebugOverlaySectionDescriptor[] = 
         eventLoop: value.eventLoop,
         processMemory: value.processMemory,
         disks: systemInfo?.disks,
-        ...(typeof value.uptimeMs === "number" ? { uptimeMs: value.uptimeMs } : {}),
+        uptimeMs: systemInfo?.uptimeMs,
       } satisfies DebugOverlayStatusSnapshot;
     },
     render: renderStatus,

--- a/ui/src/pages/debug/view.test.ts
+++ b/ui/src/pages/debug/view.test.ts
@@ -471,6 +471,7 @@ describe("DebugOverlay", () => {
   it("graphs bounded status samples without clamping CPU and resets history on reopen", async () => {
     vi.useFakeTimers();
     let sampleCount = 0;
+    let uptimeMs = 60_000;
     let diskResponse: "available" | "single" | "empty" | "legacy" | "missing" | "rejected" =
       "available";
     const request = vi.fn(async (method: string) => {
@@ -517,7 +518,7 @@ describe("DebugOverlay", () => {
         } else if (diskResponse === "empty") {
           disks.length = 0;
         }
-        return { disks: sampleCount % 2 ? disks : disks.toReversed() };
+        return { uptimeMs, disks: sampleCount % 2 ? disks : disks.toReversed() };
       }
       if (method === "sessions.list") {
         return { sessions: [] };
@@ -544,6 +545,9 @@ describe("DebugOverlay", () => {
       expect(overlay.querySelectorAll(".gateway-vital")).toHaveLength(5);
       expect(normalizedText(overlay.querySelector(".gateway-vital--cpu"))).toContain("loop 42%");
       expect(overlay.querySelector(".sparkline-tile__chart")).toBeNull();
+      expect(normalizedText(overlay.querySelector(".debug-overlay__vitals-footer"))).toBe(
+        "Uptime 1m",
+      );
 
       await vi.advanceTimersByTimeAsync(2_000);
       await vitalUpdated();
@@ -582,6 +586,7 @@ describe("DebugOverlay", () => {
         ?.split(" ");
       expect(points).toHaveLength(90);
 
+      uptimeMs = 0;
       overlay.toggle();
       overlay.toggle();
       await vi.advanceTimersByTimeAsync(0);
@@ -589,6 +594,9 @@ describe("DebugOverlay", () => {
 
       expect(overlay.querySelectorAll(".gateway-vital")).toHaveLength(5);
       expect(overlay.querySelector(".sparkline-tile__chart")).toBeNull();
+      expect(normalizedText(overlay.querySelector(".debug-overlay__vitals-footer"))).toBe(
+        "Uptime 0ms",
+      );
 
       diskResponse = "single";
       await vi.advanceTimersByTimeAsync(2_000);
@@ -608,6 +616,9 @@ describe("DebugOverlay", () => {
 
         expect(overlay.querySelectorAll(".gateway-vital")).toHaveLength(3);
         expect(overlay.querySelector(".gateway-vital--disk")).toBeNull();
+        expect(normalizedText(overlay.querySelector(".debug-overlay__vitals-footer"))).toBe(
+          response === "empty" ? "Uptime 0ms" : undefined,
+        );
         for (const vital of ["cpu", "memory", "delay"]) {
           expect(overlay.querySelector(`.gateway-vital--${vital}`)).not.toBeNull();
         }


### PR DESCRIPTION
## What Problem This Solves

The Debug overlay hides Gateway uptime even though its existing `system.info` request returns that value.

## User Impact

The overlay now displays process uptime, including a valid zero value. It still omits unavailable uptime while keeping the other status graphs usable.

## Why This Change Was Made

The overlay read `uptimeMs` from `status`, which does not publish it. It now reads the existing authoritative `system.info` response alongside disk data. This adds no request, option, or protocol field. Production is +1/−1 (net zero); the existing mounted regression gains 11 net test lines.

## Evidence

On base `ce6718fd82a492b7c1f2b068e1c68477fd9a8b7f`, the mounted regression fails because the footer is missing. The normal production-bundle browser flow reproduces missing positive and zero uptime. With the fix, inspected Chromium captures show `Uptime 1m` and `Uptime 0ms`; rejected system information still leaves three usable status graphs and no uptime footer.

All 165 Debug, formatter, Connection, and Devices tests pass, along with the full explicit-base changed gate and a fresh managed P0–P2 review. The successful browser phases use the same driver and synthetic fixtures. An earlier standalone-driver setup failure is retained and excluded from proof. No operator Gateway, real provider, or channel was used.

![Before: uptime missing despite successful system information](https://github.com/user-attachments/assets/b9fb7900-6397-4a7a-9b3a-cf468735b2c8)

![After: Gateway uptime is visible in the overlay](https://github.com/user-attachments/assets/36ac31c9-df00-459b-9628-61d5722727af)