### PR TITLE
fix: deliver recovered answers after message-tool progress

### DIFF
--- a/src/agents/embedded-agent-runner/run/payloads.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.ts
@@ -148,6 +148,8 @@ export function buildEmbeddedRunPayloads(params: {
   messagingToolSentTargets?: MessagingToolSend[];
   messagingToolSourceReplyPayloads?: MessagingToolSourceReplyPayload[];
   sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
+  /** Only the settled-turn owner can authorize its successful tool-free answer. */
+  settledTurnFinalizationAnswered?: boolean;
   agentId?: string;
   runId?: string;
   runAborted?: boolean;
@@ -190,8 +192,9 @@ export function buildEmbeddedRunPayloads(params: {
   const suppressAssistantArtifacts =
     params.heartbeatToolResponse !== undefined ||
     params.didSendDeterministicApprovalPrompt === true ||
-    (params.sourceReplyDeliveryMode === "message_tool_only" && hasSourceReplyPayload) ||
-    deliveredSourceReplyViaMessageTool;
+    (((params.sourceReplyDeliveryMode === "message_tool_only" && hasSourceReplyPayload) ||
+      deliveredSourceReplyViaMessageTool) &&
+      !(params.settledTurnFinalizationAnswered === true && !completedSourceReplyViaMessageTool));
   const suppressFailureArtifacts =
     params.didSendDeterministicApprovalPrompt === true ||
     (params.sourceReplyDeliveryMode === "message_tool_only" && completedSourceReplyViaMessageTool);

--- a/src/agents/embedded-agent-runner/run/settled-turn-finalization.source-delivery.test.ts
+++ b/src/agents/embedded-agent-runner/run/settled-turn-finalization.source-delivery.test.ts
@@ -1,0 +1,167 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { makeTextToolResult } from "../../../../test/helpers/text-tool-result.js";
+import { settleReplyDispatcher } from "../../../auto-reply/dispatch-dispatcher.js";
+import {
+  describe2BeforeEach0,
+  dispatchReplyFromConfig,
+  globalBeforeAll0,
+  setNoAbort,
+} from "../../../auto-reply/reply/dispatch-from-config.test-harness.js";
+import { createReplyDispatcher } from "../../../auto-reply/reply/reply-dispatcher.js";
+import { buildTestCtx } from "../../../auto-reply/reply/test-ctx.js";
+import { prepareSystemAgentRunAdmission } from "../../admitted-run-context.js";
+import {
+  buildEmbeddedRunnerAssistant,
+  createResolvedEmbeddedRunnerModel,
+  makeEmbeddedRunnerAttempt,
+} from "../../test-helpers/embedded-agent-runner-e2e-fixtures.js";
+import { prepareTerminalWithSettledTurnFinalization } from "./settled-turn-finalization.js";
+import { createSettledFinalizationTestInput } from "./settled-turn-finalization.test-support.js";
+
+beforeAll(globalBeforeAll0);
+
+describe("settled finalizer through source dispatch", () => {
+  let admission: ReturnType<typeof prepareSystemAgentRunAdmission>;
+  beforeEach(() => {
+    describe2BeforeEach0();
+    setNoAbort();
+    admission = prepareSystemAgentRunAdmission({}, "run-settled", "main", "source-finalizer");
+  });
+  afterEach(() => admission.close());
+
+  it.each([
+    { mode: "message_tool_only", receipt: "progress", finalization: "answered" },
+    { mode: "automatic", receipt: "progress", finalization: "answered" },
+    { mode: "message_tool_only", receipt: "progress", finalization: "empty" },
+    { mode: "message_tool_only", receipt: "progress", finalization: "failed" },
+    { mode: "message_tool_only", receipt: "progress", finalization: "cancelled" },
+    { mode: "message_tool_only", receipt: "off-target", finalization: "not-attempted" },
+    { mode: "message_tool_only", receipt: "completed", finalization: "not-attempted" },
+    { mode: "message_tool_only", receipt: "progress", finalization: "not-attempted" },
+  ] as const)(
+    "$mode: $receipt with finalization=$finalization delivers only the intended answer",
+    async ({ mode, receipt, finalization }) => {
+      const recovered = finalization !== "not-attempted";
+      const answered = finalization === "answered";
+      const controller = new AbortController();
+      const finalText = "The note was saved.";
+      const progressText = "Saving the note.";
+      const assistant = buildEmbeddedRunnerAssistant({
+        provider: "openai",
+        model: "gpt-4.1",
+        stopReason: recovered || receipt === "completed" ? "toolUse" : "stop",
+        content:
+          recovered || receipt === "completed"
+            ? [{ type: "toolCall", id: "write-note", name: "write", arguments: {} }]
+            : [{ type: "text", text: "Private completion details." }],
+      });
+      const toolResult = makeTextToolResult("write-note", "write", "Saved", false, 1);
+      const attempt = makeEmbeddedRunnerAttempt({
+        sessionIdUsed: "session-settled",
+        terminal: { kind: "ok" },
+        assistantTexts: recovered || receipt === "completed" ? [] : ["Private completion details."],
+        lastAssistant: assistant,
+        currentAttemptAssistant: assistant,
+        currentAttemptCompletedAssistant: assistant,
+        messagesSnapshot: [
+          { role: "user", content: "Save the note, then summarize.", timestamp: 0 },
+          assistant,
+          toolResult,
+        ],
+        toolMetas: [
+          { toolName: "write", toolCallId: "write-note", isError: false, replaySafe: false },
+        ],
+        itemLifecycle: { startedCount: 1, completedCount: 1, activeCount: 0 },
+        replayMetadata: { hadPotentialSideEffects: true, replaySafe: false },
+        currentAttemptReplayMetadata: { hadPotentialSideEffects: true, replaySafe: false },
+        didSendViaMessagingTool: true,
+        didDeliverSourceReplyViaMessageTool: receipt !== "off-target",
+        messagingToolSentTexts: [receipt === "completed" ? finalText : progressText],
+        messagingToolSentTargets: [
+          {
+            tool: "message",
+            provider: "telegram",
+            to: receipt === "off-target" ? "synthetic-other" : "synthetic-source",
+            text: receipt === "completed" ? finalText : progressText,
+            ...(receipt !== "off-target" ? { sourceReplyFinal: receipt === "completed" } : {}),
+          },
+        ],
+      });
+      const input = createSettledFinalizationTestInput(attempt, await admission.admit("embedded"));
+      Object.assign(
+        input.finalization.preparedAttempt,
+        createResolvedEmbeddedRunnerModel("openai", "gpt-4.1"),
+      );
+      input.finalization.abortSignal = controller.signal;
+      input.terminalBase.runParams.trigger = "user";
+      input.terminalBase.runParams.sourceReplyDeliveryMode = mode;
+      input.terminalBase.model = "gpt-4.1";
+      input.terminalBase.activeErrorContext.model = "gpt-4.1";
+      const finalize = vi.fn<NonNullable<typeof input.finalization.harness.finalizeSettledTurn>>(
+        async ({ attempt: prepared, settledAttempt }) => {
+          expect(prepared).toMatchObject({
+            disableTools: true,
+            operation: "settled-tool-finalization",
+          });
+          expect(settledAttempt).toBe(attempt);
+          if (finalization === "failed") {
+            throw new Error("Synthetic finalizer failure");
+          }
+          if (finalization === "cancelled") {
+            controller.abort(new Error("Synthetic cancellation"));
+          }
+          return {
+            assistant: buildEmbeddedRunnerAssistant({
+              provider: "openai",
+              model: "gpt-4.1",
+              content: finalization === "empty" ? [] : [{ type: "text", text: finalText }],
+            }),
+          };
+        },
+      );
+      input.finalization.harness.finalizeSettledTurn = finalize;
+      const deliver = vi.fn(async () => undefined);
+      const dispatcher = createReplyDispatcher({ deliver });
+      let finalized:
+        | Awaited<ReturnType<typeof prepareTerminalWithSettledTurnFinalization>>
+        | undefined;
+
+      await dispatchReplyFromConfig({
+        ctx: buildTestCtx({
+          Provider: "telegram",
+          Surface: "telegram",
+          ChatType: "direct",
+          SessionKey: "agent:main:telegram:direct:synthetic",
+          MessageSid: "synthetic-request",
+        }),
+        cfg: {},
+        dispatcher,
+        replyOptions: { sourceReplyDeliveryMode: mode },
+        replyResolver: async () => {
+          finalized = await prepareTerminalWithSettledTurnFinalization(input);
+          return finalized.prepared.payloadsWithToolMedia;
+        },
+      });
+      await settleReplyDispatcher({ dispatcher });
+
+      expect(finalized?.finalizationOutcome).toBe(
+        finalization === "empty"
+          ? "completed-empty"
+          : finalization === "cancelled"
+            ? "failed"
+            : finalization,
+      );
+      expect(finalize).toHaveBeenCalledTimes(finalization === "empty" ? 2 : recovered ? 1 : 0);
+      expect(input.finalization.harness.runAttempt).not.toHaveBeenCalled();
+      expect(finalized?.attempt.messagingToolSentTargets).toEqual(attempt.messagingToolSentTargets);
+      expect(deliver).toHaveBeenCalledTimes(answered ? 1 : 0);
+      if (answered) {
+        expect(deliver).toHaveBeenCalledWith(
+          expect.objectContaining({ text: finalText }),
+          expect.anything(),
+        );
+      }
+      expect(dispatcher.getFailedCounts()).toEqual({ tool: 0, block: 0, final: 0 });
+    },
+  );
+});

--- a/src/agents/embedded-agent-runner/run/settled-turn-finalization.test.ts
+++ b/src/agents/embedded-agent-runner/run/settled-turn-finalization.test.ts
@@ -156,6 +156,45 @@ describe("prepareTerminalWithSettledTurnFinalization", () => {
     vi.useRealTimers();
   });
 
+  it("preserves a recovered final answer after an explicit source progress receipt", async () => {
+    const attempt = settledSuccessfulAttempt();
+    const progress = { text: "Saving the note.", sourceReplyFinal: false };
+    attempt.didSendViaMessagingTool = true;
+    attempt.didDeliverSourceReplyViaMessageTool = true;
+    attempt.messagingToolSentTexts = [progress.text];
+    attempt.messagingToolSentTargets = [
+      { tool: "message", provider: "telegram", to: "synthetic-source", ...progress },
+    ];
+    backendMocks.runSettledFinalization.mockResolvedValueOnce({
+      outcome: "answered",
+      result: {
+        assistant: buildEmbeddedRunnerAssistant({
+          content: [{ type: "text", text: "The note was saved." }],
+        }),
+      },
+    });
+    const input = finalizationInput(attempt);
+    input.terminalBase.runParams.trigger = "user";
+
+    const result = await prepareTerminalWithSettledTurnFinalization(input);
+
+    expect(result.finalizationOutcome).toBe("answered");
+    expect(backendMocks.runSettledFinalization).toHaveBeenCalledOnce();
+    expect(backendMocks.runSettledFinalization).toHaveBeenCalledWith(
+      expect.objectContaining({ disableTools: true, operation: "settled-tool-finalization" }),
+      attempt,
+      input.finalization.harness,
+    );
+    expect(result.attempt.didDeliverSourceReplyViaMessageTool).toBe(true);
+    expect(result.attempt.messagingToolSentTargets).toEqual(attempt.messagingToolSentTargets);
+    expect(result.prepared.payloadsWithToolMedia).toEqual([
+      expect.objectContaining({ text: "The note was saved." }),
+    ]);
+    const [answer] = result.prepared.payloadsWithToolMedia ?? [];
+    expect(getReplyPayloadMetadata(answer ?? {})?.sourceReplyTranscriptMirror).toBeUndefined();
+    expect(getReplyPayloadMetadata(answer ?? {})?.deliverDespiteSourceReplySuppression).toBe(true);
+  });
+
   it.each([false, true])(
     "finalizes an empty post-tool turn only when media was not delivered (delivered: %s)",
     async (hasToolMediaBlockReply) => {

--- a/src/agents/embedded-agent-runner/run/settled-turn-finalization.transport.test.ts
+++ b/src/agents/embedded-agent-runner/run/settled-turn-finalization.transport.test.ts
@@ -281,6 +281,20 @@ it.each(["HTTP", "WebSocket", "terminated"])("finalizes after %s failure", async
         itemLifecycle,
       }),
     );
+    // External source sends retain target receipts, not internal-UI mirror payloads.
+    // A progress receipt must not suppress the later tool-free recovered answer.
+    attempt.didSendViaMessagingTool = true;
+    attempt.didDeliverSourceReplyViaMessageTool = true;
+    attempt.messagingToolSentTexts = ["Saving the note."];
+    attempt.messagingToolSentTargets = [
+      {
+        tool: "message",
+        provider: "telegram",
+        to: "synthetic-source",
+        text: "Saving the note.",
+        sourceReplyFinal: false,
+      },
+    ];
     expect(attempt).toMatchObject({
       terminal: { kind: "ok" },
       settledTurnFinalizationContext: { source: "openclaw-transcript" },

--- a/src/agents/embedded-agent-runner/run/settled-turn-finalization.ts
+++ b/src/agents/embedded-agent-runner/run/settled-turn-finalization.ts
@@ -58,6 +58,7 @@ type TerminalPreparationBase = Omit<
   | "sessionFileUsed"
   | "lastRunPromptUsage"
   | "terminalState"
+  | "settledTurnFinalizationAnswered"
 >;
 
 export async function prepareTerminalWithSettledTurnFinalization(input: {
@@ -279,6 +280,7 @@ export async function prepareTerminalWithSettledTurnFinalization(input: {
     ...input.terminalBase,
     ...completion,
     lastRunPromptUsage,
+    settledTurnFinalizationAnswered: finalizationOutcome === "answered",
   });
   // Only a real finalizer answer may cross source-reply suppression. The
   // synthetic fallback remains a private diagnostic on message-tool-only runs.

--- a/src/agents/embedded-agent-runner/run/terminal-preparation.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-preparation.ts
@@ -55,6 +55,7 @@ export function prepareEmbeddedRunTerminal(input: {
   contextRecoveryState: EmbeddedRunContextRecoveryState;
   resolvedToolResultFormat: NonNullable<RunEmbeddedAgentParams["toolResultFormat"]>;
   terminalState: EmbeddedRunTerminalState;
+  settledTurnFinalizationAnswered?: boolean;
 }): {
   agentMeta: EmbeddedAgentMeta;
   reportedModelRef: { provider: string; model: string };
@@ -210,6 +211,7 @@ export function prepareEmbeddedRunTerminal(input: {
     messagingToolSentTargets: attempt.messagingToolSentTargets,
     messagingToolSourceReplyPayloads: attempt.messagingToolSourceReplyPayloads,
     sourceReplyDeliveryMode: runParams.sourceReplyDeliveryMode,
+    settledTurnFinalizationAnswered: input.settledTurnFinalizationAnswered,
     agentId: runParams.agentId,
     runId: runParams.runId,
     // Owned timeout failures retain produced output; explicit cancellation still suppresses it.


### PR DESCRIPTION
Closes #146946

## What Problem This Solves

Fixes recovered answers disappearing after an agent sends a progress message, completes its tools, and needs isolated finalization to finish a message-tool-only turn.

## User Impact

Users receive the recovered answer once, without repeating progress messages or completed actions. Ordinary private finals and synthetic fallback diagnostics remain private. No configuration changes or migrations are required by this patch.

## Why This Change Was Made

The finalization owner now tells payload construction when it has a successful tool-free answer. Earlier progress receipts remain intact but cannot erase that answer before its existing source-delivery exception is attached. A completed source reply still suppresses duplicates.

This preserves #138645's distinction between a real recovered answer and a private fallback. #137887 handles an absent callback and #126404 handles a failed finalizer; here the existing callback succeeds.

## Evidence

- **Fails before / passes after:** the owner regression reports `answered` but returns `[]` before the fix. The composed real finalizer/source-dispatcher regression calls the delivery callback zero times before, exactly once after. Automatic delivery and private-final/completed-receipt/off-target controls pass.
- **164 tests pass across six files:** finalizer owner, source dispatcher, terminal preparation, ordinary payload suppression, error payloads, and loopback HTTP/WebSocket/terminated-response recovery. Empty/failed finalizers and cancellation remain non-deliverable in message-tool-only mode; existing stale-writer guards pass.
- **Real transport/effect proof:** the loopback tests execute one file write, interrupt the ordinary provider continuation, then recover with a tool-free request after a progress receipt. They verify three provider requests with tool counts `[1, 1, 0]`, one write, preserved transcript prefix, and one recovered answer.
- **Requested neighboring controls:** the six tests in `terminal-resolution.settled-request.test.ts` and `payloads.delivery-recovery.test.ts` pass, matching the issue review checklist.
- **Native Codex compatibility:** four selected existing native finalization scenarios pass with pinned Codex 0.153.4, isolated homes, real transcript writes, and a loopback provider. These are native finalization controls, not live source-channel proof.
- **Independent review:** candidate and exact-head autoreview with complete owner modules are clean at P0–P2. The full branch was reviewed again after the test-only lint repair. Current reviewed head: `b616b92c46695d09cc52d6d723e80c8825e52aab`.
- **Full build passed:** standard `pnpm build` completed in 20m 24.5s in a clean, separately installed worktree at `88a385a6`. The only subsequent change is the test-spy lint repair; the production tree is identical at current head. All selected build phases, SDK exports, and hard UI budgets passed.
- **Changed checks passed:** complete `pnpm check:changed` passed on current head, including core/test typechecks, all three dead-export scans, typed lint (zero warnings/errors), and the concluding database, media, runtime, webhook, and pairing guards. `git diff 1393a714309f46938cd9da4b39319dfa6e70ef15 HEAD --check` also passed. All eight composed tests were rerun successfully after the test-only lint repair.

- **Upstream review:** [ClawSweeper reviewed the current head](https://github.com/openclaw/openclaw/pull/146964#issuecomment-5652930584), found no correctness or security issues, accepted the terminal recovery proof as sufficient, and marked this ready for maintainer review. [Current-head CI passed](https://github.com/openclaw/openclaw/actions/runs/34753747954), including the required `openclaw/ci-gate`; all 168 non-skipped checks succeeded. No merge is claimed.

Live Telegram Test Server proof is unavailable on this host: the Convex QA broker prerequisites are absent. These are deterministic owner/source-dispatcher and loopback-provider proofs, not a production-bot or live-Telegram test. No live Gateway, credentials, private transcript, or user data were changed or published.


<details>
<summary>Reproduce the focused verification</summary>

Base: `1393a714309f46938cd9da4b39319dfa6e70ef15`. Copy the new regression tests onto the base without the three production changes to reproduce the failure.

Before the fix, the owner regression fails with `expected [] to deeply equal [ ObjectContaining{…} ]` after confirming the finalizer answered. The composed source-dispatcher regression fails with `expected "vi.fn()" to be called 1 times, but got 0 times`.

After the fix:

```sh
node scripts/run-vitest.mjs run \
  src/agents/embedded-agent-runner/run/settled-turn-finalization.test.ts \
  src/agents/embedded-agent-runner/run/settled-turn-finalization.source-delivery.test.ts \
  src/agents/embedded-agent-runner/run/settled-turn-finalization.transport.test.ts \
  src/agents/embedded-agent-runner/run/payloads.test.ts \
  src/agents/embedded-agent-runner/run/payloads.errors.test.ts \
  src/agents/embedded-agent-runner/run/terminal-preparation.test.ts
# 164 tests passed across 6 files

node scripts/run-vitest.mjs run \
  src/agents/embedded-agent-runner/run/terminal-resolution.settled-request.test.ts \
  src/agents/embedded-agent-runner/run/payloads.delivery-recovery.test.ts
# 6 tests passed across 2 files

node scripts/run-vitest.mjs run \
  extensions/codex/src/app-server/settled-turn-finalizer.native.test.ts \
  -t 'persists a host-authorized summary'
# 4 selected native tests passed; 4 intentionally filtered out

pnpm check:changed
# Passed on current head, exit 0

pnpm build
# Passed in the clean worktree with the identical production tree, exit 0

git diff 1393a714309f46938cd9da4b39319dfa6e70ef15 HEAD --check
# Passed
```

</details>
