### PR TITLE
improve(plugins): reduce JavaScript generation capture work

### DIFF
--- a/src/plugins/plugin-generation-artifact.test.ts
+++ b/src/plugins/plugin-generation-artifact.test.ts
@@ -8,6 +8,7 @@ import { createJiti } from "jiti";
 import { afterEach, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { capturePluginGenerationArtifact } from "./plugin-generation-artifact.js";
+import { inspectPluginSourceDependencies } from "./plugin-generation-source-inspection.js";
 
 // Artifact tests evaluate captured bytes independently; managed Node execution has binder suites.
 function createArtifactLoader(artifact: ReturnType<typeof capturePluginGenerationArtifact>) {
@@ -202,6 +203,87 @@ it.each(["require", "import"] as const)(
     await expect(capture()().read()).resolves.toBe("installed");
   },
 );
+
+it.each([
+  [
+    "local require",
+    `export const read = async (require) => [require('./label.json'), (await import('./peer.js')).value];`,
+    "./label.json",
+  ],
+  [
+    "local dirname",
+    `import path from 'node:path';
+     const __dirname = 'synthetic';
+     export const read = async () => [path.join(__dirname, 'label.json'), (await import('./peer.js')).value];`,
+    path.join("synthetic", "label.json"),
+  ],
+])("freezes dynamic imports without capturing labels from %s", async (_name, sourceText, label) => {
+  const source = temp.make("plugin-local-binding-");
+  const entry = path.join(source, "entry.mjs");
+  const peer = path.join(source, "peer.js");
+  const unrelated = path.join(source, "label.json");
+  fs.writeFileSync(entry, sourceText);
+  fs.writeFileSync(peer, 'export const value = "before";');
+  fs.writeFileSync(unrelated, '{"private":"unrelated"}');
+  const artifact = capturePluginGenerationArtifact(source, entry);
+  cleanups.push(artifact.dispose);
+  expect(artifact.hasSource(unrelated)).toBe(false);
+  expect(fs.existsSync(path.join(artifact.rootDir, "label.json"))).toBe(false);
+  expect(artifact.hasSource(peer)).toBe(true);
+  fs.writeFileSync(peer, 'export const value = "after";');
+  const plugin = createArtifactLoader(artifact)(artifact.resolve(entry)) as {
+    read(label: (value: string) => string): Promise<string[]>;
+  };
+  await expect(plugin.read((value) => value)).resolves.toEqual([label, "before"]);
+  expect(artifact.assertSourceCurrent).toThrow();
+});
+
+it.each([
+  ...["using", "await using"].map((declaration) => ({
+    name: `${declaration} declarations`,
+    sourceText: `${declaration} resource = null;
+      const first = import('./a.js');
+      export function later() { return import('./b.js'); }`,
+    references: ["./b.js", "./a.js"],
+  })),
+  {
+    name: "exported loop assignments",
+    sourceText: `export let value;
+      for ([value = import('./a.js')] of [[import('./b.js')]]) {}`,
+    references: ["./b.js", "./a.js"],
+  },
+  {
+    name: "imported loop assignments",
+    sourceText: `import { value } from './value.js';
+      for ([value = import('./a.js')] of [[import('./b.js')]]) {}`,
+    references: ["./value.js", "./b.js"],
+  },
+  {
+    name: "reserved export declarations",
+    sourceText: "export const { flag: __esModule } = {}; import('./a.js');",
+    references: [],
+  },
+  {
+    name: "reserved export aliases",
+    sourceText: "export { value as '__esModule' } from './value.js'; import('./a.js');",
+    references: [],
+  },
+])("preserves transformed references when inspecting $name", ({ sourceText, references }) => {
+  const source = temp.make("plugin-reference-inspection-");
+  const entry = path.join(source, "entry.mjs");
+  fs.writeFileSync(entry, sourceText);
+  for (const name of ["a.js", "b.js", "value.js"]) {
+    fs.writeFileSync(path.join(source, name), "export const value = 'fixture';");
+  }
+  const inspection = inspectPluginSourceDependencies([{ rootDir: source, entryFile: entry }]);
+  expect(inspection.references).toEqual(
+    references.map((specifier) => ({
+      source: entry,
+      specifier,
+      target: path.join(source, specifier),
+    })),
+  );
+});
 
 it.each([false, true])(
   "keeps authored absolute references on the native source graph (selective: %s)",

--- a/src/plugins/plugin-source-references.ts
+++ b/src/plugins/plugin-source-references.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
 import { pathToFileURL } from "node:url";
-import { parse, type AnyNode } from "acorn";
+import { parse, type AnyNode, type Program } from "acorn";
 import type { createJiti } from "jiti";
 
 export function capturedPluginModuleUrl(
@@ -117,6 +117,116 @@ function isCurrentFileRequire(call: RequireReferencePath): boolean {
   );
 }
 
+// These imports and native anchors need Jiti's binding-aware prepass or rewritten callee names.
+const TRANSFORMED_REFERENCE_NAMES = new Set([
+  "createRequire",
+  "URL",
+  "readFile",
+  "readFileSync",
+  "createReadStream",
+  "join",
+  "resolve",
+  "require",
+  "jitiImport",
+  "jitiESMResolve",
+  "__dirname",
+]);
+
+function parseNativePluginJavaScript(source: string, sourceText: string): Program | undefined {
+  if (!/\.[cm]?js$/.test(source)) {
+    return undefined;
+  }
+  let tree: Program;
+  try {
+    tree = parse(sourceText, {
+      ecmaVersion: "latest",
+      sourceType: "module",
+      allowAwaitOutsideFunction: true,
+    });
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      return undefined;
+    }
+    throw error;
+  }
+  const needsTransform = (node: AnyNode, exportedDeclaration = false): boolean => {
+    if (node.type === "MetaProperty") {
+      return true;
+    }
+    // Jiti moves declarations around resource disposal blocks, changing reference order.
+    if (
+      node.type === "VariableDeclaration" &&
+      (node.kind === "using" || node.kind === "await using")
+    ) {
+      return true;
+    }
+    // Jiti moves module-binding loop assignments into the body or removes their targets.
+    if (
+      (node.type === "ForInStatement" || node.type === "ForOfStatement") &&
+      node.left.type !== "VariableDeclaration"
+    ) {
+      return true;
+    }
+    // Jiti rejects reserved exports before visiting references, including declaration bindings.
+    const exported =
+      node.type === "ExportSpecifier" || node.type === "ExportAllDeclaration"
+        ? node.exported
+        : undefined;
+    if (
+      (exported?.type === "Identifier" ? exported.name : staticString(exported)) === "__esModule" ||
+      (exportedDeclaration && node.type === "Identifier" && node.name === "__esModule")
+    ) {
+      return true;
+    }
+    // Jiti renames local require/__dirname bindings before the reference visitor runs.
+    if (node.type === "Identifier" && (node.name === "require" || node.name === "__dirname")) {
+      return true;
+    }
+    if (
+      node.type === "ImportExpression" &&
+      (node.source.type !== "Literal" ||
+        typeof node.source.value !== "string" ||
+        node.options != null)
+    ) {
+      return true;
+    }
+    if (node.type === "ImportDeclaration") {
+      if (node.source.value === "module" || node.source.value === "node:module") {
+        return true;
+      }
+      for (const specifier of node.specifiers) {
+        const imported =
+          specifier.type === "ImportSpecifier"
+            ? specifier.imported.type === "Identifier"
+              ? specifier.imported.name
+              : staticString(specifier.imported)
+            : undefined;
+        if (
+          TRANSFORMED_REFERENCE_NAMES.has(specifier.local.name) ||
+          (imported !== undefined && TRANSFORMED_REFERENCE_NAMES.has(imported))
+        ) {
+          return true;
+        }
+      }
+    }
+    return Object.values(node)
+      .flat()
+      .some(
+        (child) =>
+          child &&
+          typeof child === "object" &&
+          "type" in child &&
+          // SAFETY: Children belong to the Acorn tree, as in the reference visitor below.
+          needsTransform(
+            child as AnyNode,
+            exportedDeclaration ||
+              (node.type === "ExportNamedDeclaration" && child === node.declaration),
+          ),
+      );
+  };
+  return needsTransform(tree) ? undefined : tree;
+}
+
 /** Visit literal module and explicit asset inputs without evaluating plugin code. */
 export function visitPluginSourceReferences(
   source: string,
@@ -135,53 +245,90 @@ export function visitPluginSourceReferences(
       visitReference(path.join(".", ...parts), "asset");
     }
   };
-  const code = resolver.transform({
-    source: sourceText,
-    filename: source,
-    ts: /\.[cm]?tsx?$/.test(source),
-    async: true,
-    babel: {
-      plugins: [
-        {
-          pre(file: {
-            path: {
-              traverse(visitor: { CallExpression(call: RequireReferencePath): void }): void;
-            };
-          }) {
-            file.path.traverse({
-              CallExpression(call) {
-                const args = call.get("arguments");
-                // Jiti replaces this anchor with a string; capture its meaning before rewriting.
-                if (unwrapReferenceArgument(args[0])?.matchesPattern("import.meta.dirname")) {
-                  const callee = call.get("callee");
-                  const member =
-                    callee.node?.type === "MemberExpression" ? callee.get("property") : callee;
-                  const name =
-                    ["join", "resolve"].find((method) =>
-                      ["path", "node:path"].some((moduleName) =>
-                        callee.referencesImport(moduleName, method),
-                      ),
-                    ) ??
-                    member.node?.name ??
-                    "";
-                  visitDirectoryAsset(
-                    name,
-                    args.slice(1).map((arg) => staticString(unwrapReferenceArgument(arg)?.node)),
-                  );
-                }
-                const argument = unwrapReferenceArgument(args.length === 1 ? args[0] : undefined);
-                const specifier = staticString(argument?.node);
-                if (specifier !== undefined && isCurrentFileRequire(call)) {
-                  visitReference(specifier, "require");
-                }
+  const tree =
+    parseNativePluginJavaScript(source, sourceText) ??
+    parse(
+      resolver.transform({
+        source: sourceText,
+        filename: source,
+        ts: /\.[cm]?tsx?$/.test(source),
+        async: true,
+        babel: {
+          plugins: [
+            {
+              pre(file: {
+                path: {
+                  traverse(visitor: { CallExpression(call: RequireReferencePath): void }): void;
+                };
+              }) {
+                file.path.traverse({
+                  CallExpression(call) {
+                    const args = call.get("arguments");
+                    // Jiti replaces this anchor with a string; capture its meaning before rewriting.
+                    if (unwrapReferenceArgument(args[0])?.matchesPattern("import.meta.dirname")) {
+                      const callee = call.get("callee");
+                      const member =
+                        callee.node?.type === "MemberExpression" ? callee.get("property") : callee;
+                      const name =
+                        ["join", "resolve"].find((method) =>
+                          ["path", "node:path"].some((moduleName) =>
+                            callee.referencesImport(moduleName, method),
+                          ),
+                        ) ??
+                        member.node?.name ??
+                        "";
+                      visitDirectoryAsset(
+                        name,
+                        args
+                          .slice(1)
+                          .map((arg) => staticString(unwrapReferenceArgument(arg)?.node)),
+                      );
+                    }
+                    const argument = unwrapReferenceArgument(
+                      args.length === 1 ? args[0] : undefined,
+                    );
+                    const specifier = staticString(argument?.node);
+                    if (specifier !== undefined && isCurrentFileRequire(call)) {
+                      visitReference(specifier, "require");
+                    }
+                  },
+                });
               },
-            });
-          },
+            },
+          ],
         },
-      ],
-    },
-  });
+      }),
+      {
+        ecmaVersion: "latest",
+        allowAwaitOutsideFunction: true,
+        allowReturnOutsideFunction: true,
+      },
+    );
+  const staticImports = new Set<string>();
+  for (const statement of tree.body) {
+    if (
+      (statement.type === "ImportDeclaration" ||
+        statement.type === "ExportNamedDeclaration" ||
+        statement.type === "ExportAllDeclaration") &&
+      statement.source
+    ) {
+      const reference = staticString(statement.source);
+      if (reference !== undefined) {
+        staticImports.add(reference);
+      }
+    }
+  }
+  // Jiti hoists and deduplicates static module sources before the executable body.
+  for (const reference of staticImports) {
+    visitReference(reference, "import");
+  }
   const visit = (node: AnyNode) => {
+    if (node.type === "ImportExpression") {
+      const reference = staticString(node.source);
+      if (reference !== undefined) {
+        visitReference(reference, "import");
+      }
+    }
     if (node.type === "CallExpression" || node.type === "NewExpression") {
       const { callee: call, arguments: args } = node;
       // Jiti emits named-import calls as (0, binding); their last expression is the callee.
@@ -222,11 +369,5 @@ export function visitPluginSourceReferences(
       }
     }
   };
-  visit(
-    parse(code, {
-      ecmaVersion: "latest",
-      allowAwaitOutsideFunction: true,
-      allowReturnOutsideFunction: true,
-    }),
-  );
+  visit(tree);
 }

--- a/src/plugins/plugin-source-references.ts
+++ b/src/plugins/plugin-source-references.ts
@@ -216,8 +216,8 @@ function parseNativePluginJavaScript(source: string, sourceText: string): Progra
           child &&
           typeof child === "object" &&
           "type" in child &&
-          // SAFETY: Children belong to the Acorn tree, as in the reference visitor below.
           needsTransform(
+            // SAFETY: Children belong to the Acorn tree, as in the reference visitor below.
             child as AnyNode,
             exportedDeclaration ||
               (node.type === "ExportNamedDeclaration" && child === node.declaration),


### PR DESCRIPTION
## What Problem This Solves

Cold plugin generation capture spends unnecessary time transforming ordinary compiled JavaScript before discovering its dependencies.

## User Impact

Reduces capture work when loading plugins while preserving dependency and asset selection, ordered references, currentness, and cleanup. Installed-plugin update behavior is unchanged. This does not establish an overall Gateway startup percentage.

## Why This Change Was Made

Use the existing Acorn parser directly for eligible JavaScript, retaining Jiti whenever its syntax or binding rewrites can change reference discovery. The fallback covers local bindings, dynamic-import options, resource management, exported loop targets, and reserved export names. No new cache or loading owner is introduced.

## Evidence

- 373-case exact original/candidate ordered-reference and error parity; 95 tests across artifact, ownership, native-module-loader, and setup-lifecycle suites passed. Eight public regressions also reproduce the earlier incorrect prototypes' failures.
- Core and plugins-platform test types, focused lint, formatting and diff checks passed. Fresh independent P2 review has no findings.
- CI exposed a misplaced existing assertion-safety comment. Moving it beside the cast changes no executable tokens or comment-free TypeScript AST; the maintained counter now reports zero uncommented assertions. The tests, timing, and build above used the code before this comment-only follow-up.
- Ordinary full build and protocol check passed. Maintained built-entrypoint profiles for feishu and anthropic-vertex both passed.
- Final-source generation-capture benchmark: four fresh processes in O,C,C,O order, same 19 built setup entries plus a TypeScript control. Every arm matched all 20 artifacts, 4474 inspected files, 2175 ordered references, and disposal results.

| Compiled capture | Original 1 | Candidate 2 | Candidate 3 | Original 4 |
| --- | ---: | ---: | ---: | ---: |
| Elapsed, ms | 4678.46 | 1838.24 | 1789.23 | 3877.07 |
| Process CPU, ms | 5004.37 | 2242.75 | 2175.89 | 5226.96 |

Paired elapsed ratios are 0.393 and 0.461; mean elapsed time is 57.6% lower and CPU time 56.8% lower. This is two samples per variant on WSL/Linux Node 24.19, with substantial baseline variation and coordination of our known workloads rather than exclusive host use. The TypeScript control was also faster: originals 30.54/45.27 ms, candidates 26.59/18.82 ms. Initial RSS differed, so no retained-memory benefit is claimed.

The per-entry anthropic-vertex capture regressed from 12.10/17.45 ms to 110.05/96.15 ms. The full cohort includes that cost; shifting initial Jiti fallback work is a plausible but unproven explanation. Earlier prototype timings remain historical and are not used for the final-source claim.

Current-main source audits through 912685f confirm unchanged parser/capture/inspection/Jiti/module-loader owners and dependency manifests. Newer registry/cache/alias callers were inspected separately. The branch was replayed patch-identically onto that repaired base after the repository-wide test-shard headroom guard failed; both authored files remain identical. Replacement exact-head [CI](https://github.com/openclaw/openclaw/actions/runs/34755383041) and [CodeQL](https://github.com/openclaw/openclaw/actions/runs/34755383074) passed. A later normal native main capture at `4aff70f2` confirms unchanged parser/capture/inspection/Jiti/module-loader source and unchanged Acorn/Jiti/import-meta-resolve versions; main separately upgrades fs-safe and jszip. Retained package proof remains tied to the exact reviewed candidate.

## Linked Recovery

Related: #146877. This replacement preserves that PR's exact reviewed source head `e96b9be253f6640d9e042d27d034017e78500c00` and both existing commits; no source changes or rebase were made for recovery. The original was retained until this replacement merged, then closed with a backlink to the verified landing.

GitHub's original PR API and branch identify `e96b9be`, but its read-only pull head still identifies the earlier `a863dfb`. One deliberate close/reopen regenerated the merge candidate and fresh checks without repairing that discrepancy. The native workflow correctly refuses the mismatched source ref. Original-PR [CI](https://github.com/openclaw/openclaw/actions/runs/34754388234) and [CodeQL](https://github.com/openclaw/openclaw/actions/runs/34754388238) both passed at `e96b9be`; replacement-specific native identity and exact-head hosted gates have now been verified.

The accepted published-upgrade-survivor base cell passed in [Package Acceptance 34755936611](https://github.com/openclaw/openclaw/actions/runs/34755936611): published `openclaw@2026.9.4` installed, updated to the exact `e96b9be` candidate tarball (SHA256 `506cba3f1c8827d37f909c4733cb8154d3285b129d9b02d39b5b2cdfeacedfb6`), then passed migration/survival checks and Gateway health, readiness and status probes. One 287-second attempt completed without failure or timeout. Actual frozen admission records tooling `dec9fe0a` and the exact candidate/package identity. The uploaded proof includes the complete lane log and outer summary, not the container-internal per-assertion JSON; this establishes the agreed base cell, not special legacy/mobile scenarios, broad release coverage or a startup speed result.

Three earlier Package Acceptance dispatch requests returned HTTP 500/502 and remain unresolved. A separately reviewed, single recovery request returned HTTP 204 and its actual inputs/admission identify the successful run above. Complete run reconciliation does not erase the older uncertainty; no further dispatch was sent.

After this linked replacement was published, [#146950](https://github.com/openclaw/openclaw/pull/146950) landed a maintained immutable-head acquisition fix in `scripts/pr`. Subsequent native operations will use that current owner. The earlier stale-ref refusal and one close/reopen recovery remain historical evidence; both PRs still contain the same reviewed `e96b9be253f6640d9e042d27d034017e78500c00` commits.
