### PR TITLE
fix(browser): report unconfirmed profile data removal accurately

### DIFF
--- a/extensions/browser/src/cli/browser-cli-manage.test.ts
+++ b/extensions/browser/src/cli/browser-cli-manage.test.ts
@@ -811,4 +811,39 @@ describe("browser manage output", () => {
     expect(getBrowserCliRuntime().exit).not.toHaveBeenCalled();
     expect(process.exitCode).toBe(1);
   });
+
+  it.each([
+    { deleted: false, json: false },
+    { deleted: true, json: false },
+    { deleted: false, json: true },
+    { deleted: true, json: true },
+  ])("reports profile deletion with deleted=$deleted and json=$json", async ({ deleted, json }) => {
+    const result = { ok: true, profile: "proof-retained", deleted };
+    getBrowserManageCallBrowserRequestMock().mockResolvedValueOnce(result);
+
+    const program = createBrowserManageProgram();
+    await program.parseAsync(
+      ["browser", ...(json ? ["--json"] : []), "delete-profile", "--name", result.profile],
+      { from: "user" },
+    );
+
+    expect(getBrowserManageCallBrowserRequestMock()).toHaveBeenCalledWith(expect.anything(), {
+      method: "DELETE",
+      path: "/profiles/proof-retained",
+    });
+    if (json) {
+      expect(parseSingleRuntimeJson()).toEqual(result);
+      expect(getBrowserCliRuntime().writeJson).toHaveBeenCalledTimes(1);
+    } else {
+      expect(lastRuntimeLog()).toBe(
+        deleted
+          ? '🦞 Deleted profile "proof-retained" (user data removed)'
+          : '🦞 Deleted profile "proof-retained" (user data removal not confirmed)',
+      );
+      expect(getBrowserCliRuntime().writeJson).not.toHaveBeenCalled();
+    }
+    expect(getBrowserCliRuntimeCapture().runtimeErrors).toEqual([]);
+    expect(getBrowserCliRuntime().exit).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(0);
+  });
 });

--- a/extensions/browser/src/cli/browser-cli-manage.ts
+++ b/extensions/browser/src/cli/browser-cli-manage.ts
@@ -873,7 +873,7 @@ export function registerBrowserManageCommands(
         }
         const msg = result.deleted
           ? `🦞 Deleted profile "${result.profile}" (user data removed)`
-          : `🦞 Deleted profile "${result.profile}" (no user data found)`;
+          : `🦞 Deleted profile "${result.profile}" (user data removal not confirmed)`;
         defaultRuntime.log(info(msg));
       });
     });


### PR DESCRIPTION
## What Problem This Solves

`browser delete-profile` says “no user data found” when the profile alias is removed but user data is intentionally retained or removal was not confirmed.

## User Impact

The CLI now says “user data removal not confirmed” for `deleted:false`. Successful-removal text, profile deletion, and JSON results retain their existing behavior.

## Why This Change Was Made

The service reports confirmed managed-data removal through `deleted`. A false value does not establish that no data existed: existing-session, remote, and attach-only profiles can retain data, and a Trash operation can fail. The CLI now describes that existing fact accurately. Production is +1/−1 (net zero); four registered-parser cases add 35 test lines.

## Evidence

Paired ordinary CLI runs used an isolated built Gateway and two existing-session profile aliases pointing at retained synthetic markers. Before: plain output claimed no data was found. After: it reports unconfirmed removal. Both phases preserved marker bytes, removed the aliases, and returned unchanged JSON with `deleted:false`.

Each phase ran four CLI commands, observed normal launcher respawns, and completed with all 17 tracked process groups gone, no rescue, removed fixtures, and released ports. Fifty owner/sibling tests, the normal changed gate, both normal builds, and fresh managed P0–P2 review pass. Source/build proof is bound to `c23e1b27abd83e917f8f0b0b292e799a9091d37e` and the unchanged reviewed owner.

No browser session or forced filesystem failure was used; existing service tests and direct dependency source cover other removal outcomes. Earlier setup attempts remain excluded. A review scan flagged an unchanged test-fixture URL; only the copied review context was redacted before all scanning and isolation gates ran again. No production or test source was changed for that scan.
